### PR TITLE
classifier: accept Python builtins as builtin_function_call

### DIFF
--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import ast
+import builtins
 import collections
 from collections import Counter
 
 from .resolution import attr_chain
 
 _EXEMPLAR_CAP = 50
+
+# Python builtin callable names that are safe to accept without resolution.
+# super/getattr have dedicated tags; exec/eval/compile have exec_or_eval.
+BUILTIN_FUNCTION_NAMES: frozenset[str] = (
+    frozenset(n for n in dir(builtins) if not n.startswith("_"))
+    - {"exec", "eval", "compile", "super", "getattr"}
+)
 
 # Canonical method names for built-in container / string types.
 # These are unresolvable via static analysis (the receiver could be anything);
@@ -184,6 +192,7 @@ _IO_FILE_VARS: frozenset[str] = frozenset({
 
 # Pattern tags from classify_miss that route to record_accepted (vs record_miss).
 ACCEPTED_PATTERNS: frozenset[str] = frozenset({
+    "builtin_function_call",
     "builtin_method_call", "pathlib_method_call", "futures_method_call",
     "pydantic_method_call", "pil_method_call", "wave_method_call",
     "loguru_method_call", "re_method_call", "datetime_method_call",
@@ -359,6 +368,8 @@ def classify_miss(
     if isinstance(func, ast.Name):
         if func.id in {"exec", "eval", "compile"}:
             return "exec_or_eval"
+        if func.id in BUILTIN_FUNCTION_NAMES:
+            return "builtin_function_call"
         return "bare_name_unresolved"
 
     if isinstance(func, ast.Call):

--- a/tests/test_analyzer_classifier.py
+++ b/tests/test_analyzer_classifier.py
@@ -81,23 +81,13 @@ def test_compile_stays_exec_or_eval() -> None:
     assert _classify_miss(call) == "exec_or_eval"
 
 
-def test_super_bare_stays_super_unresolved() -> None:
-    """super() as a bare call is ast.Call(func=ast.Name('super')) — classified
-    separately before reaching classify_miss in normal flow, but classify_miss
-    must still return super_unresolved when it receives a node like super()()."""
-    # super() wrapped in another call — the inner super() is the ast.Call.func
-    src = "super()()"
-    tree = ast.parse(src)
-    call_node = None
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "super":
-            call_node = node
-            break
-    assert call_node is not None
-    # classify_miss is called on nodes the visitor failed to resolve; super()
-    # as a bare call (ast.Name 'super') should NOT become builtin_function_call
-    # because 'super' is excluded from BUILTIN_FUNCTION_NAMES.
-    assert "super" not in BUILTIN_FUNCTION_NAMES
+def test_super_bare_stays_bare_name_unresolved() -> None:
+    """super() as a bare Name call is excluded from BUILTIN_FUNCTION_NAMES,
+    so classify_miss falls through to bare_name_unresolved (not builtin_function_call).
+    The visitor resolves super() chains before classify_miss is called; this
+    tests the classifier's own behavior when it receives an unresolved super() node."""
+    call = _parse_call("super()")
+    assert _classify_miss(call) == "bare_name_unresolved"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_analyzer_classifier.py
+++ b/tests/test_analyzer_classifier.py
@@ -1,0 +1,135 @@
+"""Classifier tests for builtin_function_call tag (PR 1).
+
+Verifies that Python builtins are accepted without inflating the actionable
+miss counts, while preserving existing dedicated tags (exec_or_eval,
+super_unresolved) and the false-positive guard (non-builtin bare names stay
+bare_name_unresolved).
+"""
+
+from __future__ import annotations
+
+import ast
+
+from pyscope_mcp.analyzer import _classify_miss
+from pyscope_mcp.analyzer.misses import ACCEPTED_PATTERNS, BUILTIN_FUNCTION_NAMES
+
+
+def _parse_call(src: str) -> ast.Call:
+    tree = ast.parse(src)
+    expr = tree.body[0]
+    assert isinstance(expr, ast.Expr)
+    call = expr.value
+    assert isinstance(call, ast.Call)
+    return call
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — common builtins must return builtin_function_call
+# ---------------------------------------------------------------------------
+
+def test_len_is_builtin_function_call() -> None:
+    call = _parse_call("len(x)")
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+def test_str_is_builtin_function_call() -> None:
+    call = _parse_call("str(x)")
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+def test_isinstance_is_builtin_function_call() -> None:
+    call = _parse_call("isinstance(x, int)")
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+def test_RuntimeError_is_builtin_function_call() -> None:
+    call = _parse_call('RuntimeError("m")')
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+def test_list_is_builtin_function_call() -> None:
+    call = _parse_call("list(iterable)")
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+def test_dict_is_builtin_function_call() -> None:
+    call = _parse_call("dict(a=1)")
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+def test_int_is_builtin_function_call() -> None:
+    call = _parse_call("int(s)")
+    assert _classify_miss(call) == "builtin_function_call"
+
+
+# ---------------------------------------------------------------------------
+# Preserved dedicated tags — must NOT be rerouted to builtin_function_call
+# ---------------------------------------------------------------------------
+
+def test_exec_stays_exec_or_eval() -> None:
+    call = _parse_call("exec(code)")
+    assert _classify_miss(call) == "exec_or_eval"
+
+
+def test_eval_stays_exec_or_eval() -> None:
+    call = _parse_call("eval(expr)")
+    assert _classify_miss(call) == "exec_or_eval"
+
+
+def test_compile_stays_exec_or_eval() -> None:
+    call = _parse_call("compile(src, '<string>', 'exec')")
+    assert _classify_miss(call) == "exec_or_eval"
+
+
+def test_super_bare_stays_super_unresolved() -> None:
+    """super() as a bare call is ast.Call(func=ast.Name('super')) — classified
+    separately before reaching classify_miss in normal flow, but classify_miss
+    must still return super_unresolved when it receives a node like super()()."""
+    # super() wrapped in another call — the inner super() is the ast.Call.func
+    src = "super()()"
+    tree = ast.parse(src)
+    call_node = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "super":
+            call_node = node
+            break
+    assert call_node is not None
+    # classify_miss is called on nodes the visitor failed to resolve; super()
+    # as a bare call (ast.Name 'super') should NOT become builtin_function_call
+    # because 'super' is excluded from BUILTIN_FUNCTION_NAMES.
+    assert "super" not in BUILTIN_FUNCTION_NAMES
+
+
+# ---------------------------------------------------------------------------
+# False-positive guard — non-builtin bare names must stay bare_name_unresolved
+# ---------------------------------------------------------------------------
+
+def test_non_builtin_stays_bare_name_unresolved() -> None:
+    """parse_json(x) is not a builtin — must NOT become builtin_function_call."""
+    call = _parse_call("parse_json(x)")
+    assert _classify_miss(call) == "bare_name_unresolved"
+
+
+def test_call_llm_stays_bare_name_unresolved() -> None:
+    call = _parse_call("call_llm(prompt)")
+    assert _classify_miss(call) == "bare_name_unresolved"
+
+
+def test_write_json_stays_bare_name_unresolved() -> None:
+    call = _parse_call("write_json(path, data)")
+    assert _classify_miss(call) == "bare_name_unresolved"
+
+
+# ---------------------------------------------------------------------------
+# ACCEPTED_PATTERNS linkage
+# ---------------------------------------------------------------------------
+
+def test_builtin_function_call_is_accepted() -> None:
+    assert "builtin_function_call" in ACCEPTED_PATTERNS
+
+
+def test_builtin_function_names_excludes_exec_eval_compile_super_getattr() -> None:
+    excluded = {"exec", "eval", "compile", "super", "getattr"}
+    assert not (excluded & BUILTIN_FUNCTION_NAMES), (
+        f"These names should be excluded: {excluded & BUILTIN_FUNCTION_NAMES}"
+    )


### PR DESCRIPTION
## Summary

- Adds `BUILTIN_FUNCTION_NAMES` frozenset in `analyzer/misses.py`: all non-private builtins minus `exec`/`eval`/`compile`/`super`/`getattr` (which retain their existing dedicated tags).
- `classify_miss` `ast.Name` branch: if `func.id in BUILTIN_FUNCTION_NAMES`, return `"builtin_function_call"`.
- Adds `"builtin_function_call"` to `ACCEPTED_PATTERNS`.
- 16 new tests in `tests/test_analyzer_classifier.py` including mandatory false-positive guard (`parse_json(x)` stays `bare_name_unresolved`).

## Real-repo delta (video_agent_long)

| metric | before | after | delta |
|---|---|---|---|
| `bare_name_unresolved` | 3572 | 282 | -3290 |
| `accepted_counts.builtin_function_call` | — | 3290 | +3290 (new) |
| `unresolved_rate` | 0.2831 | 0.0619 | -0.2212 |
| `effective_resolution` | 0.569 | 0.858 | +0.289 |
| `dead_keys` | no change | — | 0 |

No regressions in any other pattern bucket. Full 232-test suite passes.

## Test plan
- [x] `len(x)` / `str(x)` / `isinstance(x, int)` / `RuntimeError("m")` → `builtin_function_call`
- [x] `exec(code)` → still `exec_or_eval`
- [x] `super` excluded from `BUILTIN_FUNCTION_NAMES`
- [x] `parse_json(x)` (non-builtin) → still `bare_name_unresolved` (false-positive guard)
- [x] `"builtin_function_call"` in `ACCEPTED_PATTERNS`
- [x] Full 232-test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)