### PR TITLE
fix MRO walker miss on inherited self.method (#3)

### DIFF
--- a/src/pyscope_mcp/analyzer/discovery.py
+++ b/src/pyscope_mcp/analyzer/discovery.py
@@ -38,6 +38,21 @@ def collect_defs(tree: ast.Module, module_fqn: str) -> set[str]:
     return defs
 
 
+def collect_classes(tree: ast.Module, module_fqn: str) -> set[str]:
+    """Collect FQNs of top-level class definitions in this module.
+
+    Used to distinguish class FQNs from method FQNs when searching for an
+    enclosing class in the scope stack.  Only top-level classes are needed
+    because ``collect_defs`` only records one level of nesting (class →
+    method); nested classes-inside-methods are not tracked.
+    """
+    classes: set[str] = set()
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef):
+            classes.add(f"{module_fqn}.{node.name}")
+    return classes
+
+
 def collect_class_bases(
     tree: ast.Module,
     module_fqn: str,

--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -6,7 +6,7 @@ import ast
 import sys
 from pathlib import Path
 
-from .discovery import collect_class_bases, collect_defs, discover_modules
+from .discovery import collect_class_bases, collect_classes, collect_defs, discover_modules
 from .imports import build_import_table
 from .misses import MissLog
 from .visitor import EdgeVisitor
@@ -32,6 +32,7 @@ def build_with_report(
     # Pass 1: parse all files; collect defs, import tables, class bases.
     parsed: list[tuple[str, ast.Module, Path, dict[str, str]]] = []
     known_fqns: set[str] = set()
+    known_classes: set[str] = set()
     class_bases: dict[str, list[str]] = {}
 
     for fqn, path in modules.items():
@@ -39,6 +40,7 @@ def build_with_report(
             source = path.read_text(encoding="utf-8", errors="replace")
             tree = ast.parse(source, filename=str(path))
             known_fqns.update(collect_defs(tree, fqn))
+            known_classes.update(collect_classes(tree, fqn))
             import_table = build_import_table(tree, fqn)
             parsed.append((fqn, tree, path, import_table))
         except SyntaxError as exc:
@@ -69,6 +71,7 @@ def build_with_report(
                 class_bases,
                 file_path=str(path),
                 miss_log=miss_log,
+                known_classes=known_classes,
             )
             visitor.visit(tree)
             for caller, callees in visitor.edges.items():

--- a/src/pyscope_mcp/analyzer/resolution.py
+++ b/src/pyscope_mcp/analyzer/resolution.py
@@ -129,3 +129,9 @@ class ResolveCtx:
     import_table: dict[str, str]
     known_fqns: set[str]
     class_bases: dict[str, list[str]]
+    known_classes: set[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        # Default to empty set so callers that don't supply it still work.
+        if self.known_classes is None:
+            object.__setattr__(self, "known_classes", set())

--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -31,12 +31,14 @@ class EdgeVisitor(ast.NodeVisitor):
         class_bases: dict[str, list[str]],
         file_path: str = "",
         miss_log: MissLog | None = None,
+        known_classes: set[str] | None = None,
     ) -> None:
         self._ctx = ResolveCtx(
             module_fqn=module_fqn,
             import_table=import_table,
             known_fqns=known_fqns,
             class_bases=class_bases,
+            known_classes=known_classes or set(),
         )
         self._file_path = file_path
         self._miss_log = miss_log
@@ -53,12 +55,19 @@ class EdgeVisitor(ast.NodeVisitor):
         return self._ctx.module_fqn
 
     def _enclosing_class_fqn(self) -> str | None:
-        """FQN of the enclosing class, walking inside-out through the scope stack."""
+        """FQN of the enclosing class, walking inside-out through the scope stack.
+
+        Only returns a candidate if it is a known *class* FQN.  Without this
+        check a nested function such as ``Class.method._inner`` would match
+        ``Class.method`` first (a method, not a class) and hand the wrong FQN
+        to ``walk_mro``, causing all inherited ``self.X`` calls inside nested
+        helpers to be mis-classified as ``self_method_unresolved``.
+        """
         if len(self._scope_stack) < 2:
             return None
         for i in range(len(self._scope_stack) - 2, -1, -1):
             candidate = f"{self._ctx.module_fqn}.{'.'.join(self._scope_stack[:i + 1])}"
-            if candidate in self._ctx.known_fqns:
+            if candidate in self._ctx.known_classes:
                 return candidate
         return None
 

--- a/tests/test_analyzer_m6.py
+++ b/tests/test_analyzer_m6.py
@@ -136,6 +136,82 @@ def test_mro_diamond_depth_first_left(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Regression: nested-function scope + ABC base (issue #3)
+# ---------------------------------------------------------------------------
+
+def test_self_method_inherited_via_abc_base_cross_module(tmp_path: Path) -> None:
+    """Regression: ContractChapterWriter-style failure.
+
+    A subclass in one module extends an ABC-inheriting base from another
+    module.  A *nested* helper function inside a method calls
+    ``self.call_llm(...)``.  Before the fix, ``_enclosing_class_fqn`` walked
+    the scope stack and returned the enclosing *method* FQN (which IS in
+    ``known_fqns``) rather than the enclosing *class* FQN, so ``walk_mro``
+    was invoked with a method key, found no bases, and the call was logged as
+    ``self_method_unresolved``.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "base.py": (
+            "from abc import ABC, abstractmethod\n"
+            "\n"
+            "class LLMAgent(ABC):\n"
+            "    @abstractmethod\n"
+            "    def call_llm(self, prompt: str) -> str: ...\n"
+        ),
+        "writer.py": (
+            "from pkg.base import LLMAgent\n"
+            "\n"
+            "class ContractChapterWriter(LLMAgent):\n"
+            "    def call_llm(self, prompt: str) -> str:\n"
+            "        return 'answer'\n"
+            "    def write_chapter(self, text: str) -> str:\n"
+            "        def _inner_helper() -> str:\n"
+            "            return self.call_llm(text)\n"
+            "        return _inner_helper()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    # The nested helper must resolve self.call_llm to the subclass's own override.
+    caller = "pkg.writer.ContractChapterWriter.write_chapter._inner_helper"
+    assert caller in raw, f"expected caller key {caller!r} in raw; got {sorted(raw)}"
+    assert "pkg.writer.ContractChapterWriter.call_llm" in raw[caller], (
+        f"expected self.call_llm to resolve; callees were {raw[caller]}"
+    )
+
+
+def test_self_method_inherited_in_nested_fn_resolves_to_base(tmp_path: Path) -> None:
+    """Regression companion: inherited method (not overridden) inside nested fn.
+
+    Same topology but ``call_llm`` is only defined on the base, not overridden
+    in the subclass, so the MRO walker must chase into the base class.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "base.py": (
+            "from abc import ABC\n"
+            "\n"
+            "class LLMAgent(ABC):\n"
+            "    def call_llm(self, prompt: str) -> str:\n"
+            "        return 'base'\n"
+        ),
+        "writer.py": (
+            "from pkg.base import LLMAgent\n"
+            "\n"
+            "class ContractChapterWriter(LLMAgent):\n"
+            "    def write_chapter(self, text: str) -> str:\n"
+            "        def _call_section() -> str:\n"
+            "            return self.call_llm(text)\n"
+            "        return _call_section()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    caller = "pkg.writer.ContractChapterWriter.write_chapter._call_section"
+    assert caller in raw, f"expected caller key {caller!r}; got {sorted(raw)}"
+    assert "pkg.base.LLMAgent.call_llm" in raw[caller], (
+        f"expected MRO resolution to base; callees were {raw[caller]}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Indirect dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

`_enclosing_class_fqn` in `visitor.py` walked the scope stack inside-out and returned the first FQN present in `known_fqns`. For a nested function like `ContractChapterWriter.write_chapter._call_pacing`, the scope stack is `["ContractChapterWriter", "write_chapter", "_call_pacing"]`. Walking inside-out, `i=1` produces `ContractChapterWriter.write_chapter` — a *method* FQN — which is in `known_fqns` (methods are tracked). The function returned this method key to `walk_mro`, which found no `class_bases` entry for it and returned `None`. Every `self.X` call inside a nested helper was therefore classified `self_method_unresolved`, regardless of whether the method existed on a base class.

The fix adds a `known_classes` set (collected by a new `collect_classes` pass-1 helper in `discovery.py`), threads it through `ResolveCtx` and `EdgeVisitor`, and changes `_enclosing_class_fqn` to check `known_classes` instead of `known_fqns`, so it correctly skips method FQNs when walking the scope stack inside-out.

This is cause #3 from the issue ("scope stack mis-match"), not cause #1 or #2 — `collect_class_bases` was correctly recording `LLMAgent` as a base of `ContractChapterWriter`, and `walk_mro` was not stopping early on `ABC`.

## Delta on video_agent_long

| metric | before | after | delta |
|---|---|---|---|
| `self_method_unresolved` | 244 | 241 | −3 |

Recovered: `ContractChapterWriter.write_chapter._call_pacing → LLMAgent.call_llm`, `ContractChapterWriter.write_chapter._call_structural → LLMAgent.call_llm`, and one other nested-helper site.

## Tests

Two regression tests added to `tests/test_analyzer_m6.py`:
- `test_self_method_inherited_via_abc_base_cross_module` — subclass overrides `call_llm`, nested helper resolves to the override.
- `test_self_method_inherited_in_nested_fn_resolves_to_base` — method only on base (ABC-inheriting), nested helper resolves via MRO walker.

All 52 tests pass (excluding the pre-existing `test_str_literal_join_is_builtin_method_call` failure on `main`).

Fixes #3