### PR TITLE
resolve self.<attr>.<method>() via __init__ type tracking (#4)

### DIFF
--- a/src/pyscope_mcp/analyzer/discovery.py
+++ b/src/pyscope_mcp/analyzer/discovery.py
@@ -82,6 +82,154 @@ def collect_class_bases(
     return result
 
 
+def collect_self_attr_types(
+    tree: ast.Module,
+    module_fqn: str,
+    import_table: dict[str, str],
+    known_fqns: set[str],
+) -> dict[str, dict[str, str]]:
+    """Map ``{class_fqn: {attr_name: inferred_class_fqn}}`` for top-level classes.
+
+    For each class, inspect ``__init__`` (and ``__post_init__``) for assignments
+    of the form ``self.X = Y`` where ``Y``'s type is statically resolvable:
+
+    1. RHS is a direct constructor call: ``self.X = Foo(...)`` → ``Foo`` via
+       existing import/alias machinery.
+    2. RHS is a bare name that matches an annotated ``__init__`` parameter:
+       ``def __init__(self, foo: Foo)`` + ``self.X = foo`` → ``Foo``.
+
+    First-assignment-wins; no flow-sensitive reassignment tracking.
+    No tuple/dict unpacking, no factory-function return-type resolution.
+    Returns only attrs whose inferred type is in ``known_fqns``.
+    """
+    result: dict[str, dict[str, str]] = {}
+
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        class_fqn = f"{module_fqn}.{node.name}"
+
+        for child in ast.iter_child_nodes(node):
+            if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if child.name not in {"__init__", "__post_init__"}:
+                continue
+
+            # Build param-name → annotated-type FQN map from the signature.
+            param_types: dict[str, str] = {}
+            for arg in child.args.args:
+                if arg.arg == "self":
+                    continue
+                if arg.annotation is not None:
+                    resolved = _resolve_annotation(
+                        arg.annotation, module_fqn, import_table, known_fqns
+                    )
+                    if resolved is not None:
+                        param_types[arg.arg] = resolved
+
+            # Walk the body for ``self.X = ...`` assignments.
+            attr_types: dict[str, str] = result.setdefault(class_fqn, {})
+            for stmt in ast.walk(child):
+                if not isinstance(stmt, ast.Assign):
+                    continue
+                if len(stmt.targets) != 1:
+                    continue
+                target = stmt.targets[0]
+                if not (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    continue
+                attr_name = target.attr
+                if attr_name in attr_types:
+                    continue  # first-assignment-wins
+
+                inferred = _infer_type(
+                    stmt.value, module_fqn, import_table, known_fqns, param_types
+                )
+                if inferred is not None:
+                    attr_types[attr_name] = inferred
+
+    return result
+
+
+def _resolve_annotation(
+    annotation: ast.expr,
+    module_fqn: str,
+    import_table: dict[str, str],
+    known_fqns: set[str],
+) -> str | None:
+    """Resolve a type annotation expression to an in-package FQN, or None."""
+    if isinstance(annotation, ast.Name):
+        name = annotation.id
+        if name in import_table:
+            candidate = import_table[name]
+            if candidate in known_fqns:
+                return candidate
+        candidate = f"{module_fqn}.{name}"
+        if candidate in known_fqns:
+            return candidate
+        return None
+
+    chain = attr_chain(annotation)
+    if chain is None:
+        return None
+    for prefix_len in range(len(chain) - 1, 0, -1):
+        prefix = ".".join(chain[:prefix_len])
+        if prefix in import_table:
+            base_fqn = import_table[prefix]
+            remainder = chain[prefix_len:]
+            candidate = ".".join([base_fqn] + remainder)
+            if candidate in known_fqns:
+                return candidate
+    dotted = ".".join(chain)
+    if dotted in known_fqns:
+        return dotted
+    return None
+
+
+def _infer_type(
+    rhs: ast.expr,
+    module_fqn: str,
+    import_table: dict[str, str],
+    known_fqns: set[str],
+    param_types: dict[str, str],
+) -> str | None:
+    """Infer the class type of an RHS expression (best-effort, v1 scope only)."""
+    # Case 1: bare name → parameter annotation.
+    if isinstance(rhs, ast.Name):
+        return param_types.get(rhs.id)
+
+    # Case 2: constructor call: Foo(...) or pkg.Foo(...) or aliased.Foo(...)
+    if isinstance(rhs, ast.Call):
+        func = rhs.func
+        if isinstance(func, ast.Name):
+            name = func.id
+            if name in import_table:
+                candidate = import_table[name]
+                if candidate in known_fqns:
+                    return candidate
+            candidate = f"{module_fqn}.{name}"
+            if candidate in known_fqns:
+                return candidate
+            return None
+        chain = attr_chain(func)
+        if chain is not None:
+            for prefix_len in range(len(chain) - 1, 0, -1):
+                prefix = ".".join(chain[:prefix_len])
+                if prefix in import_table:
+                    base_fqn = import_table[prefix]
+                    remainder = chain[prefix_len:]
+                    candidate = ".".join([base_fqn] + remainder)
+                    if candidate in known_fqns:
+                        return candidate
+            dotted = ".".join(chain)
+            if dotted in known_fqns:
+                return dotted
+    return None
+
+
 def _resolve_base(
     base: ast.expr,
     module_fqn: str,

--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -6,7 +6,13 @@ import ast
 import sys
 from pathlib import Path
 
-from .discovery import collect_class_bases, collect_classes, collect_defs, discover_modules
+from .discovery import (
+    collect_class_bases,
+    collect_classes,
+    collect_defs,
+    collect_self_attr_types,
+    discover_modules,
+)
 from .imports import build_import_table
 from .misses import MissLog
 from .visitor import EdgeVisitor
@@ -34,6 +40,7 @@ def build_with_report(
     known_fqns: set[str] = set()
     known_classes: set[str] = set()
     class_bases: dict[str, list[str]] = {}
+    self_attr_types: dict[str, dict[str, str]] = {}
 
     for fqn, path in modules.items():
         try:
@@ -52,11 +59,14 @@ def build_with_report(
             _warn(f"skipping {path}: {reason}")
             miss_log.record_skip(str(path), reason)
 
-    # Second sweep over parsed files to build class-bases, now that
-    # known_fqns is fully populated (bases in one module may reference
-    # classes in another).
+    # Second sweep over parsed files to build class-bases and self-attr types,
+    # now that known_fqns is fully populated (bases / types may reference
+    # classes in other modules).
     for fqn, tree, _path, import_table in parsed:
         class_bases.update(collect_class_bases(tree, fqn, import_table))
+        self_attr_types.update(
+            collect_self_attr_types(tree, fqn, import_table, known_fqns)
+        )
 
     miss_log.files_parsed = len(parsed)
 
@@ -72,6 +82,7 @@ def build_with_report(
                 file_path=str(path),
                 miss_log=miss_log,
                 known_classes=known_classes,
+                self_attr_types=self_attr_types,
             )
             visitor.visit(tree)
             for caller, callees in visitor.edges.items():

--- a/src/pyscope_mcp/analyzer/resolution.py
+++ b/src/pyscope_mcp/analyzer/resolution.py
@@ -130,8 +130,38 @@ class ResolveCtx:
     known_fqns: set[str]
     class_bases: dict[str, list[str]]
     known_classes: set[str] = None  # type: ignore[assignment]
+    # {class_fqn: {attr_name: inferred_class_fqn}} — populated in pass 1
+    self_attr_types: dict[str, dict[str, str]] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
-        # Default to empty set so callers that don't supply it still work.
+        # Default to empty set/dict so callers that don't supply it still work.
         if self.known_classes is None:
             object.__setattr__(self, "known_classes", set())
+        if self.self_attr_types is None:
+            object.__setattr__(self, "self_attr_types", {})
+
+
+# ---------------------------------------------------------------------------
+# self.<attr>.<method>() resolution via __init__ type tracking
+# ---------------------------------------------------------------------------
+
+def resolve_self_attr_method(
+    attr_name: str,
+    method: str,
+    class_fqn: str,
+    ctx: ResolveCtx,
+) -> str | None:
+    """Resolve ``self.<attr>.<method>(...)`` inside a method of ``class_fqn``.
+
+    1. Look up ``attr_name`` in ``self_attr_types[class_fqn]``.
+    2. Walk MRO of the inferred attribute class to find ``method``.
+    3. Return the FQN or None (silent on any miss).
+    """
+    attr_class = ctx.self_attr_types.get(class_fqn, {}).get(attr_name)
+    if attr_class is None:
+        return None
+    # Direct hit first (avoids MRO traversal overhead).
+    candidate = f"{attr_class}.{method}"
+    if candidate in ctx.known_fqns:
+        return candidate
+    return walk_mro(attr_class, method, ctx.class_bases, ctx.known_fqns)

--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -10,6 +10,7 @@ from .resolution import (
     attr_chain,
     dispatcher_callable_arg,
     is_dispatcher_call,
+    resolve_self_attr_method,
     walk_mro,
 )
 
@@ -32,6 +33,7 @@ class EdgeVisitor(ast.NodeVisitor):
         file_path: str = "",
         miss_log: MissLog | None = None,
         known_classes: set[str] | None = None,
+        self_attr_types: dict[str, dict[str, str]] | None = None,
     ) -> None:
         self._ctx = ResolveCtx(
             module_fqn=module_fqn,
@@ -39,6 +41,7 @@ class EdgeVisitor(ast.NodeVisitor):
             known_fqns=known_fqns,
             class_bases=class_bases,
             known_classes=known_classes or set(),
+            self_attr_types=self_attr_types or {},
         )
         self._file_path = file_path
         self._miss_log = miss_log
@@ -106,7 +109,6 @@ class EdgeVisitor(ast.NodeVisitor):
                 class_fqn = self._enclosing_class_fqn()
                 if class_fqn is None:
                     return None
-                # Only single-hop self.x is resolvable; self.x.y loses the type.
                 if len(chain) == 2:
                     method = chain[1]
                     candidate = f"{class_fqn}.{method}"
@@ -117,6 +119,12 @@ class EdgeVisitor(ast.NodeVisitor):
                         method,
                         self._ctx.class_bases,
                         self._ctx.known_fqns,
+                    )
+                # self.<attr>.<method>(...) — three-part chain via attr type tracking.
+                if len(chain) == 3:
+                    attr_name, method = chain[1], chain[2]
+                    return resolve_self_attr_method(
+                        attr_name, method, class_fqn, self._ctx
                     )
                 return None
 

--- a/tests/test_analyzer_m8.py
+++ b/tests/test_analyzer_m8.py
@@ -1,0 +1,255 @@
+"""M8: self.<attr>.<method>() resolution via __init__ attribute type tracking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyscope_mcp.analyzer import build_raw
+
+
+def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:
+    pkg = tmp_path / pkg_name
+    pkg.mkdir()
+    if "__init__.py" not in files:
+        (pkg / "__init__.py").write_text("")
+    for rel, content in files.items():
+        target = pkg / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Case 1: constructor-RHS
+# ---------------------------------------------------------------------------
+
+def test_constructor_rhs_same_module(tmp_path: Path) -> None:
+    """self.X = Foo() in __init__ → self.X.method() resolves to Foo.method."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Logger:\n"
+            "    def log(self, msg):\n"
+            "        pass\n"
+            "\n"
+            "class Agent:\n"
+            "    def __init__(self):\n"
+            "        self.logger = Logger()\n"
+            "\n"
+            "    def run(self):\n"
+            "        self.logger.log('hello')\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.mod.Logger.log" in raw.get("pkg.mod.Agent.run", [])
+
+
+def test_constructor_rhs_cross_module(tmp_path: Path) -> None:
+    """Constructor RHS imported from another module."""
+    root = _make_package(tmp_path, "pkg", {
+        "logger.py": (
+            "class Logger:\n"
+            "    def log(self, msg):\n"
+            "        pass\n"
+        ),
+        "agent.py": (
+            "from pkg.logger import Logger\n"
+            "\n"
+            "class Agent:\n"
+            "    def __init__(self):\n"
+            "        self._logger = Logger()\n"
+            "\n"
+            "    def run(self):\n"
+            "        self._logger.log('hi')\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.logger.Logger.log" in raw.get("pkg.agent.Agent.run", [])
+
+
+# ---------------------------------------------------------------------------
+# Case 2: annotated-parameter case
+# ---------------------------------------------------------------------------
+
+def test_annotated_param_rhs(tmp_path: Path) -> None:
+    """self.X = foo where foo: Foo in __init__ signature → self.X.method()."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class TTS:\n"
+            "    def synthesize(self, text):\n"
+            "        pass\n"
+            "\n"
+            "class Runner:\n"
+            "    def __init__(self, tts: TTS):\n"
+            "        self._tts = tts\n"
+            "\n"
+            "    def speak(self, text):\n"
+            "        self._tts.synthesize(text)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.mod.TTS.synthesize" in raw.get("pkg.mod.Runner.speak", [])
+
+
+def test_annotated_param_cross_module(tmp_path: Path) -> None:
+    """Annotated param type imported from another module."""
+    root = _make_package(tmp_path, "pkg", {
+        "packager.py": (
+            "class Packager:\n"
+            "    def package(self, data):\n"
+            "        pass\n"
+        ),
+        "pipeline.py": (
+            "from pkg.packager import Packager\n"
+            "\n"
+            "class Pipeline:\n"
+            "    def __init__(self, packager: Packager):\n"
+            "        self._packager = packager\n"
+            "\n"
+            "    def run(self, data):\n"
+            "        self._packager.package(data)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.packager.Packager.package" in raw.get("pkg.pipeline.Pipeline.run", [])
+
+
+# ---------------------------------------------------------------------------
+# Case 3: MRO walk up the attr's class
+# ---------------------------------------------------------------------------
+
+def test_mro_walk_on_attr_class(tmp_path: Path) -> None:
+    """Attr class inherits method from a base → MRO walk finds it."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class LoggerBase:\n"
+            "    def log_llm(self, data):\n"
+            "        pass\n"
+            "\n"
+            "class ScriptLogger(LoggerBase):\n"
+            "    pass\n"
+            "\n"
+            "class Agent:\n"
+            "    def __init__(self):\n"
+            "        self.script_logger = ScriptLogger()\n"
+            "\n"
+            "    def run(self):\n"
+            "        self.script_logger.log_llm({'tokens': 5})\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.mod.LoggerBase.log_llm" in raw.get("pkg.mod.Agent.run", [])
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards
+# ---------------------------------------------------------------------------
+
+def test_unresolvable_rhs_returns_none(tmp_path: Path) -> None:
+    """attr assigned from an unresolvable name → must NOT emit a fake edge."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Agent:\n"
+            "    def __init__(self):\n"
+            "        self.helper = some_factory()\n"  # 'some_factory' is unknown
+            "\n"
+            "    def run(self):\n"
+            "        self.helper.do_thing()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Agent.run", [])
+    # Must not fabricate any edge to a non-existent method.
+    assert not any("do_thing" in c for c in callees)
+
+
+def test_external_type_attr_returns_none(tmp_path: Path) -> None:
+    """Attr annotated with an external (non-package) type → return None silently."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import logging\n"
+            "\n"
+            "class Agent:\n"
+            "    def __init__(self, logger: logging.Logger):\n"
+            "        self._logger = logger\n"
+            "\n"
+            "    def run(self):\n"
+            "        self._logger.info('hello')\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Agent.run", [])
+    # External logger.info should not appear as a fake in-package edge.
+    assert not any("logging" in c for c in callees)
+    assert not any("info" in c and "pkg" in c for c in callees)
+
+
+def test_same_method_name_on_unrelated_class_not_picked(tmp_path: Path) -> None:
+    """A method with the same name on an unrelated class must NOT be returned."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Unrelated:\n"
+            "    def process(self):\n"
+            "        pass\n"
+            "\n"
+            "class Helper:\n"
+            "    pass\n"
+            "    # no 'process' method\n"
+            "\n"
+            "class Agent:\n"
+            "    def __init__(self):\n"
+            "        self.h = Helper()\n"
+            "\n"
+            "    def run(self):\n"
+            "        self.h.process()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Agent.run", [])
+    # Unrelated.process must not appear; h.process should just miss silently.
+    assert "pkg.mod.Unrelated.process" not in callees
+
+
+def test_no_attr_in_init_returns_none(tmp_path: Path) -> None:
+    """Attr not assigned in __init__ → call on it misses silently, no fake edge."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class TTS:\n"
+            "    def synthesize(self, text):\n"
+            "        pass\n"
+            "\n"
+            "class Agent:\n"
+            "    def run(self):\n"
+            "        self._tts.synthesize('hi')\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Agent.run", [])
+    assert "pkg.mod.TTS.synthesize" not in callees
+
+
+def test_first_assignment_wins(tmp_path: Path) -> None:
+    """Reassignment of self.X later in __init__ is ignored; first type wins."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Alpha:\n"
+            "    def run(self):\n"
+            "        pass\n"
+            "\n"
+            "class Beta:\n"
+            "    def run(self):\n"
+            "        pass\n"
+            "\n"
+            "class Agent:\n"
+            "    def __init__(self):\n"
+            "        self.worker = Alpha()\n"
+            "        self.worker = Beta()  # reassignment — ignored\n"
+            "\n"
+            "    def go(self):\n"
+            "        self.worker.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Agent.go", [])
+    # First assignment (Alpha) wins; Beta.run should NOT be the result.
+    # Alpha.run must appear (it's the first-wins type).
+    assert "pkg.mod.Alpha.run" in callees


### PR DESCRIPTION
## Summary

- **Pass-1 collector** (`discovery.py`): `collect_self_attr_types` walks each class's `__init__`/`__post_init__` and records `self.X = Foo(...)` (constructor RHS) and `self.X = foo` where `foo: Foo` (annotated param). Output: `{class_fqn: {attr_name: inferred_class_fqn}}`. First-assignment-wins; no flow-sensitive tracking, no factory return-type resolution.
- **`ResolveCtx`** (`resolution.py`): adds `self_attr_types` field (defaults to `{}`). New `resolve_self_attr_method(attr_name, method, class_fqn, ctx)` looks up the attr type then walks MRO via existing `walk_mro` helper.
- **Visitor wiring** (`visitor.py`): the 3-part `self.X.Y(...)` chain now calls `resolve_self_attr_method` from `_resolve_expr`.
- **Pipeline** (`pipeline.py`): `collect_self_attr_types` called in the second sweep (after `known_fqns` is fully populated); result threaded into `EdgeVisitor`.

## Delta on video_agent_long

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| `calls_resolved_in_package` | 1934 | 2023 | +89 |
| `self_method_unresolved` | 241 | 152 | -89 |
| `dead_keys` | 379 | 371 | -8 (9 recovered, 1 new) |

**Recovered dead keys (9):**
- `AvatarPackagingAgent.package`, `AvatarPackagingAgent.package_arkit`
- `ChatterboxServerBackend.synthesize`, `_TtsServerClient.get_voice_checksum`, `_TtsServerClient.synthesize`
- `UsageTracker.log`, `UsageTracker.log_issues`, `UsageTracker.log_llm`, `UsageTracker.section`

## Tests

10 new tests in `tests/test_analyzer_m8.py`:
- Constructor RHS (same module, cross-module)
- Annotated param (same module, cross-module)
- MRO walk up attr's class
- False-positive guards: unresolvable RHS, external type, same-name method on unrelated class, attr not in `__init__`, first-assignment-wins

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)