### PR TITLE
consolidate: fix dead SENTINEL_BUILTIN_TYPES constant and remove property from PATHLIB_METHODS

### DIFF
--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -56,7 +56,7 @@ BUILTIN_COLLECTION_METHODS: frozenset[str] = frozenset({
 PATHLIB_METHODS: frozenset[str] = frozenset({
     "exists", "mkdir", "read_text", "read_bytes", "write_text", "write_bytes",
     "stat", "relative_to", "glob", "iterdir", "resolve", "unlink",
-    "is_file", "is_dir", "parent", "with_suffix", "joinpath",
+    "is_file", "is_dir", "with_suffix", "joinpath",
     # additional pathlib.Path methods
     "with_name", "with_stem", "rename", "absolute", "touch", "rmdir", "chmod",
     "is_absolute", "is_relative_to", "samefile", "expanduser", "home", "cwd",

--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 
+from .discovery import SENTINEL_BUILTIN_TYPES
 from .misses import (
     ACCEPTED_PATTERNS,
     BUILTIN_COLLECTION_METHODS,
@@ -24,6 +25,7 @@ from .resolution import (
 )
 
 # Map sentinel FQN → accepted pattern tag + valid method set.
+# Keys must exactly match SENTINEL_BUILTIN_TYPES in discovery.py (single source of truth).
 _SENTINEL_ACCEPTED: dict[str, tuple[str, frozenset[str]]] = {
     "builtins.dict": ("builtin_method_call", BUILTIN_COLLECTION_METHODS),
     "builtins.list": ("builtin_method_call", BUILTIN_COLLECTION_METHODS),
@@ -31,6 +33,10 @@ _SENTINEL_ACCEPTED: dict[str, tuple[str, frozenset[str]]] = {
     "builtins.tuple": ("builtin_method_call", BUILTIN_COLLECTION_METHODS),
     "pathlib.Path": ("pathlib_method_call", PATHLIB_METHODS),
 }
+
+assert set(_SENTINEL_ACCEPTED) == SENTINEL_BUILTIN_TYPES, (
+    "visitor._SENTINEL_ACCEPTED keys diverged from discovery.SENTINEL_BUILTIN_TYPES"
+)
 
 
 class EdgeVisitor(ast.NodeVisitor):


### PR DESCRIPTION
## Summary

Addresses findings from post-series consolidation review of PRs #11, #12, #13, #15, #16.

**F1 (BLOCKER-level FIX) — Dead constant `SENTINEL_BUILTIN_TYPES` in `discovery.py`**

`SENTINEL_BUILTIN_TYPES` was defined in `discovery.py` but never imported anywhere. The visitor had its own independent `_SENTINEL_ACCEPTED` dict covering the same five sentinel FQNs. A future maintainer could have relied on `SENTINEL_BUILTIN_TYPES` as canonical while `_SENTINEL_ACCEPTED` drifted silently.

Fix: import `SENTINEL_BUILTIN_TYPES` from `discovery.py` into `visitor.py` and add a module-level `assert` that `_SENTINEL_ACCEPTED` keys exactly match — `discovery.py` is now the single source of truth, and any key drift will be caught at import time.

**N1 (NIT, folded in) — `"parent"` in `PATHLIB_METHODS` is a property, not a method**

`pathlib.Path.parent` is a property. Its presence in `PATHLIB_METHODS` has zero runtime impact (the visitor only visits `ast.Call` nodes; `p.parent` without parens is never a `Call`), but the set should list only callable names. Removed.

## Verification

- 260 tests pass (no change from baseline)
- Real-repo build (`video_agent_long`): unresolved_rate=0.0611, bare_name_unresolved=282, self_method_unresolved=141 — identical to pre-PR numbers, no regression

## Findings addressed

- F1: `SENTINEL_BUILTIN_TYPES` dead constant → fixed (single source of truth via import + assert)
- N1: `"parent"` property in `PATHLIB_METHODS` → removed (folded in as trivial)
- N2: `stdlib_method_call` absent from video_agent_long accepted_counts → SKIP (correct behavior, no aliased-stdlib calls in that repo)