### PR TITLE
classifier: widen accepted buckets for io/hashlib/random/argparse/anthropic/requests

### DIFF
--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -117,6 +117,69 @@ PYDANTIC_BASE_NAMES: frozenset[str] = frozenset({"BaseModel", "RootModel"})
 PYDANTIC_METHODS: frozenset[str] = frozenset({
     "model_dump", "model_dump_json", "model_validate", "model_validate_json",
     "model_copy", "model_fields",
+    "model_rebuild", "model_json_schema", "model_parametrized_name",
+})
+
+# File-like object method names.  Gated conservatively: only classified as
+# io_method_call when chain[0] is a known file-var name OR when chain is None
+# (receiver is a Call result like open(p).read()).
+IO_METHODS: frozenset[str] = frozenset({
+    "read", "write", "readline", "readlines", "writelines", "seek", "tell",
+    "flush", "close", "truncate", "readable", "writable", "seekable",
+    "getvalue", "getbuffer",
+})
+
+# hashlib hash-object method names.  These are distinctive enough to classify
+# without any chain-root guard.
+HASHLIB_METHODS: frozenset[str] = frozenset({
+    "hexdigest", "digest", "update", "copy",
+})
+
+# random / Random instance method names.
+RANDOM_METHODS: frozenset[str] = frozenset({
+    "random", "randint", "choice", "choices", "sample", "shuffle", "uniform",
+    "seed", "randrange", "getrandbits", "gauss",
+})
+
+# argparse ArgumentParser / subparsers method names.  Distinctive enough to
+# classify without chain-root guard.
+ARGPARSE_METHODS: frozenset[str] = frozenset({
+    "add_argument", "add_subparsers", "add_parser", "parse_args",
+    "parse_known_args", "set_defaults", "add_argument_group",
+    "add_mutually_exclusive_group", "print_help",
+})
+
+# Anthropic SDK client method names.  Generic names (create/list/retrieve)
+# are only classified as anthropic when the chain contains a known client-var
+# or an intermediate Anthropic namespace attr (messages/beta/completions).
+ANTHROPIC_METHODS: frozenset[str] = frozenset({
+    "create", "stream", "count_tokens", "retrieve", "list",
+})
+
+# Known Anthropic client variable names that make ANTHROPIC_METHODS unambiguous.
+_ANTHROPIC_CLIENT_VARS: frozenset[str] = frozenset({
+    "client", "anthropic_client", "_client",
+})
+
+# Intermediate attribute names that indicate an Anthropic SDK chain.
+_ANTHROPIC_ATTRS: frozenset[str] = frozenset({
+    "messages", "beta", "completions",
+})
+
+# requests Response method names — gated on chain-root variable name to avoid
+# false positives on in-package .json() style methods.
+REQUESTS_METHODS: frozenset[str] = frozenset({
+    "json", "raise_for_status", "iter_content", "iter_lines",
+})
+
+# Known requests response variable names.
+_REQUESTS_RESP_VARS: frozenset[str] = frozenset({
+    "r", "resp", "response",
+})
+
+# Known IO file variable names — used to gate io_method_call conservatively.
+_IO_FILE_VARS: frozenset[str] = frozenset({
+    "f", "fh", "fp", "file", "tmp", "buf", "stream",
 })
 
 # Pattern tags from classify_miss that route to record_accepted (vs record_miss).
@@ -125,6 +188,9 @@ ACCEPTED_PATTERNS: frozenset[str] = frozenset({
     "pydantic_method_call", "pil_method_call", "wave_method_call",
     "loguru_method_call", "re_method_call", "datetime_method_call",
     "difflib_method_call",
+    # M8 additions
+    "io_method_call", "hashlib_method_call", "random_method_call",
+    "argparse_method_call", "anthropic_method_call", "requests_method_call",
 })
 
 
@@ -258,6 +324,12 @@ def _has_pydantic_ancestor(
     return False
 
 
+def _chain_has_anthropic_attr(chain: list[str]) -> bool:
+    """Return True if any intermediate element of chain is an Anthropic namespace attr."""
+    # chain[-1] is the method, chain[0] is the root — check the middle attrs
+    return bool(set(chain[1:-1]) & _ANTHROPIC_ATTRS)
+
+
 def classify_miss(
     node: ast.Call,
     *,
@@ -330,6 +402,13 @@ def classify_miss(
                 # Chain-root special case: known logger variable names
                 if chain[0] in {"logger", "log", "logging"}:
                     return "loguru_method_call"
+                # Chain-root special case: random / rng
+                if chain[0] in {"random", "rng"}:
+                    return "random_method_call"
+                # Chain-root special case: requests response variables
+                # Only route when both chain-root AND method match.
+                if chain[0] in _REQUESTS_RESP_VARS and method in REQUESTS_METHODS:
+                    return "requests_method_call"
                 if method in BUILTIN_COLLECTION_METHODS:
                     return "builtin_method_call"
                 if method in PATHLIB_METHODS:
@@ -350,6 +429,20 @@ def classify_miss(
                     return "datetime_method_call"
                 if method in DIFFLIB_METHODS:
                     return "difflib_method_call"
+                if method in HASHLIB_METHODS:
+                    return "hashlib_method_call"
+                if method in RANDOM_METHODS:
+                    return "random_method_call"
+                if method in ARGPARSE_METHODS:
+                    return "argparse_method_call"
+                # Anthropic: gate strictly — only when chain-root is a known
+                # client var OR an intermediate attr is an Anthropic namespace.
+                if method in ANTHROPIC_METHODS:
+                    if chain[0] in _ANTHROPIC_CLIENT_VARS or _chain_has_anthropic_attr(chain):
+                        return "anthropic_method_call"
+                # IO: gate conservatively on chain[0] being a known file-var name.
+                if method in IO_METHODS and chain[0] in _IO_FILE_VARS:
+                    return "io_method_call"
         else:
             # chain is None: receiver is a non-Name/non-Attribute expression
             # (e.g. BinOp, Call, Subscript).  Fall back to method-name lookup.
@@ -374,6 +467,18 @@ def classify_miss(
                 return "datetime_method_call"
             if method in DIFFLIB_METHODS:
                 return "difflib_method_call"
+            if method in HASHLIB_METHODS:
+                return "hashlib_method_call"
+            if method in RANDOM_METHODS:
+                return "random_method_call"
+            if method in ARGPARSE_METHODS:
+                return "argparse_method_call"
+            # IO chain-None: receiver is a call result like open(p).read() —
+            # safe to classify without chain-root guard.
+            if method in IO_METHODS:
+                return "io_method_call"
+            # NOTE: anthropic and requests are NOT classified in chain-None
+            # fallback — their method names are too generic without chain context.
         return "attr_chain_unresolved"
 
     return "other_unresolved"

--- a/tests/test_misses_classifier_m8.py
+++ b/tests/test_misses_classifier_m8.py
@@ -1,0 +1,258 @@
+"""M8 classifier extension: io / hashlib / random / argparse / anthropic / requests
+accepted-miss buckets.
+
+Each test verifies a method-name is classified into the correct accepted bucket.
+False-positive guards verify that in-package .json(), bare create(), and
+unguarded obj.read() are NOT stolen by the new whitelists.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from pyscope_mcp.analyzer import _classify_miss
+
+
+def _parse_call(src: str) -> ast.Call:
+    """Parse a single-expression snippet and return the outermost Call node."""
+    tree = ast.parse(src)
+    expr = tree.body[0]
+    assert isinstance(expr, ast.Expr)
+    call = expr.value
+    assert isinstance(call, ast.Call)
+    return call
+
+
+# ---------------------------------------------------------------------------
+# io_method_call — positive cases (known file-var chain root)
+# ---------------------------------------------------------------------------
+
+def test_f_read_is_io_method_call() -> None:
+    call = _parse_call("f.read()")
+    assert _classify_miss(call) == "io_method_call"
+
+
+def test_fh_write_is_io_method_call() -> None:
+    call = _parse_call("fh.write(data)")
+    assert _classify_miss(call) == "io_method_call"
+
+
+def test_fp_readline_is_io_method_call() -> None:
+    call = _parse_call("fp.readline()")
+    assert _classify_miss(call) == "io_method_call"
+
+
+def test_buf_getvalue_is_io_method_call() -> None:
+    call = _parse_call("buf.getvalue()")
+    assert _classify_miss(call) == "io_method_call"
+
+
+def test_open_result_read_chain_none_is_io_method_call() -> None:
+    """open(p).read() — chain is None (receiver is a Call result)."""
+    call = _parse_call("open(p).read()")
+    assert _classify_miss(call) == "io_method_call"
+
+
+def test_open_result_seek_chain_none_is_io_method_call() -> None:
+    """open(p).seek(0) — chain is None."""
+    call = _parse_call("open(p).seek(0)")
+    assert _classify_miss(call) == "io_method_call"
+
+
+# ---------------------------------------------------------------------------
+# hashlib_method_call — positive cases
+# ---------------------------------------------------------------------------
+
+def test_h_hexdigest_is_hashlib_method_call() -> None:
+    call = _parse_call("h.hexdigest()")
+    assert _classify_miss(call) == "hashlib_method_call"
+
+
+def test_hasher_copy_is_hashlib_method_call() -> None:
+    # NOTE: 'update' is also in BUILTIN_COLLECTION_METHODS (dict.update) so it
+    # resolves to builtin_method_call first — which is still accepted. We use
+    # 'copy' here, but note 'copy' is also in BUILTIN_COLLECTION_METHODS (dict.copy).
+    # Use hexdigest as the unambiguous hashlib-only discriminator instead.
+    call = _parse_call("hasher.hexdigest()")
+    assert _classify_miss(call) == "hashlib_method_call"
+
+
+def test_md5_digest_is_hashlib_method_call() -> None:
+    call = _parse_call("md5.digest()")
+    assert _classify_miss(call) == "hashlib_method_call"
+
+
+# ---------------------------------------------------------------------------
+# random_method_call — positive cases
+# ---------------------------------------------------------------------------
+
+def test_random_chain_root_randint_is_random_method_call() -> None:
+    """random.randint(0, 10) — chain[0]=='random' fires chain-root guard."""
+    call = _parse_call("random.randint(0, 10)")
+    assert _classify_miss(call) == "random_method_call"
+
+
+def test_rng_choice_is_random_method_call() -> None:
+    call = _parse_call("rng.choice(items)")
+    assert _classify_miss(call) == "random_method_call"
+
+
+def test_rng_shuffle_is_random_method_call() -> None:
+    call = _parse_call("rng.shuffle(lst)")
+    assert _classify_miss(call) == "random_method_call"
+
+
+def test_gen_gauss_is_random_method_call() -> None:
+    """gen.gauss(0, 1) — method in RANDOM_METHODS, not chain-root gated."""
+    call = _parse_call("gen.gauss(0, 1)")
+    assert _classify_miss(call) == "random_method_call"
+
+
+# ---------------------------------------------------------------------------
+# argparse_method_call — positive cases
+# ---------------------------------------------------------------------------
+
+def test_parser_add_argument_is_argparse_method_call() -> None:
+    call = _parse_call('parser.add_argument("--foo")')
+    assert _classify_miss(call) == "argparse_method_call"
+
+
+def test_parser_parse_args_is_argparse_method_call() -> None:
+    call = _parse_call("parser.parse_args()")
+    assert _classify_miss(call) == "argparse_method_call"
+
+
+def test_subparsers_add_parser_is_argparse_method_call() -> None:
+    call = _parse_call('subparsers.add_parser("cmd")')
+    assert _classify_miss(call) == "argparse_method_call"
+
+
+def test_parser_print_help_is_argparse_method_call() -> None:
+    call = _parse_call("parser.print_help()")
+    assert _classify_miss(call) == "argparse_method_call"
+
+
+# ---------------------------------------------------------------------------
+# anthropic_method_call — positive cases (strictly gated)
+# ---------------------------------------------------------------------------
+
+def test_client_messages_create_is_anthropic_method_call() -> None:
+    """client.messages.create(...) — chain[0]=='client' (known client-var)."""
+    call = _parse_call("client.messages.create(model='claude-3-opus-20240229')")
+    assert _classify_miss(call) == "anthropic_method_call"
+
+
+def test_anthropic_client_messages_stream_is_anthropic_method_call() -> None:
+    call = _parse_call("anthropic_client.messages.stream()")
+    assert _classify_miss(call) == "anthropic_method_call"
+
+
+def test_chain_with_messages_attr_is_anthropic_method_call() -> None:
+    """sdk.messages.create() — 'messages' is an intermediate Anthropic attr."""
+    call = _parse_call("sdk.messages.create()")
+    assert _classify_miss(call) == "anthropic_method_call"
+
+
+def test_chain_with_beta_attr_is_anthropic_method_call() -> None:
+    """api.beta.tools.create() — 'beta' is an intermediate Anthropic attr."""
+    call = _parse_call("api.beta.tools.create()")
+    assert _classify_miss(call) == "anthropic_method_call"
+
+
+# ---------------------------------------------------------------------------
+# requests_method_call — positive cases (gated on chain-root + method)
+# ---------------------------------------------------------------------------
+
+def test_r_json_is_requests_method_call() -> None:
+    call = _parse_call("r.json()")
+    assert _classify_miss(call) == "requests_method_call"
+
+
+def test_resp_raise_for_status_is_requests_method_call() -> None:
+    call = _parse_call("resp.raise_for_status()")
+    assert _classify_miss(call) == "requests_method_call"
+
+
+def test_response_iter_content_is_requests_method_call() -> None:
+    call = _parse_call("response.iter_content(chunk_size=1024)")
+    assert _classify_miss(call) == "requests_method_call"
+
+
+# ---------------------------------------------------------------------------
+# pydantic extension — model_rebuild / model_json_schema
+# ---------------------------------------------------------------------------
+
+def test_model_rebuild_is_pydantic_method_call() -> None:
+    call = _parse_call("MyModel.model_rebuild()")
+    assert _classify_miss(call) == "pydantic_method_call"
+
+
+def test_model_json_schema_is_pydantic_method_call() -> None:
+    call = _parse_call("MyModel.model_json_schema()")
+    assert _classify_miss(call) == "pydantic_method_call"
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards
+# ---------------------------------------------------------------------------
+
+def test_inpackage_json_is_not_requests_method_call() -> None:
+    """self.config.json() — self.* branch fires first; not requests."""
+    src = (
+        "class Loader:\n"
+        "    def load(self):\n"
+        "        self.config.json()\n"
+    )
+    tree = ast.parse(src)
+    call_node = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "json"
+        ):
+            call_node = node
+            break
+    assert call_node is not None
+    assert _classify_miss(call_node) == "self_method_unresolved"
+
+
+def test_other_obj_json_is_not_requests_method_call() -> None:
+    """obj.json() where chain[0] is not in _REQUESTS_RESP_VARS — falls through."""
+    call = _parse_call("obj.json()")
+    # 'json' is not in BUILTIN_COLLECTION_METHODS, PATHLIB_METHODS etc.,
+    # and chain[0]=='obj' is not in _REQUESTS_RESP_VARS → attr_chain_unresolved.
+    assert _classify_miss(call) == "attr_chain_unresolved"
+
+
+def test_bare_create_not_anthropic() -> None:
+    """create(model='x') is bare_name_unresolved, not anthropic_method_call."""
+    call = _parse_call("create(model='x')")
+    assert _classify_miss(call) == "bare_name_unresolved"
+
+
+def test_unknown_chain_create_not_anthropic() -> None:
+    """factory.create() — no client-var root, no messages/beta/completions attr."""
+    call = _parse_call("factory.create()")
+    assert _classify_miss(call) == "attr_chain_unresolved"
+
+
+def test_obj_read_unknown_chain_root_not_io() -> None:
+    """obj.read(x) — chain[0]=='obj' is not in _IO_FILE_VARS → falls through."""
+    call = _parse_call("obj.read(x)")
+    # 'read' is not in any other whitelist, so attr_chain_unresolved
+    assert _classify_miss(call) == "attr_chain_unresolved"
+
+
+# ---------------------------------------------------------------------------
+# Cross-file linkage: M8 tags must be present in ACCEPTED_PATTERNS
+# ---------------------------------------------------------------------------
+
+def test_m8_tags_are_all_accepted() -> None:
+    """Every tag produced by M8 positive cases must be in ACCEPTED_PATTERNS."""
+    from pyscope_mcp.analyzer.misses import ACCEPTED_PATTERNS
+    for tag in {
+        "io_method_call", "hashlib_method_call", "random_method_call",
+        "argparse_method_call", "anthropic_method_call", "requests_method_call",
+    }:
+        assert tag in ACCEPTED_PATTERNS, f"{tag!r} missing from ACCEPTED_PATTERNS"


### PR DESCRIPTION
## Summary

Adds six new accepted-miss pattern tags to the classifier in `src/pyscope_mcp/analyzer/misses.py`, moving previously unclassified `attr_chain_unresolved` calls into named accepted buckets. Each new rule ships with conservative false-positive guards: io is gated on known file-var names or call-result receivers; requests requires both chain-root match and method match; anthropic fires only when the chain root is a known client var or an intermediate attr is `messages`/`beta`/`completions`. Also extends `PYDANTIC_METHODS` with three additional Pydantic v2 class-method names.

## Real-repo delta (video_agent_long)

```
unresolved:          4611 -> 4276  (-335)
attr_chain_unresolved: 878 -> 543  (-335)

accepted_counts:
  anthropic_method_call:  0 -> 4    (NEW)
  argparse_method_call:   0 -> 257  (NEW)
  hashlib_method_call:    0 -> 6    (NEW)
  io_method_call:         0 -> 17   (NEW)
  pydantic_method_call: 147 -> 149  (+2)
  random_method_call:     0 -> 3    (NEW)
  requests_method_call:   0 -> 46   (NEW)
```

## Test plan

- [x] `tests/test_misses_classifier_m8.py` — 32 new tests; all pass (`196 passed` total)
- [x] Positive cases for all six new tags
- [x] False-positive guards: `self.config.json()` → `self_method_unresolved`, `obj.json()` → `attr_chain_unresolved`, bare `create()` → `bare_name_unresolved`, `factory.create()` → `attr_chain_unresolved`, `obj.read(x)` → `attr_chain_unresolved`
- [x] `ACCEPTED_PATTERNS` membership assertion for all six new tags
- [x] Full suite: `196 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)