### PR TITLE
accept literal.method() as builtin_method_call (#2)

### DIFF
--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -166,6 +166,11 @@ def classify_miss(node: ast.Call) -> str:
         while isinstance(cur, ast.Attribute):
             cur = cur.value
         if isinstance(cur, ast.Constant):
+            # A method called on a known literal type (str, bytes, int, float,
+            # list, dict, set, tuple) — route to builtin_method_call when the
+            # method name is in the whitelist; otherwise keep literal_method_call.
+            if isinstance(func, ast.Attribute) and func.attr in BUILTIN_COLLECTION_METHODS:
+                return "builtin_method_call"
             return "literal_method_call"
         # super().foo() — value of the outer Attribute is a Call to super()
         if isinstance(cur, ast.Call) and isinstance(cur.func, ast.Name) and cur.func.id == "super":

--- a/tests/test_analyzer_builtin_methods.py
+++ b/tests/test_analyzer_builtin_methods.py
@@ -34,6 +34,41 @@ def _parse_call(src: str) -> ast.Call:
 # Classifier unit tests (pattern tag only, no full pipeline needed)
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Literal receiver tests (issue #2): '<literal>'.method(...) routing
+# ---------------------------------------------------------------------------
+
+def test_str_literal_join_is_builtin_method_call() -> None:
+    """'\\n'.join(lines) must route to builtin_method_call, not literal_method_call."""
+    call = _parse_call("'\\n'.join(lines)")
+    assert _classify_miss(call) == "builtin_method_call"
+
+
+def test_str_literal_format_is_builtin_method_call() -> None:
+    call = _parse_call("'{}'.format(x)")
+    assert _classify_miss(call) == "builtin_method_call"
+
+
+def test_str_literal_unknown_method_stays_literal_method_call() -> None:
+    """A method on a literal that is NOT in the whitelist stays literal_method_call."""
+    call = _parse_call("'hello'.not_a_real_method()")
+    assert _classify_miss(call) == "literal_method_call"
+
+
+def test_bare_name_join_is_bare_name_unresolved() -> None:
+    """foo.join(y) where foo is a bare Name must not be affected."""
+    call = _parse_call("foo.join(y)")
+    assert _classify_miss(call) == "builtin_method_call"
+
+
+def test_call_result_bit_length_is_call_on_call_result() -> None:
+    """(1+2).bit_length() — func.value is a BinOp (non-literal), bucket unchanged."""
+    call = _parse_call("(1+2).bit_length()")
+    # BinOp receiver: not a Constant, so falls through to attr_chain_unresolved
+    result = _classify_miss(call)
+    assert result not in ("builtin_method_call", "literal_method_call")
+
+
 def test_list_append_is_accepted() -> None:
     call = _parse_call("lines.append(x)")
     assert _classify_miss(call) == "builtin_method_call"


### PR DESCRIPTION
## Summary

- In `classify_miss`, when the call receiver is an `ast.Constant` (string/bytes/int/float literal) and the method name is in `BUILTIN_COLLECTION_METHODS`, route to the existing `builtin_method_call` accepted bucket instead of `literal_method_call`.
- This is a ~5-line change in `misses.py` in the `ast.Attribute` branch that walks to the chain root.
- Added 5 new synthetic tests covering: str literal `.join()` accepted, `.format()` accepted, unknown method stays `literal_method_call`, bare `foo.join(y)` unaffected, `(1+2).bit_length()` BinOp receiver unaffected.

## Delta on video_agent_long

| metric | before | after |
|--------|--------|-------|
| `literal_method_call` (unresolved) | 274 | 0 |
| `accepted_counts.builtin_method_call` | 2581 | 2855 (+274) |

## Test plan

- [x] All 63 existing tests pass
- [x] `test_str_literal_join_is_builtin_method_call` — `'\n'.join(lines)` → `builtin_method_call`
- [x] `test_str_literal_format_is_builtin_method_call` — `'{}'.format(x)` → `builtin_method_call`
- [x] `test_str_literal_unknown_method_stays_literal_method_call` — non-whitelisted method stays `literal_method_call`
- [x] `test_bare_name_join_is_bare_name_unresolved` — `foo.join(y)` bare name unaffected
- [x] `test_call_result_bit_length_is_call_on_call_result` — BinOp receiver bucket unchanged

Fixes #2