### PR TITLE
fix(#42): add truncation flag to search response

### DIFF
--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -160,9 +160,22 @@ class CallGraphIndex:
     def module_callees(self, module: str, depth: int = 1) -> list[str]:
         return _bfs(self.module_graph, module, depth)
 
-    def search(self, substring: str, limit: int = 50) -> list[str]:
+    def search(self, substring: str, limit: int = 50) -> dict:
+        """Substring search over known fully-qualified function names.
+
+        Returns a dict with:
+          - ``results``: list of matching FQNs (capped at *limit*)
+          - ``truncated``: True when the full match count exceeds *limit*
+          - ``total_matched``: count of all matches before capping
+        """
         s = substring.lower()
-        return [n for n in self.function_graph.nodes if s in n.lower()][:limit]
+        all_matches = [n for n in self.function_graph.nodes if s in n.lower()]
+        total = len(all_matches)
+        return {
+            "results": all_matches[:limit],
+            "truncated": total > limit,
+            "total_matched": total,
+        }
 
     def stats(self) -> dict[str, int]:
         return {

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -160,7 +160,7 @@ class CallGraphIndex:
     def module_callees(self, module: str, depth: int = 1) -> list[str]:
         return _bfs(self.module_graph, module, depth)
 
-    def search(self, substring: str, limit: int = 50) -> dict:
+    def search(self, substring: str, limit: int = 50) -> dict[str, object]:
         """Substring search over known fully-qualified function names.
 
         Returns a dict with:

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -119,7 +119,11 @@ _TOOL_LIST = [
     },
     {
         "name": "search",
-        "description": "Substring search over known fully-qualified function names.",
+        "description": (
+            "Substring search over known fully-qualified function names. "
+            "Results are capped at 50; use a more specific query if `truncated` is true. "
+            "Returns {results: [...], truncated: bool, total_matched: int}."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -121,7 +121,7 @@ _TOOL_LIST = [
         "name": "search",
         "description": (
             "Substring search over known fully-qualified function names. "
-            "Results are capped at 50; use a more specific query if `truncated` is true. "
+            "Results are capped at `limit` (default 50); use a more specific query if `truncated` is true. "
             "Returns {results: [...], truncated: bool, total_matched: int}."
         ),
         "inputSchema": {

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -59,3 +59,9 @@ def test_search_truncation() -> None:
     assert len(result_all["results"]) == 5
     assert result_all["truncated"] is False
     assert result_all["total_matched"] == 5
+
+    # Cap exactly equal to match count — truncated must be False (condition is total > limit, not >=)
+    result_exact = idx.search("fn", limit=5)
+    assert len(result_exact["results"]) == 5
+    assert result_exact["truncated"] is False
+    assert result_exact["total_matched"] == 5

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -26,7 +26,10 @@ def test_queries() -> None:
     assert "sample.b.helper" in idx.callees_of("sample.a.top", depth=1)
     assert "sample.b.inner" in idx.callees_of("sample.a.top", depth=2)
     assert "sample.a.top" in idx.callers_of("sample.b.helper", depth=1)
-    assert idx.search("helper") == ["sample.b.helper"]
+    result = idx.search("helper")
+    assert result["results"] == ["sample.b.helper"]
+    assert result["truncated"] is False
+    assert result["total_matched"] == 1
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
@@ -37,3 +40,22 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     loaded = CallGraphIndex.load(out)
     assert loaded.stats() == idx.stats()
     assert loaded.search("helper") == idx.search("helper")
+
+
+def test_search_truncation() -> None:
+    """When matches exceed the cap, truncated=True and total_matched reflects the full count."""
+    # Build a raw graph with 5 symbols all containing "fn"
+    raw = {f"pkg.mod.fn{i}": [] for i in range(5)}
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+
+    # Cap at 3 — should truncate
+    result = idx.search("fn", limit=3)
+    assert len(result["results"]) == 3
+    assert result["truncated"] is True
+    assert result["total_matched"] == 5
+
+    # Cap at 10 — should not truncate
+    result_all = idx.search("fn", limit=10)
+    assert len(result_all["results"]) == 5
+    assert result_all["truncated"] is False
+    assert result_all["total_matched"] == 5

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -264,7 +264,7 @@ async def test_tool_search(server: RpcServer):
 
 @pytest.mark.asyncio
 async def test_tool_search_truncation(server: RpcServer):
-    """search with limit=1 on a fixture that has 2 'pkg' symbols triggers truncated=true."""
+    """search with limit=1 on a fixture that has 3 'pkg' symbols triggers truncated=true."""
     # The fixture has: pkg.mod.foo, pkg.mod.bar, pkg.other.baz — all contain "pkg"
     lines = [_req("tools/call", {"name": "search", "arguments": {"query": "pkg", "limit": 1}}, req_id=1)]
     responses = await _run(server, lines)

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -252,6 +252,42 @@ async def test_tool_search(server: RpcServer):
     responses = await _run(server, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    # Response must include truncation metadata
+    assert "results" in payload
+    assert "truncated" in payload
+    assert "total_matched" in payload
+    assert isinstance(payload["results"], list)
+    assert isinstance(payload["truncated"], bool)
+    assert isinstance(payload["total_matched"], int)
+
+
+@pytest.mark.asyncio
+async def test_tool_search_truncation(server: RpcServer):
+    """search with limit=1 on a fixture that has 2 'pkg' symbols triggers truncated=true."""
+    # The fixture has: pkg.mod.foo, pkg.mod.bar, pkg.other.baz — all contain "pkg"
+    lines = [_req("tools/call", {"name": "search", "arguments": {"query": "pkg", "limit": 1}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert payload["truncated"] is True
+    assert payload["total_matched"] == 3
+    assert len(payload["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_search_not_truncated(server: RpcServer):
+    """search that returns fewer results than the cap has truncated=false."""
+    # "baz" matches only pkg.other.baz
+    lines = [_req("tools/call", {"name": "search", "arguments": {"query": "baz"}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert payload["truncated"] is False
+    assert payload["total_matched"] == 1
+    assert payload["results"] == ["pkg.other.baz"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #42

## What changed

The `search` MCP tool returned a plain list capped at 50 results, silently discarding any matches beyond the cap. An agent querying a common term like `"run"` would receive exactly 50 results with no indication that the index contains more, leading it to treat a partial list as complete. This PR changes the response shape to a structured dict (`results`, `truncated`, `total_matched`) so agents can detect truncation and refine their query. The tool description in `tools/list` is also updated to document the cap.

## Implementation walkthrough

### New / modified functions

**`CallGraphIndex.search(substring, limit=50)` in `src/pyscope_mcp/graph.py`** — previously returned `list[str]` (matching FQNs sliced to `limit`). Now returns `dict` with three keys:
- `results`: the capped list of matching FQNs (same as before, now nested)
- `truncated`: `True` when the full match count exceeds `limit`, `False` otherwise
- `total_matched`: integer count of all matches before the cap is applied

The implementation collects all matches into `all_matches` first (one pass), then derives both `total_matched` and the sliced `results` from that list. This avoids a second iteration while keeping the logic transparent.

**`_TOOL_LIST["search"]["description"]` in `src/pyscope_mcp/server.py`** — extended to read: *"Results are capped at 50; use a more specific query if `truncated` is true. Returns {results: [...], truncated: bool, total_matched: int}."* No change to the dispatch logic in `_dispatch_tool` — `idx.search(...)` already returns the dict, and `_text()` serialises it as-is.

### Default execution path

**Before**: `agent calls search("run")` → `CallGraphIndex.search` collects matches, slices to 50, returns `["fqn1", ..., "fqn50"]` → agent sees 50 results, cannot distinguish "50 results exist" from "exactly 50 results were found".

**After**: `agent calls search("run")` → `CallGraphIndex.search` collects all matches, returns `{"results": [...50...], "truncated": true, "total_matched": 147}` → agent sees `truncated: true` and knows to narrow its query before relying on the list.

### Edge cases and error handling

- When `total_matched == limit` exactly, `truncated` is `False` (the condition is `total > limit`, not `>=`). This is intentional: an exact hit at the cap is not truncated.
- `limit=0` is not guarded against by this change (the existing schema sets no minimum). The behaviour is that all matches are truncated and `total_matched` reflects the real count — consistent with the general contract.
- The `total_matched` and `truncated` fields are always present (not conditional on the truncated state), so callers can rely on them unconditionally.

### What was intentionally not changed

The `limit` parameter default (50) is unchanged. The JSON-RPC dispatch layer in `_dispatch_tool` passes the return value of `idx.search()` directly to `_text()`, which JSON-serialises it — no changes needed there. The `_rpc.py` transport is not touched.

## Tier / approach

Tier 1 — Planner → Coder (single wave)

## Acceptance criteria

- [x] When `len(matches) > cap`, response includes `"truncated": true`
- [x] When `len(matches) <= cap`, `"truncated"` is `false`
- [x] `total_matched` is the count of all matches before capping
- [x] Tool description updated to document the cap and the flag
- [x] Tests added for the truncated-response shape (3 new tests; 435 total pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)