### PR TITLE
feat(analyzer): resolve cls(...) / cls.method() in classmethods

### DIFF
--- a/src/pyscope_mcp/analyzer/resolution.py
+++ b/src/pyscope_mcp/analyzer/resolution.py
@@ -364,6 +364,56 @@ def resolve_nested_def(
     return None
 
 
+# ---------------------------------------------------------------------------
+# cls() / cls.method() inside @classmethod resolution
+# ---------------------------------------------------------------------------
+
+def is_classmethod_context(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    """True iff func_node is a @classmethod whose first positional arg is named 'cls'.
+
+    Both conditions must hold:
+    1. At least one decorator whose ``id`` or ``attr`` is ``'classmethod'``
+       (covers both bare ``@classmethod`` and attribute forms such as
+       ``@builtins.classmethod``).
+    2. First positional argument is literally named 'cls'.
+    """
+    if not func_node.args.args:
+        return False
+    if func_node.args.args[0].arg != "cls":
+        return False
+    for dec in func_node.decorator_list:
+        # bare: @classmethod
+        if isinstance(dec, ast.Name) and dec.id == "classmethod":
+            return True
+        # attribute: @builtins.classmethod or similar
+        if isinstance(dec, ast.Attribute) and dec.attr == "classmethod":
+            return True
+    return False
+
+
+def resolve_cls_call(
+    enclosing_class_fqn: str,
+    method: str | None,
+    ctx: "ResolveCtx",
+) -> str | None:
+    """Resolve ``cls(...)`` or ``cls.<method>(...)`` inside a classmethod.
+
+    - method is None: ``cls(...)`` → resolve to ``__init__`` of enclosing class
+      (direct hit or MRO walk).
+    - method is a string: ``cls.<method>(...)`` → resolve to
+      ``enclosing_class_fqn.<method>`` (direct hit or MRO walk).
+
+    Returns the resolved FQN or None.
+    """
+    target_method = method if method is not None else "__init__"
+    candidate = f"{enclosing_class_fqn}.{target_method}"
+    if candidate in ctx.known_fqns:
+        return candidate
+    return walk_mro(enclosing_class_fqn, target_method, ctx.class_bases, ctx.known_fqns)
+
+
 def resolve_call_result_method(
     node: ast.Attribute,
     ctx: ResolveCtx,

--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -19,7 +19,9 @@ from .resolution import (
     attr_chain,
     dispatcher_callable_arg,
     infer_call_class_type,
+    is_classmethod_context,
     is_dispatcher_call,
+    resolve_cls_call,
     resolve_local_var_method,
     resolve_nested_def,
     resolve_self_attr_method,
@@ -78,6 +80,7 @@ class EdgeVisitor(ast.NodeVisitor):
         self._file_path = file_path
         self._miss_log = miss_log
         self._scope_stack: list[str] = []
+        self._func_node_stack: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
         self.edges: dict[str, set[str]] = {}
 
     # ------------------------------------------------------------------
@@ -121,6 +124,10 @@ class EdgeVisitor(ast.NodeVisitor):
                 result.append(candidate)
         return result
 
+    def _enclosing_func_node(self) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+        """Return the innermost enclosing function AST node, or None."""
+        return self._func_node_stack[-1] if self._func_node_stack else None
+
     def _enclosing_class_fqn(self) -> str | None:
         """FQN of the enclosing class, walking inside-out through the scope stack.
 
@@ -162,6 +169,12 @@ class EdgeVisitor(ast.NodeVisitor):
                 candidate = self._ctx.import_table[name]
                 if candidate in self._ctx.known_fqns:
                     return candidate
+            # cls(...) inside a @classmethod → resolve to enclosing class __init__.
+            if name == "cls":
+                enc_func = self._enclosing_func_node()
+                enc_class = self._enclosing_class_fqn()
+                if enc_func is not None and enc_class is not None and is_classmethod_context(enc_func):
+                    return resolve_cls_call(enc_class, None, self._ctx)
             # Nested-def lookup: check enclosing scopes before module-global.
             # Only attempt when we have a call_lineno (pass 2 call sites always
             # have one; dispatcher-arg resolution may not).
@@ -201,6 +214,13 @@ class EdgeVisitor(ast.NodeVisitor):
             chain = attr_chain(func_node)
             if chain is None:
                 return None
+
+            # cls.method(...) inside a @classmethod.
+            if chain[0] == "cls" and len(chain) == 2:
+                enc_func = self._enclosing_func_node()
+                enc_class = self._enclosing_class_fqn()
+                if enc_func is not None and enc_class is not None and is_classmethod_context(enc_func):
+                    return resolve_cls_call(enc_class, chain[1], self._ctx)
 
             # self.method(...) with MRO fallback for inherited methods.
             if chain[0] == "self" and len(chain) >= 2:
@@ -411,10 +431,17 @@ class EdgeVisitor(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._scope_stack.append(node.name)
+        self._func_node_stack.append(node)
         self.generic_visit(node)
+        self._func_node_stack.pop()
         self._scope_stack.pop()
 
-    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._scope_stack.append(node.name)
+        self._func_node_stack.append(node)
+        self.generic_visit(node)
+        self._func_node_stack.pop()
+        self._scope_stack.pop()
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._scope_stack.append(node.name)

--- a/tests/test_analyzer_classmethod_cls.py
+++ b/tests/test_analyzer_classmethod_cls.py
@@ -1,0 +1,244 @@
+"""Tests for cls() / cls.method() resolution inside @classmethod bodies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyscope_mcp.analyzer import build_raw
+
+
+def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:
+    pkg = tmp_path / pkg_name
+    pkg.mkdir()
+    if "__init__.py" not in files:
+        (pkg / "__init__.py").write_text("")
+    for rel, content in files.items():
+        target = pkg / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. cls(...) → enclosing __init__
+# ---------------------------------------------------------------------------
+
+def test_cls_call_resolves_to_enclosing_init(tmp_path: Path) -> None:
+    """cls(...) inside a classmethod resolves to the enclosing class __init__."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Widget:\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+            "\n"
+            "    @classmethod\n"
+            "    def create(cls, x):\n"
+            "        return cls(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.mod.Widget.__init__" in raw["pkg.mod.Widget.create"]
+
+
+# ---------------------------------------------------------------------------
+# 2. cls.from_dict(...) → enclosing class method
+# ---------------------------------------------------------------------------
+
+def test_cls_method_resolves_to_enclosing_class_method(tmp_path: Path) -> None:
+    """cls.from_dict(...) inside a classmethod resolves to EnclosingClass.from_dict."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Record:\n"
+            "    def __init__(self, data):\n"
+            "        self.data = data\n"
+            "\n"
+            "    @classmethod\n"
+            "    def from_dict(cls, d):\n"
+            "        return cls(d)\n"
+            "\n"
+            "    @classmethod\n"
+            "    def from_json(cls, s):\n"
+            "        import json\n"
+            "        return cls.from_dict(json.loads(s))\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.mod.Record.from_dict" in raw["pkg.mod.Record.from_json"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Subclass cls.parent_method(...) → resolves via MRO
+# ---------------------------------------------------------------------------
+
+def test_cls_method_inherits_via_mro(tmp_path: Path) -> None:
+    """cls.parent_method() inside subclass classmethod resolves via MRO."""
+    root = _make_package(tmp_path, "pkg", {
+        "base.py": (
+            "class Base:\n"
+            "    @classmethod\n"
+            "    def build(cls, x):\n"
+            "        return cls(x)\n"
+            "\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+        ),
+        "child.py": (
+            "from pkg.base import Base\n"
+            "\n"
+            "class Child(Base):\n"
+            "    @classmethod\n"
+            "    def make(cls, x):\n"
+            "        return cls.build(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    assert "pkg.base.Base.build" in raw["pkg.child.Child.make"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Override preference: child defines method → resolves to child version
+# ---------------------------------------------------------------------------
+
+def test_cls_method_prefers_child_override(tmp_path: Path) -> None:
+    """cls.method() resolves to the child's own override, not the parent's."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Base:\n"
+            "    @classmethod\n"
+            "    def build(cls, x):\n"
+            "        return x\n"
+            "\n"
+            "class Child(Base):\n"
+            "    @classmethod\n"
+            "    def build(cls, x):\n"
+            "        return x * 2\n"
+            "\n"
+            "    @classmethod\n"
+            "    def make(cls, x):\n"
+            "        return cls.build(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw["pkg.mod.Child.make"]
+    assert "pkg.mod.Child.build" in callees
+    assert "pkg.mod.Base.build" not in callees
+
+
+# ---------------------------------------------------------------------------
+# 5. FP guard: plain method with first arg named cls but no @classmethod decorator
+# ---------------------------------------------------------------------------
+
+def test_no_edge_plain_method_named_cls_no_decorator(tmp_path: Path) -> None:
+    """A plain method whose first arg is named 'cls' (no @classmethod) must NOT resolve."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Thing:\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+            "\n"
+            "    def weird(cls, x):\n"
+            "        return cls(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Thing.weird", [])
+    assert "pkg.mod.Thing.__init__" not in callees
+
+
+# ---------------------------------------------------------------------------
+# 6. FP guard: @classmethod decorator but first arg is not 'cls'
+# ---------------------------------------------------------------------------
+
+def test_no_edge_classmethod_first_arg_not_cls(tmp_path: Path) -> None:
+    """@classmethod with non-'cls' first arg must NOT trigger cls resolution."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Factory:\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+            "\n"
+            "    @classmethod\n"
+            "    def create(klass, x):\n"
+            "        return klass(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Factory.create", [])
+    assert "pkg.mod.Factory.__init__" not in callees
+
+
+# ---------------------------------------------------------------------------
+# 7. FP guard: cls(...) in module-scope function (no enclosing class)
+# ---------------------------------------------------------------------------
+
+def test_no_edge_cls_in_module_scope_function(tmp_path: Path) -> None:
+    """cls used in a module-level function (not inside any class) must not resolve."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class MyClass:\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+            "\n"
+            "def factory(cls, x):\n"
+            "    return cls(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.factory", [])
+    assert "pkg.mod.MyClass.__init__" not in callees
+
+
+# ---------------------------------------------------------------------------
+# 8. cls.a.b(...) 3-part chain → no edge (out of scope)
+# ---------------------------------------------------------------------------
+
+def test_no_edge_cls_three_part_chain(tmp_path: Path) -> None:
+    """cls.a.b(...) three-part chain is out of scope and must not emit an edge."""
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Registry:\n"
+            "    _store = {}\n"
+            "\n"
+            "    @classmethod\n"
+            "    def register(cls, key, val):\n"
+            "        cls._store[key] = val\n"
+            "\n"
+            "    @classmethod\n"
+            "    def do_something(cls):\n"
+            "        cls._store.update({'a': 1})\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    callees = raw.get("pkg.mod.Registry.do_something", [])
+    # Must not resolve cls._store.update as an in-package edge
+    assert not any(c.startswith("pkg.mod.Registry") for c in callees)
+
+
+# ---------------------------------------------------------------------------
+# 9. Local variable 'cls = ...' inside classmethod — documents current behavior
+# ---------------------------------------------------------------------------
+
+def test_local_cls_shadow_resolves_to_enclosing_class(tmp_path: Path) -> None:
+    """A local variable named 'cls' inside a classmethod shadows the parameter.
+
+    Current behavior (by design): the resolver uses the enclosing function's
+    classmethod context, not dataflow, so cls(...) still resolves to the
+    enclosing class __init__. This test asserts current behavior and documents
+    the known limitation.
+    """
+    root = _make_package(tmp_path, "pkg", {
+        "mod.py": (
+            "class Widget:\n"
+            "    def __init__(self, x):\n"
+            "        self.x = x\n"
+            "\n"
+            "    @classmethod\n"
+            "    def create(cls, x):\n"
+            "        cls = Widget  # shadows the cls parameter\n"
+            "        return cls(x)\n"
+        ),
+    })
+    raw = build_raw(root, "pkg")
+    # Documented limitation: resolver uses classmethod context, not dataflow.
+    # cls(x) still resolves to Widget.__init__ even though cls was rebound.
+    assert "pkg.mod.Widget.__init__" in raw["pkg.mod.Widget.create"]


### PR DESCRIPTION
## Summary
- Resolver for `cls(...)` and `cls.<method>(...)` inside `@classmethod` functions whose first arg is `cls`.
- Walks MRO for inherited classmethods; falls back to MRO for `__init__`.
- Requires BOTH `@classmethod` decorator AND first-arg `cls` to avoid FPs.

## Handler-playbook checklist
- [x] Pattern observed on real repo (video_agent_long, exemplars 56 and 76)
- [x] Pass-1 facts identified: enclosing function AST (decorator list, args)
- [x] Resolver is a pure function in `resolution.py`; visitor wires the slot
- [x] False-positive guards covered by tests (plain method, @classmethod without cls arg, module-scope, 3-part chain)
- [x] Real-repo delta: `bare_name_unresolved` 28 -> 27. Residual is pydantic.BaseModel subclass (correctly unresolvable).
- [x] Full suite green (363 tests).

## Test plan
- [x] `tests/test_analyzer_classmethod_cls.py` — 9 tests (positive + 4 FP guards + MRO + override + 3-part chain + shadow-limitation doc)
- [x] Full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)