### PR TITLE
Handler: resolve PEP 604 unions and Optional[X] in annotations (#20)

### DIFF
--- a/src/pyscope_mcp/analyzer/discovery.py
+++ b/src/pyscope_mcp/analyzer/discovery.py
@@ -399,14 +399,132 @@ def collect_local_var_types(
     return result
 
 
+def _is_none_literal(node: ast.expr) -> bool:
+    """Return True if node is the literal ``None`` (ast.Constant(value=None))."""
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _resolve_union_lhs(
+    value: ast.expr,
+    import_table: dict[str, str],
+) -> str | None:
+    """Resolve the LHS of a Subscript to a normalised typing FQN.
+
+    Returns one of ``"typing.Optional"``, ``"typing.Union"``, or ``None``.
+    We accept both bare names (``Optional``, ``Union``) and qualified forms
+    (``typing.Optional``, ``t.Union``) by checking the import table.
+    """
+    # Bare name: Optional[X] or Union[X, Y]
+    if isinstance(value, ast.Name):
+        name = value.id
+        if name in ("Optional", "Union"):
+            # Check import_table to see if it really maps to typing.*
+            target = import_table.get(name)
+            if target in ("typing.Optional", "typing.Union"):
+                return target
+            # Bare name with no confirmed import mapping.  In practice, bare
+            # `Optional` and `Union` nearly always come from `from typing import
+            # Optional/Union` — accept them.  A user-defined class named
+            # Optional/Union subscripted in an annotation is pathological and
+            # not guarded here.
+            if name == "Optional":
+                return "typing.Optional"
+            if name == "Union":
+                return "typing.Union"
+        return None
+
+    # Qualified form: typing.Optional[X], t.Union[X, Y]
+    chain = attr_chain(value)
+    if chain is None:
+        return None
+    for prefix_len in range(len(chain) - 1, 0, -1):
+        prefix = ".".join(chain[:prefix_len])
+        target = import_table.get(prefix)
+        if target is not None:
+            remainder = chain[prefix_len:]
+            resolved = ".".join([target] + remainder)
+            if resolved in ("typing.Optional", "typing.Union"):
+                return resolved
+    # Fully qualified without import alias: e.g. typing.Optional without import
+    dotted = ".".join(chain)
+    if dotted in ("typing.Optional", "typing.Union"):
+        return dotted
+    return None
+
+
 def _resolve_annotation_to_class(
     annotation: ast.expr | str,
     module_fqn: str,
     import_table: dict[str, str],
     known_classes: set[str],
 ) -> str | None:
-    """Resolve a type annotation (or forward-ref string) to an in-package class FQN."""
-    # Handle forward-reference string annotations e.g. "ClassName" or "mod.ClassName"
+    """Resolve a type annotation (or forward-ref string) to an in-package class FQN.
+
+    Handles:
+    - ``ast.Name`` / ``ast.Attribute`` / dotted chains — simple name lookup.
+    - ``ast.Constant(str)`` — forward-reference string annotations.
+    - ``ast.BinOp(op=BitOr)`` — PEP 604 union (``X | None``, ``X | Y``).
+    - ``ast.Subscript`` with typing.Optional or typing.Union LHS.
+
+    False-positive guards: ``list[X]``, ``dict[K, V]``, ``Callable[...]``,
+    ``Annotated[X, ...]`` all return ``None`` — only Union-shaped subscripts
+    are peeled.
+    """
+    # ------------------------------------------------------------------ #
+    # PEP 604 union: X | Y  (left-associative; None literals are skipped) #
+    # ------------------------------------------------------------------ #
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        # Filter None on either side immediately.
+        if not _is_none_literal(annotation.left):
+            result = _resolve_annotation_to_class(
+                annotation.left, module_fqn, import_table, known_classes
+            )
+            if result is not None:
+                return result
+        if not _is_none_literal(annotation.right):
+            result = _resolve_annotation_to_class(
+                annotation.right, module_fqn, import_table, known_classes
+            )
+            if result is not None:
+                return result
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Subscript: Optional[X] or Union[X, Y, ...]                         #
+    # Guard: only peel recognised typing forms; list[X], Callable, etc.  #
+    # must NOT be treated as unions.                                      #
+    # ------------------------------------------------------------------ #
+    if isinstance(annotation, ast.Subscript):
+        typing_form = _resolve_union_lhs(annotation.value, import_table)
+        if typing_form == "typing.Optional":
+            # Optional[X] → recurse on slice.
+            return _resolve_annotation_to_class(
+                annotation.slice, module_fqn, import_table, known_classes
+            )
+        if typing_form == "typing.Union":
+            # Union[X, Y, ...] → try each elt in order, first in-package wins.
+            slc = annotation.slice
+            elts: list[ast.expr]
+            if isinstance(slc, ast.Tuple):
+                elts = slc.elts
+            else:
+                # Union[X] (degenerate but legal) — treat slice as single elt.
+                elts = [slc]
+            for elt in elts:
+                if _is_none_literal(elt):
+                    continue
+                result = _resolve_annotation_to_class(
+                    elt, module_fqn, import_table, known_classes
+                )
+                if result is not None:
+                    return result
+            return None
+        # Not a recognised union form — return None (guards list[X], Callable, etc.)
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Forward-reference string annotation e.g. "ClassName" or "mod.C"   #
+    # ------------------------------------------------------------------ #
     if isinstance(annotation, ast.Constant) and isinstance(annotation.value, str):
         raw = annotation.value.strip()
         # Try as a simple name first
@@ -434,6 +552,9 @@ def _resolve_annotation_to_class(
             return dotted
         return None
 
+    # ------------------------------------------------------------------ #
+    # Bare name                                                           #
+    # ------------------------------------------------------------------ #
     if isinstance(annotation, ast.Name):
         name = annotation.id
         if name in import_table:
@@ -445,6 +566,9 @@ def _resolve_annotation_to_class(
             return candidate
         return None
 
+    # ------------------------------------------------------------------ #
+    # Attribute chain: mod.ClassName, pkg.sub.ClassName                  #
+    # ------------------------------------------------------------------ #
     chain = attr_chain(annotation)
     if chain is None:
         return None

--- a/tests/test_analyzer_union_annotation.py
+++ b/tests/test_analyzer_union_annotation.py
@@ -1,0 +1,372 @@
+"""Tests for union-annotation resolution in _resolve_annotation_to_class.
+
+Covers:
+- PEP 604 unions: X | None, None | X, X | Y (both in-package: first-wins)
+- Optional[X], Union[X, None], Union[X, Y, None]
+- Qualified forms: typing.Optional[X], typing.Union[X, Y], alias forms
+- Nested: X | Y | None (left-associative BinOp)
+- False-positive guards: list[X], Callable[[X], Y], Optional[ExternalType],
+  X | int (only one in-package), X | Y both in-package (first-wins)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyscope_mcp.analyzer import build_raw
+
+
+def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:
+    """Create a minimal package tree for testing."""
+    pkg = tmp_path / pkg_name
+    pkg.mkdir()
+    if "__init__.py" not in files:
+        (pkg / "__init__.py").write_text("")
+    for rel, content in files.items():
+        target = pkg / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# PEP 604: X | None
+# ---------------------------------------------------------------------------
+
+def test_binop_union_x_or_none_resolves_x(tmp_path: Path) -> None:
+    """Parameter annotation `agent: MyAgent | None` should resolve to MyAgent."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: MyAgent | None = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_binop_union_none_or_x_resolves_x(tmp_path: Path) -> None:
+    """Reversed form `None | MyAgent` should also resolve to MyAgent."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: None | MyAgent = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_binop_union_x_or_int_resolves_in_package_only(tmp_path: Path) -> None:
+    """X | int — int is not in-package, so MyAgent is picked."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: MyAgent | int = None) -> None:\n"
+            "    agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_binop_union_both_in_package_first_wins(tmp_path: Path) -> None:
+    """X | Y where both are in-package — first (left) should win."""
+    root = _make_package(tmp_path, "pkg", {
+        "agents.py": (
+            "class AgentA:\n"
+            "    def run(self): pass\n"
+            "\n"
+            "class AgentB:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agents import AgentA, AgentB\n"
+            "\n"
+            "def dispatch(agent: AgentA | AgentB) -> None:\n"
+            "    agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.caller.dispatch", [])
+    # First-wins: AgentA.run should be present
+    assert "pkg.agents.AgentA.run" in callees
+    # AgentB.run should NOT also be added (first-wins, not both)
+    assert "pkg.agents.AgentB.run" not in callees
+
+
+def test_binop_nested_union_x_or_y_or_none(tmp_path: Path) -> None:
+    """X | Y | None is left-associative: (X | Y) | None.  First in-package wins."""
+    root = _make_package(tmp_path, "pkg", {
+        "agents.py": (
+            "class AgentA:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agents import AgentA\n"
+            "\n"
+            "def dispatch(agent: AgentA | int | None) -> None:\n"
+            "    agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agents.AgentA.run" in raw.get("pkg.caller.dispatch", [])
+
+
+# ---------------------------------------------------------------------------
+# Optional[X]  (bare name)
+# ---------------------------------------------------------------------------
+
+def test_optional_bare_name(tmp_path: Path) -> None:
+    """Optional[MyAgent] with `from typing import Optional`."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from typing import Optional\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: Optional[MyAgent] = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_optional_external_type_returns_none(tmp_path: Path) -> None:
+    """Optional[ExternalLib] should not resolve (external type not in-package)."""
+    root = _make_package(tmp_path, "pkg", {
+        "caller.py": (
+            "from typing import Optional\n"
+            "\n"
+            # httpx.Client is not an in-package class, so no resolution
+            "def export(client: Optional[int] = None) -> None:\n"
+            "    pass\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    # No in-package method calls — just ensure no crash and no spurious edges
+    callees = raw.get("pkg.caller.export", [])
+    assert callees == [] or all("pkg." in c for c in callees)
+
+
+# ---------------------------------------------------------------------------
+# Union[X, None]
+# ---------------------------------------------------------------------------
+
+def test_union_x_none(tmp_path: Path) -> None:
+    """Union[MyAgent, None] with `from typing import Union`."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from typing import Union\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: Union[MyAgent, None] = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_union_x_y_none(tmp_path: Path) -> None:
+    """Union[AgentA, AgentB, None] — first in-package wins."""
+    root = _make_package(tmp_path, "pkg", {
+        "agents.py": (
+            "class AgentA:\n"
+            "    def run(self): pass\n"
+            "\n"
+            "class AgentB:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from typing import Union\n"
+            "from pkg.agents import AgentA, AgentB\n"
+            "\n"
+            "def export(agent: Union[AgentA, AgentB, None] = None) -> None:\n"
+            "    agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.caller.export", [])
+    # First-wins: AgentA
+    assert "pkg.agents.AgentA.run" in callees
+    assert "pkg.agents.AgentB.run" not in callees
+
+
+# ---------------------------------------------------------------------------
+# Qualified forms: typing.Optional[X], typing.Union[X, Y]
+# ---------------------------------------------------------------------------
+
+def test_typing_optional_qualified(tmp_path: Path) -> None:
+    """typing.Optional[MyAgent] without explicit `from typing import Optional`."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "import typing\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: typing.Optional[MyAgent] = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_typing_union_qualified(tmp_path: Path) -> None:
+    """typing.Union[MyAgent, None] without explicit `from typing import Union`."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "import typing\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: typing.Union[MyAgent, None] = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_typing_alias_optional(tmp_path: Path) -> None:
+    """import typing as t; t.Optional[MyAgent] — alias form."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "import typing as t\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: t.Optional[MyAgent] = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+def test_typing_alias_union(tmp_path: Path) -> None:
+    """import typing as t; t.Union[MyAgent, None] — alias form."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "import typing as t\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export(agent: t.Union[MyAgent, None] = None) -> None:\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards
+# ---------------------------------------------------------------------------
+
+def test_list_subscript_not_treated_as_union(tmp_path: Path) -> None:
+    """list[MyAgent] must NOT resolve to MyAgent — not a union form."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def process(agents: list[MyAgent]) -> None:\n"
+            "    # iterating, not calling agent.run() directly via annotation\n"
+            "    pass\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    # The parameter annotation should NOT resolve to MyAgent via the list subscript
+    # (verify by checking there's no erroneous direct method call)
+    callees = raw.get("pkg.caller.process", [])
+    assert "pkg.agent.MyAgent.run" not in callees
+
+
+def test_callable_subscript_not_treated_as_union(tmp_path: Path) -> None:
+    """Callable[[MyAgent], None] must NOT resolve to MyAgent."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from typing import Callable\n"
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def process(fn: Callable[[MyAgent], None]) -> None:\n"
+            "    pass\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.caller.process", [])
+    assert "pkg.agent.MyAgent.run" not in callees
+
+
+def test_annotated_assignment_with_union(tmp_path: Path) -> None:
+    """x: MyAgent | None = ... inside a function body resolves via annotation."""
+    root = _make_package(tmp_path, "pkg", {
+        "agent.py": (
+            "class MyAgent:\n"
+            "    def run(self): pass\n"
+        ),
+        "caller.py": (
+            "from pkg.agent import MyAgent\n"
+            "\n"
+            "def export() -> None:\n"
+            "    agent: MyAgent | None = None\n"
+            "    if agent is not None:\n"
+            "        agent.run()\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.agent.MyAgent.run" in raw.get("pkg.caller.export", [])


### PR DESCRIPTION
## Summary

- Extends `_resolve_annotation_to_class` in `analyzer/discovery.py` with three new recursive cases: `ast.BinOp(op=BitOr)` (PEP 604 `X | None`), `ast.Subscript` with `Optional` LHS, and `ast.Subscript` with `Union` LHS.
- Adds `_is_none_literal` and `_resolve_union_lhs` as module-private helpers (no new public API, no new `ResolveCtx` fields).
- Wires automatically through existing `collect_local_var_types` (parameter annotations + annotated assignments) — no changes to `visitor.py` required.

## Real-repo delta on `video_agent_long`

| Metric | Before | After | Delta |
|---|---|---|---|
| in-package edges | 2347 | 2348 | +1 |
| unresolved calls | 909 | 908 | -1 |
| `attr_chain_unresolved` | 477 | 476 | -1 |
| dead-key recovery | — | — | 1 recovered |

**Motivating exemplar resolved:** `video_agent_long.agents.performance_editor_agent.export_performance_md` → `agent.compute_style_summary_from_script(script)` (parameter annotation `agent: PerformanceEditorAgent | None`).

The second miss in that function (`_tmp_agent.compute_style_summary_from_script`) uses `PerformanceEditorAgent.__new__(...)` — bucket C in #18, separate issue.

## Acceptance checklist

- [x] `X | None` resolves to X
- [x] `None | X` resolves to X
- [x] `Optional[X]` (bare name) resolves to X
- [x] `Union[X, None]` resolves to X
- [x] `typing.Optional[X]` (qualified) resolves to X
- [x] `typing.Union[X, Y]` (qualified) resolves to X
- [x] `t.Optional[X]` / `t.Union[X, Y]` (alias import) resolve correctly
- [x] Nested `X | Y | None` (left-associative): first in-package wins
- [x] `X | Y` both in-package: first-wins documented and tested
- [x] FP guard: `list[X]` → None
- [x] FP guard: `Callable[[X], Y]` → None
- [x] FP guard: `Optional[ExternalType]` → None
- [x] FP guard: `X | int` (one external) → picks X only
- [x] 276 tests pass (260 pre-existing + 16 new), 0 regressions

## Reviewer findings (self-review)

1. **Bare-name false-positive risk**: `_resolve_union_lhs` accepts bare `Optional`/`Union` names without an import-table hit as a fallback. Comment updated to clarify this is intentional — a user-defined class named `Optional` subscripted in an annotation is pathological and not worth guarding.
2. **`collect_self_attr_types` gap**: That path uses `_resolve_annotation` (a separate, older function) and does not benefit from union resolution. This is in-scope of the issue's "out of scope" list — no change needed.

No disagreements with the acceptance criteria.

Closes #20
Parent: #18