### PR TITLE
fix: add missing local-var sentinel visitor wiring

### DIFF
--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -288,6 +288,29 @@ class EdgeVisitor(ast.NodeVisitor):
             return accepted_tag
         return None
 
+    def _try_accept_local_var_sentinel(self, node: ast.Call) -> str | None:
+        """For ``var.<method>(...)`` calls where ``var`` is a local variable typed
+        as a sentinel (builtin or pathlib.Path), return the accepted-pattern tag if
+        the method is in the corresponding whitelist; otherwise return None.
+        """
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return None
+        chain = attr_chain(func)
+        if chain is None or len(chain) != 2 or chain[0] == "self":
+            return None
+        var_name, method = chain[0], chain[1]
+        func_fqn = self._current_func_fqn()
+        if func_fqn is None:
+            return None
+        var_class = self._ctx.local_types.get(func_fqn, {}).get(var_name)
+        if var_class is None or var_class not in _SENTINEL_ACCEPTED:
+            return None
+        accepted_tag, valid_methods = _SENTINEL_ACCEPTED[var_class]
+        if method in valid_methods:
+            return accepted_tag
+        return None
+
     def _try_emit_dispatcher_edge(self, call: ast.Call) -> bool:
         """If `call` looks like `dispatcher(fn, ...)` where fn is an in-package
         callable reference, emit an extra edge to fn. Returns True iff we emitted.
@@ -336,10 +359,12 @@ class EdgeVisitor(ast.NodeVisitor):
                 if ext is not None:
                     self._miss_log.record_resolved(in_package=False)
                 else:
-                    # Check if this is a self-attr sentinel call before falling
-                    # through to classify_miss (which would tag it as
-                    # self_method_unresolved).
-                    sentinel_tag = self._try_accept_self_attr_sentinel(node)
+                    # Check self-attr and local-var sentinel calls before falling
+                    # through to classify_miss.
+                    sentinel_tag = (
+                        self._try_accept_self_attr_sentinel(node)
+                        or self._try_accept_local_var_sentinel(node)
+                    )
                     if sentinel_tag is not None:
                         self._miss_log.record_accepted(sentinel_tag, self._file_path)
                     else:


### PR DESCRIPTION
## Summary

PR #15 added sentinel inference to `collect_local_var_types` (`discovery.py`) but the visitor-side `_try_accept_local_var_sentinel` helper was dropped during the rebase and not caught before merge.

**Impact without this fix:** local-var sentinel types (`builtins.dict`, `builtins.list`, `pathlib.Path`, etc.) are recorded in `local_types` but `var.get()` / `var.mkdir()` calls still fall through to `classify_miss`. In practice those calls are still accepted via the method-name heuristics in `classify_miss`, so there is no regression in counts — but the sentinel intercept path (which is more precise) is not firing.

## Change

- Adds `_try_accept_local_var_sentinel` to `EdgeVisitor` (mirrors `_try_accept_self_attr_sentinel` from PR #13).
- Wires it into `visit_Call` alongside the self-attr helper.

## Test

260 tests pass (all existing, including `test_analyzer_local_var_builtin.py` which covers the local-var sentinel path end-to-end).