### PR TITLE
fix(#43): prefix-match semantics for module_callers and module_callees

### DIFF
--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -154,11 +154,25 @@ class CallGraphIndex:
     def callees_of(self, fqn: str, depth: int = 1) -> list[str]:
         return _bfs(self.function_graph, fqn, depth)
 
-    def module_callers(self, module: str, depth: int = 1) -> list[str]:
-        return _bfs(self.module_graph.reverse(copy=False), module, depth)
+    def module_callers(self, module: str, depth: int = 1) -> dict[str, object]:
+        """Return callers of all modules whose FQN starts with *module* (prefix query).
 
-    def module_callees(self, module: str, depth: int = 1) -> list[str]:
-        return _bfs(self.module_graph, module, depth)
+        An exact FQN is a degenerate prefix and behaves identically to the
+        pre-change implementation.  Results are capped at 50 items; the
+        ``truncated`` key in the returned dict signals when the cap triggers.
+        An empty-string prefix matches all modules.  A prefix that matches no
+        module nodes returns ``{"results": [], "truncated": false}``.
+        """
+        return _prefix_module_bfs(
+            self.module_graph.reverse(copy=False), self.module_graph, module, depth
+        )
+
+    def module_callees(self, module: str, depth: int = 1) -> dict[str, object]:
+        """Return callees of all modules whose FQN starts with *module* (prefix query).
+
+        Symmetric to :meth:`module_callers` — see its docstring for semantics.
+        """
+        return _prefix_module_bfs(self.module_graph, self.module_graph, module, depth)
 
     def search(self, substring: str, limit: int = 50) -> dict[str, object]:
         """Substring search over known fully-qualified function names.
@@ -186,8 +200,46 @@ class CallGraphIndex:
         }
 
 
+_MODULE_BFS_CAP = 50
+
+
 def _module_of(fqn: str) -> str:
     return fqn.rsplit(".", 1)[0] if "." in fqn else fqn
+
+
+def _prefix_module_bfs(
+    query_graph: _DiGraph | _DiGraphReverseView,
+    node_graph: _DiGraph,
+    prefix: str,
+    depth: int,
+    cap: int = _MODULE_BFS_CAP,
+) -> dict[str, object]:
+    """BFS over *query_graph* for all nodes in *node_graph* whose FQN starts with *prefix*.
+
+    Results from each matched seed node are unioned and deduplicated.  The matched
+    seed nodes themselves are excluded from the result set (same semantics as _bfs).
+    Results are capped at *cap*; ``truncated`` reflects whether the full union
+    exceeded the cap.
+
+    ``prefix=""`` matches all module nodes.
+    """
+    # Collect all module nodes that start with the given prefix
+    matched_seeds = [n for n in node_graph.nodes if n.startswith(prefix)]
+
+    # Union BFS results across all matched seeds, excluding the seeds themselves
+    seed_set = set(matched_seeds)
+    union: set[str] = set()
+    for seed in matched_seeds:
+        for node in _bfs(query_graph, seed, depth):
+            if node not in seed_set:
+                union.add(node)
+
+    results_all = sorted(union)
+    truncated = len(results_all) > cap
+    return {
+        "results": results_all[:cap],
+        "truncated": truncated,
+    }
 
 
 def _bfs(g: _DiGraph | _DiGraphReverseView, start: str, depth: int) -> list[str]:

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -93,11 +93,23 @@ _TOOL_LIST = [
     },
     {
         "name": "module_callers",
-        "description": "List modules that import/call into the given module.",
+        "description": (
+            "List modules that import/call into the given module or package prefix. "
+            "The `module` argument is treated as a dotted-prefix query: supply a full "
+            "FQN (e.g. `pkg.mod`) for an exact match, or a package prefix "
+            "(e.g. `pkg.agents`) to aggregate callers across all matching modules. "
+            "An empty string matches all modules. "
+            "Results are capped at 50 and deduplicated; when the cap triggers, "
+            "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
+            "Returns {results: [...], truncated: bool}."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "module": {"type": "string"},
+                "module": {
+                    "type": "string",
+                    "description": "Dotted module prefix or exact FQN, e.g. 'pkg.agents' or 'pkg.agents.writer'",
+                },
                 "depth": {"type": "integer", "minimum": 1, "maximum": 10, "default": 1},
             },
             "required": ["module"],
@@ -106,11 +118,23 @@ _TOOL_LIST = [
     },
     {
         "name": "module_callees",
-        "description": "List modules that the given module imports/calls into.",
+        "description": (
+            "List modules that the given module or package prefix imports/calls into. "
+            "The `module` argument is treated as a dotted-prefix query: supply a full "
+            "FQN (e.g. `pkg.mod`) for an exact match, or a package prefix "
+            "(e.g. `pkg.agents`) to aggregate callees across all matching modules. "
+            "An empty string matches all modules. "
+            "Results are capped at 50 and deduplicated; when the cap triggers, "
+            "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
+            "Returns {results: [...], truncated: bool}."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "module": {"type": "string"},
+                "module": {
+                    "type": "string",
+                    "description": "Dotted module prefix or exact FQN, e.g. 'pkg.agents' or 'pkg.agents.writer'",
+                },
                 "depth": {"type": "integer", "minimum": 1, "maximum": 10, "default": 1},
             },
             "required": ["module"],
@@ -229,13 +253,13 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
 
     if name == "module_callers":
         module = arguments.get("module")
-        if not module:
+        if module is None:
             return _error_result("module_callers requires 'module'")
         return _text(idx.module_callers(module, int(arguments.get("depth", 1))))
 
     if name == "module_callees":
         module = arguments.get("module")
-        if not module:
+        if module is None:
             return _error_result("module_callees requires 'module'")
         return _text(idx.module_callees(module, int(arguments.get("depth", 1))))
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -42,6 +42,120 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     assert loaded.search("helper") == idx.search("helper")
 
 
+def _prefix_raw() -> dict[str, list[str]]:
+    """Raw data for prefix-match tests.
+
+    Module graph derived from this:
+      pkg.agents.writer  →  pkg.io.disk
+      pkg.agents.reader  →  pkg.io.network
+      pkg.core           →  pkg.agents.writer, pkg.agents.reader
+    """
+    return {
+        "pkg.agents.writer.write": ["pkg.io.disk.save"],
+        "pkg.agents.reader.read": ["pkg.io.network.fetch"],
+        "pkg.core.run": ["pkg.agents.writer.write", "pkg.agents.reader.read"],
+        "pkg.io.disk.save": [],
+        "pkg.io.network.fetch": [],
+    }
+
+
+def test_module_callers_prefix_match() -> None:
+    """module_callers with a prefix returns callers of all matched modules."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callers("pkg.agents")
+    assert result["truncated"] is False
+    # pkg.core calls into pkg.agents.writer and pkg.agents.reader
+    assert "pkg.core" in result["results"]
+    # The matched seeds themselves must NOT appear in results
+    assert "pkg.agents.writer" not in result["results"]
+    assert "pkg.agents.reader" not in result["results"]
+
+
+def test_module_callees_prefix_match() -> None:
+    """module_callees with a prefix returns callees of all matched modules."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callees("pkg.agents")
+    assert result["truncated"] is False
+    # pkg.agents.writer calls pkg.io.disk; pkg.agents.reader calls pkg.io.network
+    assert "pkg.io.disk" in result["results"]
+    assert "pkg.io.network" in result["results"]
+
+
+def test_module_callers_exact_match_backward_compat() -> None:
+    """An exact FQN returns the same callers as before, now in structured form."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callers("pkg.agents.writer")
+    assert isinstance(result, dict)
+    assert "results" in result
+    assert "truncated" in result
+    assert result["truncated"] is False
+    assert "pkg.core" in result["results"]
+
+
+def test_module_callers_no_match() -> None:
+    """A prefix matching no module nodes returns empty results, no error."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callers("nonexistent.pkg")
+    assert result == {"results": [], "truncated": False}
+
+
+def test_module_callees_no_match() -> None:
+    """A prefix matching no module nodes returns empty results, no error."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callees("nonexistent.pkg")
+    assert result == {"results": [], "truncated": False}
+
+
+def test_module_callers_empty_prefix() -> None:
+    """Empty-string prefix matches all modules; returns structured dict with no error."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callers("")
+    # All modules are seeds — callers within the same set are excluded.
+    # The important invariants are shape and no error.
+    assert isinstance(result, dict)
+    assert "results" in result
+    assert "truncated" in result
+    assert isinstance(result["results"], list)
+    assert isinstance(result["truncated"], bool)
+
+
+def test_module_callees_empty_prefix() -> None:
+    """Empty-string prefix matches all modules; returns structured dict with no error."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callees("")
+    assert isinstance(result, dict)
+    assert "results" in result
+    assert "truncated" in result
+    assert isinstance(result["results"], list)
+    assert isinstance(result["truncated"], bool)
+
+
+def test_module_callers_truncation() -> None:
+    """When more than 50 distinct callers exist, truncated=True and len==50."""
+    # Build a graph where one "target" module has 60 distinct callers
+    raw: dict[str, list[str]] = {}
+    for i in range(60):
+        raw[f"callers.mod{i}.fn"] = [f"target.core.fn"]
+    raw["target.core.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.module_callers("target")
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+
+
+def test_module_callees_truncation() -> None:
+    """When more than 50 distinct callees exist, truncated=True and len==50."""
+    raw: dict[str, list[str]] = {
+        "source.mod.fn": [f"target.mod{i}.fn" for i in range(60)]
+    }
+    for i in range(60):
+        raw[f"target.mod{i}.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.module_callees("source")
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+
+
 def test_search_truncation() -> None:
     """When matches exceed the cap, truncated=True and total_matched reflects the full count."""
     # Build a raw graph with 5 symbols all containing "fn"

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -236,6 +236,11 @@ async def test_tool_module_callers(server: RpcServer):
     responses = await _run(server, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "results" in payload
+    assert "truncated" in payload
+    assert isinstance(payload["results"], list)
+    assert isinstance(payload["truncated"], bool)
 
 
 @pytest.mark.asyncio
@@ -244,6 +249,75 @@ async def test_tool_module_callees(server: RpcServer):
     responses = await _run(server, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "results" in payload
+    assert "truncated" in payload
+    assert isinstance(payload["results"], list)
+    assert isinstance(payload["truncated"], bool)
+
+
+@pytest.mark.asyncio
+async def test_tool_module_callers_prefix(server: RpcServer):
+    """module_callers with a package prefix returns aggregated callers as {results, truncated}."""
+    # The fixture has: pkg.mod.foo, pkg.mod.bar, pkg.other.baz
+    # pkg.other calls into pkg.mod (pkg.other.baz → pkg.mod.foo)
+    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "pkg.mod"}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "pkg.other" in payload["results"]
+
+
+@pytest.mark.asyncio
+async def test_tool_module_callees_prefix(server: RpcServer):
+    """module_callees with a package prefix returns aggregated callees as {results, truncated}."""
+    lines = [_req("tools/call", {"name": "module_callees", "arguments": {"module": "pkg.other"}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "pkg.mod" in payload["results"]
+
+
+@pytest.mark.asyncio
+async def test_tool_module_callers_empty_prefix(server: RpcServer):
+    """Empty-string prefix is valid — matches all modules; payload has truncated key."""
+    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": ""}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "results" in payload
+    assert "truncated" in payload
+
+
+@pytest.mark.asyncio
+async def test_tool_module_callers_no_match(server: RpcServer):
+    """A prefix matching no module returns {results: [], truncated: false} — no error."""
+    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "does.not.exist"}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert payload["results"] == []
+    assert payload["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_tool_descriptions_mention_prefix(server: RpcServer):
+    """module_callers and module_callees tool descriptions document prefix semantics."""
+    lines = [_req("tools/list", req_id=1)]
+    responses = await _run(server, lines)
+    tools = {t["name"]: t for t in responses[0]["result"]["tools"]}
+
+    mc_desc = tools["module_callers"]["description"]
+    mce_desc = tools["module_callees"]["description"]
+
+    assert "prefix" in mc_desc.lower(), "module_callers description must mention 'prefix'"
+    assert "truncated" in mc_desc.lower(), "module_callers description must mention truncation"
+    assert "prefix" in mce_desc.lower(), "module_callees description must mention 'prefix'"
+    assert "truncated" in mce_desc.lower(), "module_callees description must mention truncation"
 
 
 @pytest.mark.asyncio
@@ -928,11 +1002,12 @@ async def test_notification_handler_raises_silent(server: RpcServer):
 @pytest.mark.parametrize(
     "name,arguments,expect_error",
     [
-        # Wrong-type fqn / module: truthy values that aren't in the graph.
+        # Wrong-type fqn: truthy values that aren't in the graph.
         # _bfs handles unknown starts gracefully → empty list, isError:false.
         ("callers_of",     {"fqn": 123},                             False),
         ("callees_of",     {"fqn": 123},                             False),
-        ("module_callers", {"module": True},                         False),
+        # Non-string module: str.startswith raises TypeError → isError:true.
+        ("module_callers", {"module": True},                         True),
         # List-typed module: unhashable → TypeError on dict lookup → isError:true.
         ("module_callees", {"module": ["pkg", "mod"]},               True),
         # Non-string query: `.lower()` on dict raises AttributeError → isError:true.


### PR DESCRIPTION
Closes #43

## What changed

`module_callers` and `module_callees` previously required an exact module FQN (e.g. `video_agent_long.tools.orchestrator.dispatch`) — querying a package prefix like `video_agent_long.agents` returned nothing because no node lived at that exact path. This PR makes both tools treat their `module` argument as a dotted-prefix query, aggregating and deduplicating results across all matching module nodes, capped at 50 with an explicit truncation signal in the response payload. An exact FQN remains a valid (degenerate) prefix, so behavior is backward-compatible in terms of results, though the return type changes from a plain list to `{results: [...], truncated: bool}`.

## Implementation walkthrough

### New / modified functions

**`CallGraphIndex.module_callers(module, depth)` in `src/pyscope_mcp/graph.py`** — Changed return type from `list[str]` to `dict[str, object]` (`{results: list[str], truncated: bool}`). Now delegates to `_prefix_module_bfs` instead of `_bfs`. The `module` argument is treated as a `str.startswith()` prefix against all module nodes. An exact FQN matches exactly one node (itself), preserving backward-compatible query semantics while changing the response shape uniformly.

**`CallGraphIndex.module_callees(module, depth)` in `src/pyscope_mcp/graph.py`** — Symmetric change to `module_callers`. Both methods now document their prefix semantics in their docstrings.

**`_prefix_module_bfs(query_graph, node_graph, prefix, depth, cap)` in `src/pyscope_mcp/graph.py`** — New internal helper. Collects all module nodes from `node_graph` whose FQN starts with `prefix`, runs `_bfs` from each matched seed node in `query_graph`, unions and deduplicates the results (excluding the seed nodes themselves), sorts alphabetically, and caps at `cap` (default 50). Returns `{"results": ..., "truncated": bool}`. The existing `_bfs` function is unchanged.

**`_dispatch_tool` — module_callers and module_callees branches in `src/pyscope_mcp/server.py`** — The `if not module` guard was changed to `if module is None`. Previously an empty string would trigger `isError: true`; now it is valid input (matches all modules). The structured return value from `module_callers`/`module_callees` passes through `_text()` unchanged.

**Tool descriptors in `src/pyscope_mcp/server.py` (`_TOOL_LIST`)** — Both `module_callers` and `module_callees` descriptions updated to document dotted-prefix input, the 50-item cap, the truncation signal, and the `{results, truncated}` return shape. The `module` parameter description was extended with examples.

### How components interact

```
tools/call {name: "module_callers", arguments: {module: "pkg.agents"}}
  └─► _dispatch_tool("module_callers", {"module": "pkg.agents"})
        └─► idx.module_callers("pkg.agents", depth=1)
              └─► _prefix_module_bfs(reversed_module_graph, module_graph, "pkg.agents", 1)
                    ├─ collect seeds: [n for n in module_graph.nodes if n.startswith("pkg.agents")]
                    ├─ for each seed: _bfs(reversed_module_graph, seed, 1)
                    ├─ union results, exclude seeds
                    ├─ sort, cap at 50
                    └─ return {"results": [...], "truncated": bool}
        └─► _text({"results": [...], "truncated": bool})
              └─► {"content": [{"type": "text", "text": "<json>"}], "isError": false}
```

### Default execution path

**Before**: `module_callers("pkg.agents")` → `_bfs(reversed_module_graph, "pkg.agents", 1)` → checks if `"pkg.agents"` is a node → it isn't (leaf modules are nodes, not packages) → returns `[]`. Agent receives an empty list with no path forward.

**After**: `module_callers("pkg.agents")` → `_prefix_module_bfs(...)` → finds all nodes starting with `"pkg.agents"` → runs BFS from each → unions callers → returns `{"results": ["pkg.core", ...], "truncated": false}`. Agent can navigate the call graph from a known package prefix without a prior discovery step.

### Edge cases and error handling

- **Empty string prefix**: valid — matches all module nodes. Result is the union of callers/callees across all modules, capped at 50. Since all nodes are seeds, only cross-module edges produce results.
- **No-match prefix**: returns `{"results": [], "truncated": false}` — no error raised, consistent with `_bfs` returning `[]` for unknown starts.
- **Non-string `module`**: `str.startswith()` raises `TypeError` for non-string arguments → caught by `_tools_call` exception handler → `isError: true` result (was previously silent degradation for some types).
- **Truncation at exactly 50**: `truncated` is `len(all_results) > cap` — so 50 results with 50 matches is `truncated: false`; 51 matches → `truncated: true, results[:50]`.

### What was intentionally not changed

Per the refined spec, `callers_of` and `callees_of` (function-level tools) do not get prefix matching. `_bfs` itself is unchanged. No new `module_search` tool was added (Option A explicitly rejected in the issue comments). The `depth` parameter continues to control BFS hop depth on each matched seed node individually.

## Tier / approach

Tier 1 — Planner → Coder (single wave, single agent)

## Acceptance criteria

- [x] `module_callers("pkg.agents")` returns non-empty when modules starting with "pkg.agents" exist
- [x] `module_callees("pkg.agents")` returns non-empty when modules starting with "pkg.agents" exist
- [x] Results capped at 50; `truncated: true` when cap triggered
- [x] Exact FQN works identically (backward compat) — shape is now `{results: [...], truncated: bool}`
- [x] Empty prefix (`""`) returns structured dict with no error
- [x] No-match prefix returns `{"results": [], "truncated": false}` — no error
- [x] Server dispatch passes structured return through `_text()` unchanged
- [x] Tool descriptions updated to document prefix semantics and truncation
- [x] Tests added: prefix query, exact match (shape check), empty prefix, no-match prefix, truncation at 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)