### PR TITLE
Fix: recognize aliased stdlib imports (import sys as sys_module) in classifier (#22)

### DIFF
--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -441,6 +441,16 @@ def classify_miss(
                 # Also handle direct module names: `import sys` → chain[0]=='sys' in STDLIB_MODULES
                 if chain[0] in STDLIB_MODULES and chain[0] not in import_table:
                     return "stdlib_method_call"
+                # Parameter injection pattern: def f(sys_module): sys_module.exit(...)
+                # Common in testable CLI code where the caller passes `sys` as an argument
+                # to allow tests to intercept exit(). Recognize <stdlib_name>_module and
+                # <stdlib_name>_lib naming conventions.
+                root = chain[0]
+                for suffix in ("_module", "_lib"):
+                    if root.endswith(suffix):
+                        stem = root[: -len(suffix)]
+                        if stem in STDLIB_MODULES:
+                            return "stdlib_method_call"
             method = chain[-1]
             if chain[0] != "self":
                 # ClassName.__new__(...) — inherited from object/type; never a

--- a/tests/test_analyzer_alias_stdlib.py
+++ b/tests/test_analyzer_alias_stdlib.py
@@ -1,0 +1,166 @@
+"""End-to-end tests for aliased / injected stdlib imports (issue #22).
+
+Covers three scenarios:
+1. Import alias:  ``import sys as sys_module; sys_module.exit(0)``
+2. Direct import: ``import os.path as op; op.join('a', 'b')``
+3. Parameter injection: ``def f(sys_module): sys_module.exit(1)``
+   — common testable-CLI pattern where the caller passes ``sys`` as an arg.
+
+All three should land in an accepted bucket (``stdlib_method_call`` or
+``calls_resolved_external``) rather than ``attr_chain_unresolved``.
+
+FP guard: a variable whose name ends in ``_module`` but whose stem is NOT a
+stdlib module must still land in ``attr_chain_unresolved``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyscope_mcp.analyzer import build_raw, build_with_report
+
+
+def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:
+    pkg = tmp_path / pkg_name
+    pkg.mkdir()
+    if "__init__.py" not in files:
+        (pkg / "__init__.py").write_text("")
+    for rel, content in files.items():
+        target = pkg / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Import-alias path: import sys as sys_module
+# ---------------------------------------------------------------------------
+
+def test_import_alias_sys_exit_is_not_attr_chain_unresolved(tmp_path: Path) -> None:
+    """``import sys as sys_module; sys_module.exit(0)`` must not land in
+    ``attr_chain_unresolved``.  Via _resolve_external it becomes
+    ``calls_resolved_external``; via classify_miss it becomes
+    ``stdlib_method_call`` (both are correct).
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import sys as sys_module\n"
+            "\n"
+            "def f():\n"
+            "    sys_module.exit(0)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    unresolved = report["pattern_counts"]
+    assert "attr_chain_unresolved" not in unresolved or unresolved.get("attr_chain_unresolved", 0) == 0, (
+        f"sys_module.exit(0) should not be attr_chain_unresolved; got {unresolved}"
+    )
+
+
+def test_import_alias_os_path_join_is_not_attr_chain_unresolved(tmp_path: Path) -> None:
+    """``import os.path as op; op.join('a', 'b')`` must not land in
+    ``attr_chain_unresolved``.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import os.path as op\n"
+            "\n"
+            "def f(x, y):\n"
+            "    return op.join(x, y)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    unresolved = report["pattern_counts"]
+    assert "attr_chain_unresolved" not in unresolved or unresolved.get("attr_chain_unresolved", 0) == 0, (
+        f"op.join should not be attr_chain_unresolved; got {unresolved}"
+    )
+
+
+def test_import_alias_json_loads_is_not_attr_chain_unresolved(tmp_path: Path) -> None:
+    """``import json as j; j.loads('{}')`` must not land in
+    ``attr_chain_unresolved``.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "import json as j\n"
+            "\n"
+            "def f(s):\n"
+            "    return j.loads(s)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    unresolved = report["pattern_counts"]
+    assert "attr_chain_unresolved" not in unresolved or unresolved.get("attr_chain_unresolved", 0) == 0, (
+        f"j.loads should not be attr_chain_unresolved; got {unresolved}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parameter injection: def f(sys_module): sys_module.exit(...)
+# — matches STDLIB_MODULES stem + "_module" / "_lib" suffix heuristic
+# ---------------------------------------------------------------------------
+
+def test_parameter_injection_sys_module_exit_is_accepted(tmp_path: Path) -> None:
+    """``def f(sys_module): sys_module.exit(2)`` — sys_module is a parameter,
+    not an import, but the name strongly implies it holds the ``sys`` stdlib
+    module.  Must land in ``stdlib_method_call`` (accepted) not
+    ``attr_chain_unresolved``.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "def gate(phases, sys_module) -> None:\n"
+            "    if not phases:\n"
+            "        sys_module.exit(2)\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    accepted = report["summary"]["accepted_counts"]
+    pattern_counts = report["pattern_counts"]
+    assert accepted.get("stdlib_method_call", 0) >= 1, (
+        f"sys_module.exit(2) should be accepted as stdlib_method_call; "
+        f"accepted={accepted}, pattern_counts={pattern_counts}"
+    )
+    assert pattern_counts.get("attr_chain_unresolved", 0) == 0, (
+        f"sys_module.exit(2) should not be attr_chain_unresolved; "
+        f"pattern_counts={pattern_counts}"
+    )
+
+
+def test_parameter_injection_os_lib_is_accepted(tmp_path: Path) -> None:
+    """``def f(os_lib): os_lib.getcwd()`` — ``_lib`` suffix variant."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "def f(os_lib):\n"
+            "    return os_lib.getcwd()\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    accepted = report["summary"]["accepted_counts"]
+    assert accepted.get("stdlib_method_call", 0) >= 1, (
+        f"os_lib.getcwd() should be accepted as stdlib_method_call; accepted={accepted}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FP guard: non-stdlib_module suffix must NOT false-accept
+# ---------------------------------------------------------------------------
+
+def test_fp_guard_non_stdlib_stem_is_attr_chain_unresolved(tmp_path: Path) -> None:
+    """``myapp_module.exit()`` — ``myapp`` is not a stdlib module; must not be
+    accepted as ``stdlib_method_call``.  Should land in ``attr_chain_unresolved``.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "def f(myapp_module):\n"
+            "    myapp_module.exit()\n"
+        ),
+    })
+    _raw, report = build_with_report(root, "pkg")
+    accepted = report["summary"]["accepted_counts"]
+    pattern_counts = report["pattern_counts"]
+    assert accepted.get("stdlib_method_call", 0) == 0, (
+        f"myapp_module.exit() must NOT be accepted as stdlib_method_call; accepted={accepted}"
+    )
+    assert pattern_counts.get("attr_chain_unresolved", 0) >= 1, (
+        f"myapp_module.exit() should land in attr_chain_unresolved; pattern_counts={pattern_counts}"
+    )


### PR DESCRIPTION
## Diagnosis

**Investigation result: Partial Fix A — new sub-case of parameter injection, not a pure import-alias bug.**

### What the investigation found

Step 1 — Reproducing minimally with `import sys as sys_module; sys_module.exit(0)` in `build_raw`:
- The call is handled correctly: `_resolve_external` fires, looks up `sys_module` in `import_table` (which has `sys_module -> sys`), and records it as `calls_resolved_external`.
- Result: **not** `attr_chain_unresolved` — already handled.

Step 2 — Inspect `import_table`: `sys_module -> sys` IS recorded. Fix B does not apply.

Step 3 — Inspect classifier: The stdlib alias block in `classify_miss` (lines 433–441) correctly routes `sys_module.exit()` to `stdlib_method_call` when `import_table` is supplied. Fix C does not apply.

### The actual bug (new sub-case)

The three real exemplars in `video_agent_long` are NOT import aliases — they are **parameter injection** patterns:

```python
def gate_opt_in_phases(phases: list[str] | None, flags: FlagState, sys_module) -> None:
    """sys_module is injected so the caller's sys.exit is used (for testability)."""
    if not phases:
        sys_module.exit(2)
```

`sys_module` is a function parameter, absent from `import_table`. Both `_resolve_external` and the existing import-table alias check in `classify_miss` fall through → `attr_chain_unresolved`.

## Narrow fix

Added 10 lines to `classify_miss` inside the existing `import_table is not None` block (`src/pyscope_mcp/analyzer/misses.py`):

```python
# Parameter injection pattern: def f(sys_module): sys_module.exit(...)
# Common in testable CLI code where the caller passes `sys` as an argument.
# Recognize <stdlib_name>_module and <stdlib_name>_lib naming conventions.
root = chain[0]
for suffix in ("_module", "_lib"):
    if root.endswith(suffix):
        stem = root[: -len(suffix)]
        if stem in STDLIB_MODULES:
            return "stdlib_method_call"
```

No changes to `imports.py`, `visitor.py`, `pipeline.py`, or `discovery.py`.

## Delta on video_agent_long

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| `attr_chain_unresolved` | 464 | 461 | −3 |
| `stdlib_method_call` (accepted) | 0 | 3 | +3 |
| `sys_module` exemplars in unresolved | 3 | 0 | −3 |

All 3 motivating exemplars (`sys_module.exit(2)`, `sys_module.exit(1)` ×2) moved to accepted bucket.

## Acceptance checklist

- [x] `import sys as sys_module; sys_module.exit(0)` → not `attr_chain_unresolved` (already worked via `_resolve_external`)
- [x] `import os.path as op; op.join('a', 'b')` → not `attr_chain_unresolved` (already worked)
- [x] `import json as j; j.loads('{}')` → not `attr_chain_unresolved` (already worked)
- [x] `def f(sys_module): sys_module.exit(2)` → `stdlib_method_call` (new fix)
- [x] `def f(os_lib): os_lib.getcwd()` → `stdlib_method_call` (new fix, `_lib` suffix)
- [x] **FP guard**: `def f(myapp_module): myapp_module.exit()` → `attr_chain_unresolved` (non-stdlib stem not accepted)
- [x] All 266 tests pass (260 existing + 6 new)

## Reviewer findings

Self-review (read-only pass):
- Fix is narrow: 10 lines in one function, no drive-by refactoring
- FP guard test passes: `myapp_module.exit()` stays `attr_chain_unresolved`
- The heuristic is specific to `_module` / `_lib` suffixes on stdlib stem names — low false-positive risk
- Existing 260 tests all pass
- The fix sits inside `import_table is not None` guard (backward-compatible when caller omits `import_table`)

Closes #22. Parent: #18.