### PR TITLE
Handler: external-factory local-var accept (#19)

### DIFF
--- a/src/pyscope_mcp/analyzer/discovery.py
+++ b/src/pyscope_mcp/analyzer/discovery.py
@@ -366,6 +366,223 @@ def _infer_type(
     return None
 
 
+def collect_external_local_var_types(
+    tree: ast.AST,
+    module_fqn: str,
+    import_table: dict[str, str],
+    external_factories: dict[str, str],
+) -> dict[str, dict[str, str]]:
+    """Map ``{func_fqn: {var_name: external_factory_fqn}}`` for locals bound
+    from a whitelisted external factory call.
+
+    Mirrors ``collect_local_var_types`` but targets external FQNs (not
+    in-package classes).  Only records bindings where the resolved factory
+    FQN appears in ``external_factories`` (the whitelist).
+
+    Also handles second-order (chained) bindings: if the RHS is a method
+    call on an already-typed external local (e.g. ``paginator =
+    client.get_paginator(...)``) and that ``(factory_fqn, method)`` pair
+    maps to a known return type in ``EXTERNAL_RETURNS``, the result type
+    is recorded too.
+
+    Scope/last-write-wins rules are identical to ``collect_local_var_types``.
+    """
+    from .resolution import EXTERNAL_RETURNS  # avoid circular at module level
+    result: dict[str, dict[str, str]] = {}
+    # Collect module-level external factory bindings (e.g. `_cli = typer.Typer()` at top level).
+    # These are keyed under the module_fqn so the visitor can find them when
+    # a function-level lookup misses.
+    module_vars: dict[str, str] = {}
+    if isinstance(tree, ast.Module):
+        _walk_body_for_external_bindings(
+            tree.body, module_fqn, import_table, external_factories,
+            EXTERNAL_RETURNS, module_vars,
+        )
+        if module_vars:
+            result[module_fqn] = module_vars
+    _collect_func_external_types(
+        tree, module_fqn, module_fqn, import_table, external_factories, result
+    )
+    return result
+
+
+def _resolve_external_factory(
+    rhs: ast.expr,
+    import_table: dict[str, str],
+    external_factories: dict[str, str],
+) -> str | None:
+    """If ``rhs`` is a call to a whitelisted external factory, return the factory FQN."""
+    if not isinstance(rhs, ast.Call):
+        return None
+    func = rhs.func
+    if isinstance(func, ast.Name):
+        name = func.id
+        if name in import_table:
+            fqn = import_table[name]
+            if fqn in external_factories:
+                return external_factories[fqn]
+        return None
+    chain = attr_chain(func)
+    if chain is not None:
+        for prefix_len in range(len(chain) - 1, 0, -1):
+            prefix = ".".join(chain[:prefix_len])
+            if prefix in import_table:
+                base_fqn = import_table[prefix]
+                remainder = chain[prefix_len:]
+                candidate = ".".join([base_fqn] + remainder)
+                if candidate in external_factories:
+                    return external_factories[candidate]
+        dotted = ".".join(chain)
+        if dotted in external_factories:
+            return external_factories[dotted]
+    return None
+
+
+def _resolve_chained_external_factory(
+    rhs: ast.expr,
+    partial_vars: dict[str, str],
+    external_returns: dict[tuple[str, str], str],
+) -> str | None:
+    """If ``rhs`` is ``var.method(...)`` and ``var`` is already a typed external
+    local, look up ``(factory_fqn, method)`` in ``external_returns``.
+    """
+    if not isinstance(rhs, ast.Call):
+        return None
+    func = rhs.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if not isinstance(func.value, ast.Name):
+        return None
+    var_name = func.value.id
+    method = func.attr
+    factory_fqn = partial_vars.get(var_name)
+    if factory_fqn is None:
+        return None
+    return external_returns.get((factory_fqn, method))
+
+
+def _collect_func_external_types(
+    node: ast.AST,
+    module_fqn: str,
+    func_fqn: str,
+    import_table: dict[str, str],
+    external_factories: dict[str, str],
+    result: dict[str, dict[str, str]],
+) -> None:
+    """Recursively collect external factory var types for each function scope."""
+    from .resolution import EXTERNAL_RETURNS
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.ClassDef):
+            class_fqn = (
+                f"{func_fqn}.{child.name}"
+                if func_fqn != module_fqn
+                else f"{module_fqn}.{child.name}"
+            )
+            _collect_func_external_types(
+                child, module_fqn, class_fqn, import_table, external_factories, result
+            )
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            child_fqn = f"{func_fqn}.{child.name}"
+            _scan_function_external_bindings(
+                child, module_fqn, child_fqn, import_table, external_factories,
+                EXTERNAL_RETURNS, result
+            )
+
+
+def _scan_function_external_bindings(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    module_fqn: str,
+    func_fqn: str,
+    import_table: dict[str, str],
+    external_factories: dict[str, str],
+    external_returns: dict[tuple[str, str], str],
+    result: dict[str, dict[str, str]],
+) -> None:
+    """Scan a single function body for external-factory bindings (non-recursive)."""
+    var_types: dict[str, str] = {}
+    _walk_body_for_external_bindings(
+        func_node.body, module_fqn, import_table, external_factories,
+        external_returns, var_types,
+    )
+    if var_types:
+        result[func_fqn] = var_types
+
+    # Recurse into nested functions.
+    for nested in _iter_direct_nested_funcs(func_node.body):
+        nested_fqn = f"{func_fqn}.{nested.name}"
+        _scan_function_external_bindings(
+            nested, module_fqn, nested_fqn, import_table, external_factories,
+            external_returns, result
+        )
+
+
+def _walk_body_for_external_bindings(
+    stmts: list[ast.stmt],
+    module_fqn: str,
+    import_table: dict[str, str],
+    external_factories: dict[str, str],
+    external_returns: dict[tuple[str, str], str],
+    var_types: dict[str, str],
+) -> None:
+    """Walk a statement list collecting external-factory Assign bindings."""
+    for stmt in stmts:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+
+        if isinstance(stmt, ast.Assign):
+            if len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+                var_name = stmt.targets[0].id
+                # Direct factory call
+                resolved = _resolve_external_factory(
+                    stmt.value, import_table, external_factories
+                )
+                if resolved is None:
+                    # Chained: var.method(...) where var is already typed
+                    resolved = _resolve_chained_external_factory(
+                        stmt.value, var_types, external_returns
+                    )
+                # last-write-wins: always overwrite
+                if resolved is not None:
+                    var_types[var_name] = resolved
+                elif var_name in var_types:
+                    # var was rebound to something non-factory → shadow, remove
+                    del var_types[var_name]
+
+        elif isinstance(stmt, ast.For):
+            _walk_body_for_external_bindings(
+                stmt.body + stmt.orelse, module_fqn, import_table,
+                external_factories, external_returns, var_types,
+            )
+        elif isinstance(stmt, ast.While):
+            _walk_body_for_external_bindings(
+                stmt.body + stmt.orelse, module_fqn, import_table,
+                external_factories, external_returns, var_types,
+            )
+        elif isinstance(stmt, ast.If):
+            _walk_body_for_external_bindings(
+                stmt.body + stmt.orelse, module_fqn, import_table,
+                external_factories, external_returns, var_types,
+            )
+        elif isinstance(stmt, ast.With):
+            _walk_body_for_external_bindings(
+                stmt.body, module_fqn, import_table,
+                external_factories, external_returns, var_types,
+            )
+        elif isinstance(stmt, ast.AsyncWith):
+            _walk_body_for_external_bindings(
+                stmt.body, module_fqn, import_table,
+                external_factories, external_returns, var_types,
+            )
+        elif isinstance(stmt, ast.Try):
+            all_stmts = stmt.body + stmt.orelse + stmt.finalbody
+            for handler in stmt.handlers:
+                all_stmts += handler.body
+            _walk_body_for_external_bindings(
+                all_stmts, module_fqn, import_table,
+                external_factories, external_returns, var_types,
+            )
+
+
 def collect_local_var_types(
     tree: ast.AST,
     module_fqn: str,

--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -211,6 +211,8 @@ ACCEPTED_PATTERNS: frozenset[str] = frozenset({
     # M8 additions
     "io_method_call", "hashlib_method_call", "random_method_call",
     "argparse_method_call", "anthropic_method_call", "requests_method_call",
+    # Handler #19: external-factory local-var accept buckets
+    "httpx_method_call", "boto3_method_call", "typer_method_call", "googleapi_method_call",
 })
 
 

--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -10,12 +10,14 @@ from .discovery import (
     collect_class_bases,
     collect_classes,
     collect_defs,
+    collect_external_local_var_types,
     collect_local_var_types,
     collect_self_attr_types,
     discover_modules,
 )
 from .imports import build_import_table
 from .misses import MissLog
+from .resolution import EXTERNAL_FACTORIES
 from .visitor import EdgeVisitor
 
 
@@ -43,6 +45,7 @@ def build_with_report(
     class_bases: dict[str, list[str]] = {}
     self_attr_types: dict[str, dict[str, str]] = {}
     local_types: dict[str, dict[str, str]] = {}
+    external_local_types: dict[str, dict[str, str]] = {}
 
     for fqn, path in modules.items():
         try:
@@ -72,6 +75,9 @@ def build_with_report(
         local_types.update(
             collect_local_var_types(tree, fqn, import_table, known_classes)
         )
+        external_local_types.update(
+            collect_external_local_var_types(tree, fqn, import_table, EXTERNAL_FACTORIES)
+        )
 
     miss_log.files_parsed = len(parsed)
 
@@ -89,6 +95,7 @@ def build_with_report(
                 known_classes=known_classes,
                 self_attr_types=self_attr_types,
                 local_types=local_types,
+                external_local_types=external_local_types,
             )
             visitor.visit(tree)
             for caller, callees in visitor.edges.items():

--- a/src/pyscope_mcp/analyzer/resolution.py
+++ b/src/pyscope_mcp/analyzer/resolution.py
@@ -26,6 +26,42 @@ def attr_chain(node: ast.expr) -> list[str] | None:
 
 
 # ---------------------------------------------------------------------------
+# External-factory whitelist (Handler #19)
+# ---------------------------------------------------------------------------
+
+# Map from external factory FQN → descriptive label (which is also the FQN
+# stored in external_local_types so the classifier can look up a bucket).
+# Start narrow — additional factories are future PRs keyed to observed misses.
+EXTERNAL_FACTORIES: dict[str, str] = {
+    "httpx.Client": "httpx.Client",
+    "httpx.AsyncClient": "httpx.AsyncClient",
+    "boto3.client": "boto3.client",
+    "boto3.resource": "boto3.resource",
+    "typer.Typer": "typer.Typer",
+    "googleapiclient.discovery.build": "googleapiclient.discovery.Resource",
+}
+
+# Second-order (chained) factory returns: (factory_fqn, method) → return type FQN.
+# Used by collect_external_local_var_types to resolve e.g.
+# paginator = client.get_paginator(...) where client is a boto3.client.
+EXTERNAL_RETURNS: dict[tuple[str, str], str] = {
+    ("boto3.client", "get_paginator"): "boto3.paginator.Paginator",
+    ("boto3.resource", "get_paginator"): "boto3.paginator.Paginator",
+}
+
+# Map external factory FQN → accepted classifier bucket name.
+EXTERNAL_FACTORY_BUCKETS: dict[str, str] = {
+    "httpx.Client": "httpx_method_call",
+    "httpx.AsyncClient": "httpx_method_call",
+    "boto3.client": "boto3_method_call",
+    "boto3.resource": "boto3_method_call",
+    "boto3.paginator.Paginator": "boto3_method_call",
+    "typer.Typer": "typer_method_call",
+    "googleapiclient.discovery.Resource": "googleapi_method_call",
+}
+
+
+# ---------------------------------------------------------------------------
 # Class hierarchy (MRO) resolution
 # ---------------------------------------------------------------------------
 
@@ -134,6 +170,8 @@ class ResolveCtx:
     self_attr_types: dict[str, dict[str, str]] = None  # type: ignore[assignment]
     # {func_fqn: {var_name: class_fqn}} — populated in pass 1 by collect_local_var_types
     local_types: dict[str, dict[str, str]] = None  # type: ignore[assignment]
+    # {func_fqn: {var_name: external_factory_fqn}} — populated by collect_external_local_var_types
+    external_local_types: dict[str, dict[str, str]] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         # Default to empty set/dict so callers that don't supply it still work.
@@ -143,6 +181,8 @@ class ResolveCtx:
             object.__setattr__(self, "self_attr_types", {})
         if self.local_types is None:
             object.__setattr__(self, "local_types", {})
+        if self.external_local_types is None:
+            object.__setattr__(self, "external_local_types", {})
 
 
 # ---------------------------------------------------------------------------

--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -14,6 +14,7 @@ from .misses import (
     snippet,
 )
 from .resolution import (
+    EXTERNAL_FACTORY_BUCKETS,
     ResolveCtx,
     attr_chain,
     dispatcher_callable_arg,
@@ -59,6 +60,7 @@ class EdgeVisitor(ast.NodeVisitor):
         known_classes: set[str] | None = None,
         self_attr_types: dict[str, dict[str, str]] | None = None,
         local_types: dict[str, dict[str, str]] | None = None,
+        external_local_types: dict[str, dict[str, str]] | None = None,
     ) -> None:
         self._ctx = ResolveCtx(
             module_fqn=module_fqn,
@@ -68,6 +70,7 @@ class EdgeVisitor(ast.NodeVisitor):
             known_classes=known_classes or set(),
             self_attr_types=self_attr_types or {},
             local_types=local_types or {},
+            external_local_types=external_local_types or {},
         )
         self._file_path = file_path
         self._miss_log = miss_log
@@ -317,6 +320,41 @@ class EdgeVisitor(ast.NodeVisitor):
             return accepted_tag
         return None
 
+    def _try_accept_external_local_var(self, node: ast.Call) -> str | None:
+        """For ``var.<method>(...)`` 2-part chains where ``var`` is a local variable
+        (or module-level variable) bound to a whitelisted external factory, return
+        the accepted-pattern bucket tag.
+
+        Only fires for 2-part chains (``var.method``).  Longer chains (e.g.
+        ``service.channels().list().execute()``) are not handled here — they fall
+        through to ``attr_chain_unresolved`` as before.
+
+        Lookup order:
+          1. Current function-level bindings.
+          2. Module-level bindings (for `_cli = typer.Typer()` at module scope,
+             called from inside a function like `_cli.command()`).
+
+        Returns the accepted-bucket name (e.g. ``"httpx_method_call"``) or None.
+        """
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return None
+        chain = attr_chain(func)
+        if chain is None or len(chain) != 2 or chain[0] == "self":
+            return None
+        var_name = chain[0]
+        # 1. Function-level lookup.
+        func_fqn = self._current_func_fqn()
+        if func_fqn is not None:
+            factory_fqn = self._ctx.external_local_types.get(func_fqn, {}).get(var_name)
+            if factory_fqn is not None:
+                return EXTERNAL_FACTORY_BUCKETS.get(factory_fqn)
+        # 2. Module-level fallback: vars bound at module scope are visible inside functions.
+        factory_fqn = self._ctx.external_local_types.get(self._ctx.module_fqn, {}).get(var_name)
+        if factory_fqn is not None:
+            return EXTERNAL_FACTORY_BUCKETS.get(factory_fqn)
+        return None
+
     def _try_emit_dispatcher_edge(self, call: ast.Call) -> bool:
         """If `call` looks like `dispatcher(fn, ...)` where fn is an in-package
         callable reference, emit an extra edge to fn. Returns True iff we emitted.
@@ -370,6 +408,7 @@ class EdgeVisitor(ast.NodeVisitor):
                     sentinel_tag = (
                         self._try_accept_self_attr_sentinel(node)
                         or self._try_accept_local_var_sentinel(node)
+                        or self._try_accept_external_local_var(node)
                     )
                     if sentinel_tag is not None:
                         self._miss_log.record_accepted(sentinel_tag, self._file_path)

--- a/tests/test_analyzer_external_factory.py
+++ b/tests/test_analyzer_external_factory.py
@@ -1,0 +1,267 @@
+"""Handler #19: external-factory local-var accept buckets.
+
+Tests that method calls on locals bound from whitelisted external factories
+(httpx, boto3, typer, googleapiclient) are classified into the correct
+accepted bucket rather than emitted as attr_chain_unresolved.
+
+Each factory family has:
+  - A positive test: correct bucket, no unresolved entry.
+  - FP guards: shadowed local, non-whitelisted factory, function param.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyscope_mcp.analyzer import build_with_report
+
+
+def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:
+    pkg = tmp_path / pkg_name
+    pkg.mkdir()
+    if "__init__.py" not in files:
+        (pkg / "__init__.py").write_text("")
+    for rel, content in files.items():
+        target = pkg / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# httpx.Client
+# ---------------------------------------------------------------------------
+
+def test_httpx_client_post_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import httpx\n"
+            "\n"
+            "def upload(url: str, data: bytes) -> None:\n"
+            "    client = httpx.Client()\n"
+            "    client.post(url, content=data)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    summary = report["summary"]
+    assert summary["accepted_counts"].get("httpx_method_call", 0) >= 1, (
+        f"Expected httpx_method_call in accepted, got: {summary['accepted_counts']}"
+    )
+    patterns = {e["pattern"] for e in report["unresolved_calls"]}
+    assert "attr_chain_unresolved" not in patterns, (
+        f"client.post() should not be attr_chain_unresolved; unresolved: {report['unresolved_calls']}"
+    )
+
+
+def test_httpx_async_client_get_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import httpx\n"
+            "\n"
+            "async def fetch(url: str) -> bytes:\n"
+            "    client = httpx.AsyncClient()\n"
+            "    resp = await client.get(url)\n"
+            "    return resp\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    summary = report["summary"]
+    assert summary["accepted_counts"].get("httpx_method_call", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# boto3.client / boto3.resource
+# ---------------------------------------------------------------------------
+
+def test_boto3_client_put_object_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import boto3\n"
+            "\n"
+            "def store(bucket: str, key: str, body: bytes) -> None:\n"
+            "    client = boto3.client('s3')\n"
+            "    client.put_object(Bucket=bucket, Key=key, Body=body)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    summary = report["summary"]
+    assert summary["accepted_counts"].get("boto3_method_call", 0) >= 1
+    patterns = {e["pattern"] for e in report["unresolved_calls"]}
+    assert "attr_chain_unresolved" not in patterns
+
+
+def test_boto3_client_head_object_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import boto3\n"
+            "\n"
+            "def exists(bucket: str, key: str) -> bool:\n"
+            "    client = boto3.client('s3')\n"
+            "    client.head_object(Bucket=bucket, Key=key)\n"
+            "    return True\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    assert report["summary"]["accepted_counts"].get("boto3_method_call", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# boto3 chained factory: get_paginator → paginator.paginate
+# ---------------------------------------------------------------------------
+
+def test_boto3_paginator_paginate_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import boto3\n"
+            "\n"
+            "def list_objects(bucket: str):\n"
+            "    client = boto3.client('s3')\n"
+            "    paginator = client.get_paginator('list_objects_v2')\n"
+            "    for page in paginator.paginate(Bucket=bucket):\n"
+            "        pass\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    summary = report["summary"]
+    # get_paginator itself is boto3_method_call; paginator.paginate is also boto3_method_call
+    assert summary["accepted_counts"].get("boto3_method_call", 0) >= 2, (
+        f"Expected >=2 boto3_method_call, got {summary['accepted_counts']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# typer.Typer
+# ---------------------------------------------------------------------------
+
+def test_typer_command_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import typer\n"
+            "\n"
+            "_cli = typer.Typer()\n"
+            "\n"
+            "def setup():\n"
+            "    _cli.command()(lambda: None)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    summary = report["summary"]
+    assert summary["accepted_counts"].get("typer_method_call", 0) >= 1
+
+
+def test_typer_command_in_function_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import typer\n"
+            "\n"
+            "def make_app():\n"
+            "    app = typer.Typer()\n"
+            "    app.command()(lambda: None)\n"
+            "    return app\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    assert report["summary"]["accepted_counts"].get("typer_method_call", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# googleapiclient.discovery.build
+# ---------------------------------------------------------------------------
+
+def test_googleapi_channels_list_accepted(tmp_path: Path) -> None:
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "from googleapiclient import discovery\n"
+            "\n"
+            "def get_channels(api_key: str):\n"
+            "    service = discovery.build('youtube', 'v3', developerKey=api_key)\n"
+            "    service.channels()\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    assert report["summary"]["accepted_counts"].get("googleapi_method_call", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# False-positive guard: shadowed local — client reassigned to non-factory value
+# ---------------------------------------------------------------------------
+
+def test_shadowed_local_not_accepted(tmp_path: Path) -> None:
+    """After `client = 42`, client.post() should NOT be accepted as httpx_method_call."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import httpx\n"
+            "\n"
+            "def mixed():\n"
+            "    client = httpx.Client()\n"
+            "    client = 42\n"
+            "    client.post('http://example.com')\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    # After shadow, client is int — should NOT be accepted as httpx_method_call.
+    assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0, (
+        "Shadowed local should not be accepted as httpx_method_call"
+    )
+
+
+# ---------------------------------------------------------------------------
+# False-positive guard: non-whitelisted factory
+# ---------------------------------------------------------------------------
+
+def test_non_whitelisted_factory_not_accepted(tmp_path: Path) -> None:
+    """A call like SomeOtherLib.Client() → .post() must NOT produce httpx_method_call."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import some_other_lib\n"
+            "\n"
+            "def run():\n"
+            "    client = some_other_lib.Client()\n"
+            "    client.post('http://example.com')\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0
+    assert report["summary"]["accepted_counts"].get("boto3_method_call", 0) == 0
+    assert report["summary"]["accepted_counts"].get("typer_method_call", 0) == 0
+    assert report["summary"]["accepted_counts"].get("googleapi_method_call", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# False-positive guard: client is a parameter (no local binding)
+# ---------------------------------------------------------------------------
+
+def test_parameter_not_accepted(tmp_path: Path) -> None:
+    """If `client` is a function parameter with no type binding, .post() stays unresolved."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "def upload(client, url: str) -> None:\n"
+            "    client.post(url)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    # No factory binding — should not be httpx_method_call accepted
+    assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# False-positive guard: in-package class with same name wins over factory whitelist
+# ---------------------------------------------------------------------------
+
+def test_inpackage_class_wins_over_whitelist(tmp_path: Path) -> None:
+    """An in-package `Client` class is resolved via local_types, not httpx whitelist."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Client:\n"
+            "    def post(self, url: str):\n"
+            "        pass\n"
+            "\n"
+            "def run():\n"
+            "    c = Client()\n"
+            "    c.post('http://example.com')\n"
+        ),
+    })
+    raw, report = build_with_report(root, "pkg")
+    # Resolved in-package, not accepted as httpx_method_call
+    assert "pkg.mod.Client.post" in raw.get("pkg.mod.run", [])
+    assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0


### PR DESCRIPTION
## Summary

Implements Handler #19: classify method calls on locals bound from a whitelisted set of external factories as accepted-miss buckets rather than `attr_chain_unresolved`, quieting misses.json noise without emitting false in-package edges.

- New collector `collect_external_local_var_types` in `analyzer/discovery.py` (mirrors `collect_local_var_types` for external factories). Also handles module-level bindings (e.g. `_cli = typer.Typer()` at module scope, called from inside a function).
- `EXTERNAL_FACTORIES` whitelist + `EXTERNAL_RETURNS` chained-factory map + `EXTERNAL_FACTORY_BUCKETS` label map in `analyzer/resolution.py`.
- New field `external_local_types` on `ResolveCtx` (same default-empty pattern as `local_types`).
- `pipeline.py` threads the new collector alongside `local_types`.
- `visitor.py` adds `_try_accept_external_local_var` checked before `classify_miss`, wired into the existing sentinel-tag gate in `visit_Call`.
- New accept buckets: `httpx_method_call`, `boto3_method_call`, `typer_method_call`, `googleapi_method_call` added to `ACCEPTED_PATTERNS`.

## Real-repo delta (video_agent_long)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| `calls_unresolved` | 909 | 896 | -13 |
| `calls_accepted` | 8403 | 8416 | +13 |
| `attr_chain_unresolved` | 477 | 464 | -13 |
| `typer_method_call` | 0 | 12 | +12 |
| `googleapi_method_call` | 0 | 1 | +1 |
| `httpx_method_call` | 0 | 0 | 0 |
| `boto3_method_call` | 0 | 0 | 0 |
| dead_keys recovered | — | — | 0 |

**Note on lower-than-expected httpx/boto3 count:** The `video_agent_long` codebase uses `httpx.Client()` exclusively via `with httpx.Client() as client:` (context manager, not simple assignment) and boto3 via an in-package wrapper method `self._boto3_client()`. Both patterns are deliberately out of scope for this handler (context manager bindings are a separate PR; wrapper methods are interprocedural). The handler correctly does not fire for them. The 12 typer + 1 googleapi reclassifications are the accurate count for direct factory-call bindings in this repo.

## Acceptance criteria checklist

- [x] New collector `collect_external_local_var_types` mirrors `collect_local_var_types` but for external factories
- [x] `EXTERNAL_FACTORIES` whitelist module-level in `resolution.py` — exactly the set listed in the issue
- [x] New field `external_local_types` on `ResolveCtx` with default-empty pattern
- [x] Collector threaded through `pipeline.py` where `local_types` is already threaded
- [x] Classifier wiring in `visitor.py`: before `attr_chain_unresolved`, check `external_local_types`
- [x] New accept buckets: `httpx_method_call`, `boto3_method_call`, `typer_method_call`, `googleapi_method_call`
- [x] `EXTERNAL_RETURNS` secondary map for `get_paginator` chained case implemented
- [x] Module-level binding support (typer `_cli = typer.Typer()` pattern)

## False-positive guards (all pass)

- Shadowed local (`client = httpx.Client()` then `client = 42`) → not accepted after shadow ✅
- Non-whitelisted factory → stays `attr_chain_unresolved` ✅
- In-package `Client` class → resolves in-package via `local_types`, not accepted as httpx ✅
- Unannotated parameter (`def f(client, ...): client.post(...)`) → not accepted ✅

## Self-review findings

Reviewer was self (Agent tool not available in this environment). The review covered:

1. **Correctness against acceptance criteria** — all items above checked against the issue design. ✅
2. **FP guard tests pass** — all 12 tests pass (`pytest` 272/272). ✅
3. **No regression in existing tests** — full suite 272 passed. ✅
4. **Classifier ordering** — `_try_accept_external_local_var` is inserted at the correct slot: after sentinel checks (which fire for in-package types), before `classify_miss`. In-package classes always win via `_resolve_expr` before any accept-branch is reached. ✅
5. **No out-of-scope edits** — changes confined to `src/pyscope_mcp/analyzer/` and `tests/`. ✅

One finding applied during review: initial implementation returned factory *key* FQN instead of *value* FQN from `EXTERNAL_FACTORIES`, causing `googleapiclient` bucket lookup to fail. Fixed by returning `external_factories[fqn]` (the type label) rather than the raw key.

## Deferred items

- `with httpx.Client() as client:` context-manager bindings — mentioned as out of scope in the issue. Would require handling `ast.With.items[].optional_vars`.
- Async-context-manager bindings (`async with httpx.AsyncClient() as client`) — same.
- boto3 via-wrapper pattern (`client = self._boto3_client()`) — interprocedural, wait for confidence-tagged edges schema.

Closes #19. Part of #18.