### PR TITLE
feat(#44): file_skeleton tool — symbols + signatures for a given file

### DIFF
--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -26,11 +26,106 @@ def _warn(msg: str) -> None:
     print(f"[pyscope-mcp] {msg}", file=sys.stderr)
 
 
+def _extract_skeletons(
+    root: Path,
+    parsed: list[tuple[str, ast.Module, Path, dict[str, str]]],
+) -> dict[str, list[dict]]:
+    """Extract symbol skeletons (fqn, kind, signature, lineno) from parsed ASTs.
+
+    Skeleton data is keyed by file path relative to ``root``.  Each entry is a
+    list of SymbolSummary-compatible dicts sorted by lineno.
+
+    Only top-level functions, top-level classes, and methods (functions defined
+    directly inside a class body) are included.  Nested functions inside other
+    functions are excluded — they are not part of the public structural surface.
+
+    The ``signature`` field is the first ``def`` or ``class`` line only — no body.
+    """
+    skeletons: dict[str, list[dict]] = {}
+    for module_fqn, tree, file_path, _import_table in parsed:
+        try:
+            rel = str(file_path.relative_to(root))
+        except ValueError:
+            rel = str(file_path)
+
+        symbols: list[dict] = []
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            # Only process top-level nodes and methods (depth == 1 inside a class)
+            # We iterate ast.walk which is unordered; we need explicit parent traversal.
+            break  # exit early — we do explicit traversal below
+
+        # Explicit two-level traversal: top-level defs + class bodies
+        for top_node in ast.iter_child_nodes(tree):
+            if isinstance(top_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                name = top_node.name
+                fqn = f"{module_fqn}.{name}"
+                sig = _first_def_line(top_node)
+                symbols.append({
+                    "fqn": fqn,
+                    "kind": "function",
+                    "signature": sig,
+                    "lineno": top_node.lineno,
+                })
+            elif isinstance(top_node, ast.ClassDef):
+                cls_name = top_node.name
+                cls_fqn = f"{module_fqn}.{cls_name}"
+                symbols.append({
+                    "fqn": cls_fqn,
+                    "kind": "class",
+                    "signature": _first_def_line(top_node),
+                    "lineno": top_node.lineno,
+                })
+                # Methods inside the class body (one level deep)
+                for class_node in ast.iter_child_nodes(top_node):
+                    if isinstance(class_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        method_name = class_node.name
+                        method_fqn = f"{cls_fqn}.{method_name}"
+                        symbols.append({
+                            "fqn": method_fqn,
+                            "kind": "method",
+                            "signature": _first_def_line(class_node),
+                            "lineno": class_node.lineno,
+                        })
+
+        symbols.sort(key=lambda s: s["lineno"])
+        skeletons[rel] = symbols
+
+    return skeletons
+
+
+def _first_def_line(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> str:
+    """Return the first line of the def/class statement as a signature string.
+
+    We reconstruct from the AST rather than slicing source lines so that the
+    pipeline stays stateless (no need to pass raw source strings around).
+    The result is ``def name(args...):`` or ``class Name(bases...):`` — no body.
+    """
+    if isinstance(node, ast.ClassDef):
+        bases = ", ".join(ast.unparse(b) for b in node.bases)
+        base_str = f"({bases})" if bases else ""
+        return f"class {node.name}{base_str}:"
+
+    # FunctionDef / AsyncFunctionDef
+    prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+    args_str = ast.unparse(node.args)
+    ret = ""
+    if node.returns is not None:
+        ret = f" -> {ast.unparse(node.returns)}"
+    return f"{prefix} {node.name}({args_str}){ret}:"
+
+
 def build_with_report(
     root: str | Path,
     package: str,
-) -> tuple[dict[str, list[str]], dict]:
-    """Pass 1 + pass 2 with MissLog. Returns (raw_edges, miss_report_dict)."""
+) -> tuple[dict[str, list[str]], dict, dict[str, list[dict]]]:
+    """Pass 1 + pass 2 with MissLog. Returns (raw_edges, miss_report_dict, skeletons).
+
+    ``skeletons`` maps relative file paths to pre-computed symbol lists suitable
+    for storage in the index under the ``skeletons`` key (version 2 schema).
+    """
     root = Path(root)
     pkg_root = root / package if (root / package).is_dir() else root
 
@@ -111,7 +206,8 @@ def build_with_report(
 
     raw = {caller: sorted(callees) for caller, callees in sorted(all_edges.items())}
     report = miss_log.to_dict(raw, known_fqns)
-    return raw, report
+    skeletons = _extract_skeletons(root, parsed)
+    return raw, report, skeletons
 
 
 def build_raw(root: str | Path, package: str) -> dict[str, list[str]]:
@@ -119,5 +215,5 @@ def build_raw(root: str | Path, package: str) -> dict[str, list[str]]:
 
     Returns just the raw edge dict (public contract, unchanged).
     """
-    raw, _report = build_with_report(root, package)
+    raw, _report, _skeletons = build_with_report(root, package)
     return raw

--- a/src/pyscope_mcp/cli.py
+++ b/src/pyscope_mcp/cli.py
@@ -60,8 +60,8 @@ def cmd_build(args: argparse.Namespace) -> int:
     print(f"[pyscope-mcp] building index: root={root} package={package or root.name}", file=sys.stderr)
     from pyscope_mcp.analyzer import build_with_report
 
-    raw, miss_report = build_with_report(root, package=package or root.name)
-    idx = CallGraphIndex.from_raw(root, raw)
+    raw, miss_report, skeletons = build_with_report(root, package=package or root.name)
+    idx = CallGraphIndex.from_raw(root, raw, skeletons=skeletons)
     idx.save(out)
 
     # Write misses sidecar next to index.json

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TypedDict
+
+
+class SymbolSummary(TypedDict):
+    fqn: str
+    kind: str  # "function" | "class" | "method"
+    signature: str
+    lineno: int
+
+
+_SKELETON_CAP = 50
 
 
 class _DiGraph:
@@ -106,15 +117,24 @@ class CallGraphIndex:
     Graphs are derived from `raw` on construction and on `load`. The backend
     that populates `raw` from source code lives in pyscope_mcp.analyzer
     (not yet implemented — see CLAUDE.md for the rewrite plan).
+
+    ``skeletons`` maps relative file paths → pre-computed lists of SymbolSummary
+    dicts, populated during ``pyscope-mcp build`` (index version 2+).
     """
 
     root: Path
     function_graph: _DiGraph = field(default_factory=_DiGraph)
     module_graph: _DiGraph = field(default_factory=_DiGraph)
     raw: dict[str, list[str]] = field(default_factory=dict)
+    skeletons: dict[str, list[SymbolSummary]] = field(default_factory=dict)
 
     @classmethod
-    def from_raw(cls, root: str | Path, raw: dict[str, list[str]]) -> "CallGraphIndex":
+    def from_raw(
+        cls,
+        root: str | Path,
+        raw: dict[str, list[str]],
+        skeletons: dict[str, list[SymbolSummary]] | None = None,
+    ) -> "CallGraphIndex":
         root = Path(root).resolve()
         fg = _DiGraph()
         mg = _DiGraph()
@@ -127,15 +147,22 @@ class CallGraphIndex:
                 tm = _module_of(callee)
                 if cm != tm:
                     mg.add_edge(cm, tm)
-        return cls(root=root, function_graph=fg, module_graph=mg, raw=raw)
+        return cls(
+            root=root,
+            function_graph=fg,
+            module_graph=mg,
+            raw=raw,
+            skeletons=skeletons or {},
+        )
 
     def save(self, path: str | Path) -> Path:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "version": 1,
+        payload: dict = {
+            "version": 2,
             "root": str(self.root),
             "raw": self.raw,
+            "skeletons": self.skeletons,
         }
         path.write_text(json.dumps(payload))
         return path
@@ -144,9 +171,38 @@ class CallGraphIndex:
     def load(cls, path: str | Path) -> "CallGraphIndex":
         path = Path(path)
         payload = json.loads(path.read_text())
-        if payload.get("version") != 1:
-            raise ValueError(f"unsupported index version: {payload.get('version')}")
-        return cls.from_raw(Path(payload["root"]), payload["raw"])
+        version = payload.get("version")
+        if version not in (1, 2):
+            raise ValueError(f"unsupported index version: {version}")
+        skeletons: dict[str, list[SymbolSummary]] = payload.get("skeletons", {})
+        return cls.from_raw(Path(payload["root"]), payload["raw"], skeletons=skeletons)
+
+    def file_skeleton(self, path: str, cap: int = _SKELETON_CAP) -> dict:
+        """Return a compact symbol list for the given relative file path.
+
+        Returns a dict with:
+          - ``results``: list of SymbolSummary dicts sorted by lineno (capped at *cap*)
+          - ``truncated``: True when the full symbol count exceeds *cap*
+          - ``total``: total number of symbols before capping
+
+        If the path is not in the index, returns an error dict with ``isError: True``.
+        """
+        if path not in self.skeletons:
+            return {
+                "isError": True,
+                "message": (
+                    f"File '{path}' is not in the index. "
+                    "Run 'pyscope-mcp build' and then 'reload' to update the index."
+                ),
+            }
+        symbols = self.skeletons[path]
+        total = len(symbols)
+        truncated = total > cap
+        return {
+            "results": symbols[:cap],
+            "truncated": truncated,
+            "total": total,
+        }
 
     def callers_of(self, fqn: str, depth: int = 1) -> list[str]:
         return _bfs(self.function_graph.reverse(copy=False), fqn, depth)

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -158,6 +158,31 @@ _TOOL_LIST = [
         },
         "annotations": {"readOnlyHint": True, "idempotentHint": True},
     },
+    {
+        "name": "file_skeleton",
+        "description": (
+            "Return all top-level functions, classes, and methods defined in the given file. "
+            "Input path must be relative to the repo root (e.g. 'agents/avatar_agent.py'). "
+            "Each symbol includes: fqn (fully-qualified name), kind (function|class|method), "
+            "signature (first def-line only, no body), and lineno. "
+            "Results are sorted by lineno and capped at 50; when the cap triggers, "
+            "`truncated` is true and `total` holds the full count. "
+            "If the file was added after the last build, returns isError:true — run "
+            "'pyscope-mcp build' then 'reload'. "
+            "Returns {results: [...], truncated: bool, total: int} or {isError: true, message: str}."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path relative to the repo root, e.g. 'agents/avatar_agent.py'",
+                },
+            },
+            "required": ["path"],
+        },
+        "annotations": {"readOnlyHint": True, "idempotentHint": True},
+    },
 ]
 
 _TOOL_NAMES = {t["name"] for t in _TOOL_LIST}
@@ -268,6 +293,15 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
         if query is None:
             return _error_result("search requires 'query'")
         return _text(idx.search(query, int(arguments.get("limit", 50))))
+
+    if name == "file_skeleton":
+        path = arguments.get("path")
+        if not path:
+            return _error_result("file_skeleton requires 'path'")
+        result = idx.file_skeleton(path)
+        if result.get("isError"):
+            return {"content": [{"type": "text", "text": result["message"]}], "isError": True}
+        return _text(result)
 
     # Should never reach here — guarded by _TOOL_NAMES check above
     return _error_result(f"unknown tool: {name!r}")

--- a/tests/test_analyzer_alias_stdlib.py
+++ b/tests/test_analyzer_alias_stdlib.py
@@ -50,7 +50,7 @@ def test_import_alias_sys_exit_is_not_attr_chain_unresolved(tmp_path: Path) -> N
             "    sys_module.exit(0)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     unresolved = report["pattern_counts"]
     assert "attr_chain_unresolved" not in unresolved or unresolved.get("attr_chain_unresolved", 0) == 0, (
         f"sys_module.exit(0) should not be attr_chain_unresolved; got {unresolved}"
@@ -69,7 +69,7 @@ def test_import_alias_os_path_join_is_not_attr_chain_unresolved(tmp_path: Path) 
             "    return op.join(x, y)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     unresolved = report["pattern_counts"]
     assert "attr_chain_unresolved" not in unresolved or unresolved.get("attr_chain_unresolved", 0) == 0, (
         f"op.join should not be attr_chain_unresolved; got {unresolved}"
@@ -88,7 +88,7 @@ def test_import_alias_json_loads_is_not_attr_chain_unresolved(tmp_path: Path) ->
             "    return j.loads(s)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     unresolved = report["pattern_counts"]
     assert "attr_chain_unresolved" not in unresolved or unresolved.get("attr_chain_unresolved", 0) == 0, (
         f"j.loads should not be attr_chain_unresolved; got {unresolved}"
@@ -113,7 +113,7 @@ def test_parameter_injection_sys_module_exit_is_accepted(tmp_path: Path) -> None
             "        sys_module.exit(2)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     accepted = report["summary"]["accepted_counts"]
     pattern_counts = report["pattern_counts"]
     assert accepted.get("stdlib_method_call", 0) >= 1, (
@@ -134,7 +134,7 @@ def test_parameter_injection_os_lib_is_accepted(tmp_path: Path) -> None:
             "    return os_lib.getcwd()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     accepted = report["summary"]["accepted_counts"]
     assert accepted.get("stdlib_method_call", 0) >= 1, (
         f"os_lib.getcwd() should be accepted as stdlib_method_call; accepted={accepted}"
@@ -155,7 +155,7 @@ def test_fp_guard_non_stdlib_stem_is_attr_chain_unresolved(tmp_path: Path) -> No
             "    myapp_module.exit()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     accepted = report["summary"]["accepted_counts"]
     pattern_counts = report["pattern_counts"]
     assert accepted.get("stdlib_method_call", 0) == 0, (

--- a/tests/test_analyzer_builtin_methods.py
+++ b/tests/test_analyzer_builtin_methods.py
@@ -176,7 +176,7 @@ def test_calls_total_invariant(tmp_path: Path) -> None:
             "    unknown_fn(x)     # unresolved bare_name\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     s = report["summary"]
     total = s["calls_total"]
     parts = (

--- a/tests/test_analyzer_dunder_new.py
+++ b/tests/test_analyzer_dunder_new.py
@@ -90,7 +90,7 @@ def test_dunder_new_bare_call_not_unresolved(tmp_path: Path) -> None:
             "    C.__new__(C)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
 
     # Should NOT appear in unresolved_calls
     unresolved_snippets = {e["snippet"] for e in report.get("unresolved_calls", [])}

--- a/tests/test_analyzer_external_factory.py
+++ b/tests/test_analyzer_external_factory.py
@@ -42,7 +42,7 @@ def test_httpx_client_post_accepted(tmp_path: Path) -> None:
             "    client.post(url, content=data)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("httpx_method_call", 0) >= 1, (
         f"Expected httpx_method_call in accepted, got: {summary['accepted_counts']}"
@@ -64,7 +64,7 @@ def test_httpx_async_client_get_accepted(tmp_path: Path) -> None:
             "    return resp\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("httpx_method_call", 0) >= 1
 
@@ -83,7 +83,7 @@ def test_boto3_client_put_object_accepted(tmp_path: Path) -> None:
             "    client.put_object(Bucket=bucket, Key=key, Body=body)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("boto3_method_call", 0) >= 1
     patterns = {e["pattern"] for e in report["unresolved_calls"]}
@@ -101,7 +101,7 @@ def test_boto3_client_head_object_accepted(tmp_path: Path) -> None:
             "    return True\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert report["summary"]["accepted_counts"].get("boto3_method_call", 0) >= 1
 
 
@@ -121,7 +121,7 @@ def test_boto3_paginator_paginate_accepted(tmp_path: Path) -> None:
             "        pass\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     # get_paginator itself is boto3_method_call; paginator.paginate is also boto3_method_call
     assert summary["accepted_counts"].get("boto3_method_call", 0) >= 2, (
@@ -144,7 +144,7 @@ def test_typer_command_accepted(tmp_path: Path) -> None:
             "    _cli.command()(lambda: None)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("typer_method_call", 0) >= 1
 
@@ -160,7 +160,7 @@ def test_typer_command_in_function_accepted(tmp_path: Path) -> None:
             "    return app\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert report["summary"]["accepted_counts"].get("typer_method_call", 0) >= 1
 
 
@@ -178,7 +178,7 @@ def test_googleapi_channels_list_accepted(tmp_path: Path) -> None:
             "    service.channels()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert report["summary"]["accepted_counts"].get("googleapi_method_call", 0) >= 1
 
 
@@ -198,7 +198,7 @@ def test_shadowed_local_not_accepted(tmp_path: Path) -> None:
             "    client.post('http://example.com')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # After shadow, client is int — should NOT be accepted as httpx_method_call.
     assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0, (
         "Shadowed local should not be accepted as httpx_method_call"
@@ -220,7 +220,7 @@ def test_non_whitelisted_factory_not_accepted(tmp_path: Path) -> None:
             "    client.post('http://example.com')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0
     assert report["summary"]["accepted_counts"].get("boto3_method_call", 0) == 0
     assert report["summary"]["accepted_counts"].get("typer_method_call", 0) == 0
@@ -239,7 +239,7 @@ def test_parameter_not_accepted(tmp_path: Path) -> None:
             "    client.post(url)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # No factory binding — should not be httpx_method_call accepted
     assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0
 
@@ -261,7 +261,7 @@ def test_inpackage_class_wins_over_whitelist(tmp_path: Path) -> None:
             "    c.post('http://example.com')\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
     # Resolved in-package, not accepted as httpx_method_call
     assert "pkg.mod.Client.post" in raw.get("pkg.mod.run", [])
     assert report["summary"]["accepted_counts"].get("httpx_method_call", 0) == 0

--- a/tests/test_analyzer_googleapi_chain.py
+++ b/tests/test_analyzer_googleapi_chain.py
@@ -45,7 +45,7 @@ def test_googleapi_three_segment_chain_accepted(tmp_path: Path) -> None:
             "    result = service.channels().list(part='snippet')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     # Both service.channels() (2-part, handled by existing path) and
     # service.channels().list(...) (3-part chain) should be accepted.
@@ -69,7 +69,7 @@ def test_googleapi_four_segment_chain_accepted(tmp_path: Path) -> None:
             "    service.channels().list(part='snippet').execute()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     # service.channels() → accepted (2-part, existing handler)
     # service.channels().list(...) → accepted (3-part, new handler)
@@ -94,7 +94,7 @@ def test_googleapi_videos_insert_chain_accepted(tmp_path: Path) -> None:
             "    youtube.videos().insert(part='snippet', body={}).execute()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("googleapi_method_call", 0) >= 3, (
         f"Expected >=3 googleapi_method_call; got: {summary['accepted_counts']}"
@@ -115,7 +115,7 @@ def test_googleapi_module_level_service_chain(tmp_path: Path) -> None:
             "    _service.channels().list(part='snippet').execute()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     # The inline chain calls (channels().list().execute()) should be accepted.
     assert summary["accepted_counts"].get("googleapi_method_call", 0) >= 1, (
@@ -139,7 +139,7 @@ def test_httpx_chain_not_self_returning(tmp_path: Path) -> None:
             "    client.post('http://example.com').raise_for_status()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # httpx.Client is NOT in EXTERNAL_SELF_RETURNING, so chain walker must not fire.
     # client.post(...) is still accepted via the 2-part handler.
     # client.post(...).raise_for_status() is an unknown chain — that's fine, it
@@ -170,7 +170,7 @@ def test_boto3_chain_not_self_returning(tmp_path: Path) -> None:
             "    client.put_object(Bucket='b', Key='k', Body=b'data').something()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     # Chain walker must not fire for boto3.client (not self-returning).
     # The googleapi bucket must remain at 0.
@@ -191,7 +191,7 @@ def test_unknown_root_var_not_accepted(tmp_path: Path) -> None:
             "    unknown_service.channels().list(part='snippet').execute()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert report["summary"]["accepted_counts"].get("googleapi_method_call", 0) == 0, (
         "Unknown root var should not produce googleapi_method_call"
     )
@@ -216,7 +216,7 @@ def test_inpackage_class_chain_not_intercepted(tmp_path: Path) -> None:
             "    svc.channels()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # svc.channels() should be resolved as an in-package call, not googleapi_method_call.
     assert report["summary"]["accepted_counts"].get("googleapi_method_call", 0) == 0
     # Verify it resolved in-package.
@@ -238,6 +238,6 @@ def test_self_root_chain_not_intercepted(tmp_path: Path) -> None:
             "        self._build().run()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # Must not accept via googleapi chain walker.
     assert report["summary"]["accepted_counts"].get("googleapi_method_call", 0) == 0

--- a/tests/test_analyzer_issue18_integration.py
+++ b/tests/test_analyzer_issue18_integration.py
@@ -76,7 +76,7 @@ def test_all_four_handlers_combined(tmp_path: Path) -> None:
             "        sys_mod.exit(code)\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
 
     # H2: agent.run() from union annotation
@@ -148,7 +148,7 @@ def test_h1_boto3_and_h2_union_no_false_positives(tmp_path: Path) -> None:
             "    s3.put_object(Bucket='b', Key='k', Body=b'v')\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
 
     # H2: worker.process() resolved in-package
     assert "pkg.worker.DataWorker.process" in raw.get("pkg.runner.run", []), (

--- a/tests/test_analyzer_local_var_builtin.py
+++ b/tests/test_analyzer_local_var_builtin.py
@@ -35,7 +35,7 @@ def test_local_var_ann_assign_dict_get_is_accepted(tmp_path: Path) -> None:
             "    return d.get('x')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
     assert report["pattern_counts"].get("attr_chain_unresolved", 0) == 0
 
@@ -53,7 +53,7 @@ def test_local_var_param_path_mkdir_is_accepted(tmp_path: Path) -> None:
             "    p.mkdir()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "pathlib_method_call") >= 1
     assert report["pattern_counts"].get("attr_chain_unresolved", 0) == 0
 
@@ -70,7 +70,7 @@ def test_local_var_dict_literal_assign_get_is_accepted(tmp_path: Path) -> None:
             "    return x.get('y')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
 
 
@@ -86,7 +86,7 @@ def test_local_var_list_literal_append_is_accepted(tmp_path: Path) -> None:
             "    items.append(1)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
 
 
@@ -104,7 +104,7 @@ def test_local_var_path_call_exists_is_accepted(tmp_path: Path) -> None:
             "    return p.exists()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "pathlib_method_call") >= 1
 
 
@@ -127,7 +127,7 @@ def test_fpg_factory_return_type_unknown_no_false_in_package_edge(tmp_path: Path
             "    return x.get('y')\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
     # No in-package callee should be emitted for x.get() — factory() does not
     # record a sentinel for x (it is an in-package Call, not a builtin literal/ctor).
     callees = raw.get("pkg.mod.f", [])
@@ -151,7 +151,7 @@ def test_fpg_for_loop_var_not_tracked_no_false_in_package_edge(tmp_path: Path) -
             "        p.mkdir()\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
     # f() emits no in-package edges — no callee of p.mkdir() should be in raw.
     callees = raw.get("pkg.mod.f", [])
     assert callees == [], f"Expected no in-package edges from f, got: {callees}"

--- a/tests/test_analyzer_m5.py
+++ b/tests/test_analyzer_m5.py
@@ -53,7 +53,7 @@ def test_build_with_report_structure(tmp_path):
             foo()
     """)
 
-    raw, report = build_with_report(root, "mypkg")
+    raw, report, _skeletons = build_with_report(root, "mypkg")
 
     # Top-level keys
     for key in ("version", "summary", "skipped_files", "unresolved_calls", "pattern_counts"):
@@ -93,7 +93,7 @@ def test_resolved_in_package_counted(tmp_path):
             utils.helper()
     """)
 
-    _raw, report = build_with_report(root, "mypkg")
+    _raw, report, _skeletons = build_with_report(root, "mypkg")
     assert report["summary"]["calls_resolved_in_package"] >= 1
 
 
@@ -109,7 +109,7 @@ def test_external_call_counted(tmp_path):
             os.path.join("a", "b")
     """)
 
-    _raw, report = build_with_report(root, "mypkg")
+    _raw, report, _skeletons = build_with_report(root, "mypkg")
     # External tracking is implemented; if calls are counted it should be >= 1.
     # If somehow the call falls through as unresolved, >= 0 is a safe floor.
     assert report["summary"]["calls_resolved_external"] >= 0
@@ -126,7 +126,7 @@ def test_unresolved_call_counted(tmp_path):
             mystery_function()
     """)
 
-    _raw, report = build_with_report(root, "mypkg")
+    _raw, report, _skeletons = build_with_report(root, "mypkg")
     assert report["summary"]["calls_unresolved"] >= 1
     assert report["pattern_counts"].get("bare_name_unresolved", 0) >= 1
 
@@ -144,7 +144,7 @@ def test_skipped_file_recorded(tmp_path):
     # Intentional SyntaxError
     _write(root / "mypkg" / "broken.py", "def bad(:\n    pass\n")
 
-    _raw, report = build_with_report(root, "mypkg")
+    _raw, report, _skeletons = build_with_report(root, "mypkg")
     assert report["summary"]["files_skipped"] == 1
     assert len(report["skipped_files"]) == 1
     entry = report["skipped_files"][0]
@@ -165,7 +165,7 @@ def test_dead_keys_rollup(tmp_path):
             orphan()
     """)
 
-    _raw, report = build_with_report(root, "mypkg")
+    _raw, report, _skeletons = build_with_report(root, "mypkg")
     dead = report["summary"]["rollups"]["dead_keys"]
     # orphan() is called by caller, so it is NOT a dead key.
     # caller() calls orphan but is not called by anyone — it IS a dead key.
@@ -186,7 +186,7 @@ def test_exemplar_cap(tmp_path):
         lines.append(f"    unknown_{i}()")
     _write(root / "mypkg" / "mod.py", "\n".join(lines))
 
-    _raw, report = build_with_report(root, "mypkg")
+    _raw, report, _skeletons = build_with_report(root, "mypkg")
 
     total_count = report["pattern_counts"].get("bare_name_unresolved", 0)
     assert total_count >= 60, f"expected >= 60 unresolved bare-name calls, got {total_count}"
@@ -218,8 +218,8 @@ def test_determinism_with_report(tmp_path):
             unknown_fn()
     """)
 
-    raw1, report1 = build_with_report(root, "mypkg")
-    raw2, report2 = build_with_report(root, "mypkg")
+    raw1, report1, _sk1 = build_with_report(root, "mypkg")
+    raw2, report2, _sk2 = build_with_report(root, "mypkg")
 
     assert raw1 == raw2
     assert report1["summary"] == report2["summary"]

--- a/tests/test_analyzer_m7_external_whitelist.py
+++ b/tests/test_analyzer_m7_external_whitelist.py
@@ -155,7 +155,7 @@ def test_pathlib_method_in_accepted_counts(tmp_path: Path) -> None:
             "    return cfg.read_text(encoding='utf-8')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("pathlib_method_call", 0) >= 1
     patterns = {e["pattern"] for e in report["unresolved_calls"]}
@@ -171,7 +171,7 @@ def test_futures_method_in_accepted_counts(tmp_path: Path) -> None:
             "    return fut.result(timeout=10)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("futures_method_call", 0) >= 1
     patterns = {e["pattern"] for e in report["unresolved_calls"]}
@@ -191,7 +191,7 @@ def test_pydantic_super_init_routed_to_accepted(tmp_path: Path) -> None:
             "        super().__init__(**data)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("pydantic_method_call", 0) >= 1
     # super_unresolved for the BaseModel subclass init should not be recorded.
@@ -213,7 +213,7 @@ def test_pydantic_super_init_transitive_base(tmp_path: Path) -> None:
             "        super().__init__(**data)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("pydantic_method_call", 0) >= 1
 
@@ -227,7 +227,7 @@ def test_non_pydantic_super_init_stays_super_unresolved(tmp_path: Path) -> None:
             "        super().__init__()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert report["summary"]["accepted_counts"].get("pydantic_method_call", 0) == 0
 
 
@@ -243,7 +243,7 @@ def test_pydantic_method_in_accepted_counts(tmp_path: Path) -> None:
             "    return cfg.model_dump()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     summary = report["summary"]
     assert summary["accepted_counts"].get("pydantic_method_call", 0) >= 1
     patterns = {e["pattern"] for e in report["unresolved_calls"]}
@@ -267,7 +267,7 @@ def test_user_class_submit_resolves_in_package_not_accepted(tmp_path: Path) -> N
             "        self.submit(item)\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
     # self.submit resolves to pkg.mod.MyQueue.submit (in-package)
     assert "pkg.mod.MyQueue.submit" in raw.get("pkg.mod.MyQueue.enqueue", [])
     # Nothing should be in futures_method_call accepted bucket for this package
@@ -286,6 +286,6 @@ def test_user_class_model_dump_resolves_in_package_not_accepted(tmp_path: Path) 
             "        return self.model_dump()\n"
         ),
     })
-    raw, report = build_with_report(root, "pkg")
+    raw, report, _skeletons = build_with_report(root, "pkg")
     assert "pkg.mod.MySerializer.model_dump" in raw.get("pkg.mod.MySerializer.serialize", [])
     assert report["summary"]["accepted_counts"].get("pydantic_method_call", 0) == 0

--- a/tests/test_analyzer_self_attr_builtin.py
+++ b/tests/test_analyzer_self_attr_builtin.py
@@ -37,7 +37,7 @@ def test_self_attr_dict_literal_get_is_accepted(tmp_path: Path) -> None:
             "        return self._config.get('key')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
     assert report["pattern_counts"].get("self_method_unresolved", 0) == 0
 
@@ -58,7 +58,7 @@ def test_self_attr_path_call_mkdir_is_accepted(tmp_path: Path) -> None:
             "        self._raw_dir.mkdir()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "pathlib_method_call") >= 1
     assert report["pattern_counts"].get("self_method_unresolved", 0) == 0
 
@@ -79,7 +79,7 @@ def test_self_attr_class_body_annotation_dict_is_accepted(tmp_path: Path) -> Non
             "        return self._config.get('key')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
     assert report["pattern_counts"].get("self_method_unresolved", 0) == 0
 
@@ -98,7 +98,7 @@ def test_self_attr_param_annotation_dict_is_accepted(tmp_path: Path) -> None:
             "        return self._cfg.get('key')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
     assert report["pattern_counts"].get("self_method_unresolved", 0) == 0
 
@@ -117,7 +117,7 @@ def test_self_attr_list_literal_append_is_accepted(tmp_path: Path) -> None:
             "        self._items.append(x)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
 
 
@@ -131,7 +131,7 @@ def test_self_attr_set_literal_add_is_accepted(tmp_path: Path) -> None:
             "        self._seen.add(x)\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     assert _accepted(report, "builtin_method_call") >= 1
 
 
@@ -153,7 +153,7 @@ def test_fpg_unknown_factory_rhs_stays_unresolved(tmp_path: Path) -> None:
             "        return self._cfg.get('key')\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # .get() should NOT be accepted as builtin_method_call via sentinel path
     assert _accepted(report, "builtin_method_call") == 0
     # It should remain unresolved (self_method_unresolved or builtin_method_call via classify_miss)
@@ -172,7 +172,7 @@ def test_fpg_string_rhs_path_method_stays_unresolved(tmp_path: Path) -> None:
             "        self._path.mkdir()\n"
         ),
     })
-    _raw, report = build_with_report(root, "pkg")
+    _raw, report, _skeletons = build_with_report(root, "pkg")
     # .mkdir() on a str-typed attr must NOT route to pathlib_method_call via sentinel
     # (str param annotation → no sentinel, so no intercept before classify_miss)
     assert _accepted(report, "pathlib_method_call") == 0

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -1,0 +1,268 @@
+"""Tests for the file_skeleton MCP tool and supporting infrastructure.
+
+Covers:
+- CallGraphIndex.file_skeleton() query method
+- Skeleton extraction via _extract_skeletons() in the pipeline
+- Index round-trip (save/load) with skeletons (version 2)
+- Backward compatibility: version 1 indexes load with empty skeletons
+- Truncation at 50 symbols
+- isError: true for unknown path
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from pyscope_mcp.graph import CallGraphIndex
+from pyscope_mcp.analyzer.pipeline import _extract_skeletons, _first_def_line
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_index_with_skeletons(skeletons: dict) -> CallGraphIndex:
+    """Build a minimal CallGraphIndex pre-loaded with the given skeletons dict."""
+    return CallGraphIndex.from_raw("/tmp/test", {}, skeletons=skeletons)
+
+
+def _parse(source: str) -> ast.Module:
+    return ast.parse(textwrap.dedent(source))
+
+
+# ---------------------------------------------------------------------------
+# _first_def_line
+# ---------------------------------------------------------------------------
+
+def test_first_def_line_function() -> None:
+    tree = _parse("def foo(x: int, y: str) -> bool: pass")
+    node = tree.body[0]
+    assert _first_def_line(node) == "def foo(x: int, y: str) -> bool:"
+
+
+def test_first_def_line_async() -> None:
+    tree = _parse("async def bar(a, b=None): pass")
+    node = tree.body[0]
+    assert _first_def_line(node) == "async def bar(a, b=None):"
+
+
+def test_first_def_line_class_no_bases() -> None:
+    tree = _parse("class MyClass: pass")
+    node = tree.body[0]
+    assert _first_def_line(node) == "class MyClass:"
+
+
+def test_first_def_line_class_with_bases() -> None:
+    tree = _parse("class Child(Parent, Mixin): pass")
+    node = tree.body[0]
+    assert _first_def_line(node) == "class Child(Parent, Mixin):"
+
+
+# ---------------------------------------------------------------------------
+# _extract_skeletons
+# ---------------------------------------------------------------------------
+
+def test_extract_skeletons_basic(tmp_path: Path) -> None:
+    """Extracts top-level function, class, and methods; sorts by lineno."""
+    source = textwrap.dedent("""\
+        def standalone(x):
+            pass
+
+        class MyClass:
+            def method_a(self):
+                pass
+
+            def method_b(self, value: int) -> str:
+                return str(value)
+    """)
+    file_path = tmp_path / "mymodule.py"
+    file_path.write_text(source)
+    tree = ast.parse(source, filename=str(file_path))
+
+    parsed = [("pkg.mymodule", tree, file_path, {})]
+    skeletons = _extract_skeletons(tmp_path, parsed)
+
+    rel = "mymodule.py"
+    assert rel in skeletons
+    symbols = skeletons[rel]
+
+    # All 4 symbols: standalone, MyClass, method_a, method_b
+    assert len(symbols) == 4
+
+    # Sorted by lineno
+    linenos = [s["lineno"] for s in symbols]
+    assert linenos == sorted(linenos)
+
+    # Check kinds
+    kinds = {s["fqn"].split(".")[-1]: s["kind"] for s in symbols}
+    assert kinds["standalone"] == "function"
+    assert kinds["MyClass"] == "class"
+    assert kinds["method_a"] == "method"
+    assert kinds["method_b"] == "method"
+
+    # FQNs rooted at module FQN
+    fqns = {s["fqn"] for s in symbols}
+    assert "pkg.mymodule.standalone" in fqns
+    assert "pkg.mymodule.MyClass" in fqns
+    assert "pkg.mymodule.MyClass.method_a" in fqns
+    assert "pkg.mymodule.MyClass.method_b" in fqns
+
+    # Signatures are first-def-lines only (no bodies)
+    standalone_sym = next(s for s in symbols if s["fqn"].endswith("standalone"))
+    assert "pass" not in standalone_sym["signature"]
+    assert standalone_sym["signature"].startswith("def standalone")
+
+
+def test_extract_skeletons_excludes_nested_functions(tmp_path: Path) -> None:
+    """Nested functions inside other functions are not included."""
+    source = textwrap.dedent("""\
+        def outer():
+            def inner():
+                pass
+            return inner
+    """)
+    file_path = tmp_path / "nested.py"
+    file_path.write_text(source)
+    tree = ast.parse(source)
+
+    parsed = [("pkg.nested", tree, file_path, {})]
+    skeletons = _extract_skeletons(tmp_path, parsed)
+
+    symbols = skeletons.get("nested.py", [])
+    fqns = {s["fqn"] for s in symbols}
+    assert "pkg.nested.outer" in fqns
+    assert "pkg.nested.outer.inner" not in fqns  # inner must be excluded
+
+
+def test_extract_skeletons_empty_file(tmp_path: Path) -> None:
+    """An empty module produces an empty skeleton list (not an error)."""
+    file_path = tmp_path / "empty.py"
+    file_path.write_text("")
+    tree = ast.parse("")
+
+    parsed = [("pkg.empty", tree, file_path, {})]
+    skeletons = _extract_skeletons(tmp_path, parsed)
+    assert skeletons.get("empty.py") == []
+
+
+# ---------------------------------------------------------------------------
+# CallGraphIndex.file_skeleton()
+# ---------------------------------------------------------------------------
+
+def _make_symbol(fqn: str, kind: str, lineno: int) -> dict:
+    return {"fqn": fqn, "kind": kind, "signature": f"def {fqn.split('.')[-1]}():", "lineno": lineno}
+
+
+def test_file_skeleton_returns_symbols() -> None:
+    symbols = [
+        _make_symbol("pkg.mod.ClassA", "class", 1),
+        _make_symbol("pkg.mod.ClassA.method_x", "method", 5),
+        _make_symbol("pkg.mod.helper", "function", 10),
+    ]
+    idx = _make_index_with_skeletons({"mod.py": symbols})
+    result = idx.file_skeleton("mod.py")
+
+    assert result.get("isError") is None or result.get("isError") is False
+    assert result["truncated"] is False
+    assert result["total"] == 3
+    assert len(result["results"]) == 3
+
+
+def test_file_skeleton_unknown_path_returns_error() -> None:
+    idx = _make_index_with_skeletons({"mod.py": []})
+    result = idx.file_skeleton("nonexistent/file.py")
+
+    assert result["isError"] is True
+    assert "rebuild" in result["message"].lower() or "build" in result["message"].lower()
+
+
+def test_file_skeleton_truncation_at_50() -> None:
+    """When a file has >50 symbols, truncated=True and results are capped at 50."""
+    symbols = [_make_symbol(f"pkg.mod.fn{i}", "function", i) for i in range(60)]
+    idx = _make_index_with_skeletons({"large.py": symbols})
+    result = idx.file_skeleton("large.py")
+
+    assert result["truncated"] is True
+    assert result["total"] == 60
+    assert len(result["results"]) == 50
+
+
+def test_file_skeleton_exactly_50_not_truncated() -> None:
+    """Exactly 50 symbols: truncated=False (boundary condition)."""
+    symbols = [_make_symbol(f"pkg.mod.fn{i}", "function", i) for i in range(50)]
+    idx = _make_index_with_skeletons({"exact.py": symbols})
+    result = idx.file_skeleton("exact.py")
+
+    assert result["truncated"] is False
+    assert result["total"] == 50
+    assert len(result["results"]) == 50
+
+
+def test_file_skeleton_51_symbols_truncated() -> None:
+    """51 symbols: truncated=True."""
+    symbols = [_make_symbol(f"pkg.mod.fn{i}", "function", i) for i in range(51)]
+    idx = _make_index_with_skeletons({"mod51.py": symbols})
+    result = idx.file_skeleton("mod51.py")
+
+    assert result["truncated"] is True
+    assert result["total"] == 51
+    assert len(result["results"]) == 50
+
+
+def test_file_skeleton_empty_file() -> None:
+    """Empty file (no symbols) returns results=[], truncated=False, total=0."""
+    idx = _make_index_with_skeletons({"empty.py": []})
+    result = idx.file_skeleton("empty.py")
+
+    assert result["truncated"] is False
+    assert result["total"] == 0
+    assert result["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# Index save/load round-trip (version 2)
+# ---------------------------------------------------------------------------
+
+def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
+    """Skeleton data survives save/load intact."""
+    symbols = [
+        _make_symbol("pkg.mod.MyClass", "class", 1),
+        _make_symbol("pkg.mod.MyClass.run", "method", 5),
+    ]
+    idx = CallGraphIndex.from_raw("/tmp/test", {"pkg.mod.MyClass.run": []}, skeletons={"mod.py": symbols})
+    out = tmp_path / "index.json"
+    idx.save(out)
+
+    loaded = CallGraphIndex.load(out)
+    assert loaded.skeletons == {"mod.py": symbols}
+
+    result = loaded.file_skeleton("mod.py")
+    assert len(result["results"]) == 2
+    assert result["truncated"] is False
+
+
+def test_save_version_is_2(tmp_path: Path) -> None:
+    """Saved index must have version=2."""
+    import json as _json
+    idx = CallGraphIndex.from_raw("/tmp/test", {})
+    out = tmp_path / "index.json"
+    idx.save(out)
+    payload = _json.loads(out.read_text())
+    assert payload["version"] == 2
+
+
+def test_load_version_1_backward_compat(tmp_path: Path) -> None:
+    """Version 1 index loads successfully with empty skeletons dict."""
+    import json as _json
+    payload = {"version": 1, "root": "/tmp/test", "raw": {}}
+    out = tmp_path / "v1_index.json"
+    out.write_text(_json.dumps(payload))
+
+    loaded = CallGraphIndex.load(out)
+    assert loaded.skeletons == {}
+    result = loaded.file_skeleton("any.py")
+    assert result["isError"] is True

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -178,8 +178,8 @@ async def test_golden_handshake(server: RpcServer, tmp_index: Path):
     assert list_resp["id"] == 2
     tools = list_resp["result"]["tools"]
     tool_names = {t["name"] for t in tools}
-    assert tool_names == {"stats", "reload", "callers_of", "callees_of", "module_callers", "module_callees", "search"}
-    assert len(tools) == 7
+    assert tool_names == {"stats", "reload", "callers_of", "callees_of", "module_callers", "module_callees", "search", "file_skeleton"}
+    assert len(tools) == 8
 
 
 @pytest.mark.asyncio
@@ -844,7 +844,7 @@ async def test_tools_list_ignores_cursor_and_omits_next_cursor(server: RpcServer
     result = responses[0]["result"]
     assert "tools" in result
     assert "nextCursor" not in result
-    assert len(result["tools"]) == 7
+    assert len(result["tools"]) == 8
 
 
 @pytest.mark.asyncio

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -14,6 +14,7 @@ import json
 import os
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -276,6 +277,128 @@ def test_print_in_handler_goes_to_stderr(index_path: Path, tmp_path: Path) -> No
     assert "oops from handler" in stderr, f"print did not reach stderr; stderr={stderr!r}"
     # And critically: stdout must not contain the raw print text.
     assert b"oops from handler" not in stdout_rest
+
+
+def test_file_skeleton_build_serve_e2e(tmp_path: Path) -> None:
+    """Full pipeline: build writes skeletons → serve loads them → file_skeleton RPC returns correct symbols.
+
+    The unit tests exercise extraction and querying in-memory. This test is the only
+    one that catches seam bugs: wrong tuple element unpacked by CLI, wrong key written
+    by save(), silent empty-skeleton on load(), or malformed dispatch response.
+    """
+    # 1. Synthetic package with a predictable structure
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "core.py").write_text(textwrap.dedent("""\
+        def standalone(x: int) -> str:
+            def _inner():
+                pass
+            return str(x)
+
+        class MyClass:
+            def method_a(self) -> None:
+                pass
+
+            async def method_b(self, val: int) -> str:
+                return str(val)
+    """))
+
+    # 2. Run `pyscope-mcp build` as a subprocess — exercises the 3-tuple unpack and version-2 write
+    index_file = tmp_path / ".pyscope-mcp" / "index.json"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+    build_result = subprocess.run(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "build",
+            "--root", str(tmp_path),
+            "--package", "mypkg",
+            "--output", str(index_file),
+        ],
+        capture_output=True, env=env,
+    )
+    assert build_result.returncode == 0, f"build failed: {build_result.stderr.decode()}"
+
+    # 3. Index is version 2 and contains skeletons for core.py
+    payload = json.loads(index_file.read_text())
+    assert payload["version"] == 2
+    rel = "mypkg/core.py"
+    assert rel in payload["skeletons"], (
+        f"expected '{rel}' in skeletons; got keys: {list(payload['skeletons'])}"
+    )
+    saved_symbols = payload["skeletons"][rel]
+    saved_fqns = [s["fqn"] for s in saved_symbols]
+    assert "mypkg.core.standalone" in saved_fqns
+    assert "mypkg.core.MyClass" in saved_fqns
+    assert "mypkg.core.MyClass.method_a" in saved_fqns
+    assert "mypkg.core.MyClass.method_b" in saved_fqns
+    assert not any("_inner" in fqn for fqn in saved_fqns), "nested function must be excluded"
+    assert [s["lineno"] for s in saved_symbols] == sorted(s["lineno"] for s in saved_symbols)
+
+    # 4. Serve the index and call file_skeleton over the MCP wire
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "serve",
+            "--root", str(tmp_path),
+            "--index", str(index_file),
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-skeleton", "version": "0"},
+            },
+        })
+        r = _recv(proc)
+        assert r["id"] == 1
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        # 5. Happy path: known file returns correct symbols
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "file_skeleton", "arguments": {"path": rel}},
+        })
+        r = _recv(proc)
+        assert r["id"] == 2
+        assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+        assert r["result"].get("isError") is not True
+
+        body = json.loads(r["result"]["content"][0]["text"])
+        assert body["truncated"] is False
+        assert body["total"] == len(saved_symbols)
+        result_fqns = [s["fqn"] for s in body["results"]]
+        assert "mypkg.core.MyClass.method_b" in result_fqns
+        assert not any("_inner" in fqn for fqn in result_fqns)
+
+        method_b = next(s for s in body["results"] if s["fqn"].endswith("method_b"))
+        assert method_b["kind"] == "method"
+        assert method_b["signature"].startswith("async def method_b")
+
+        # 6. Unknown path returns isError via the wire — not a JSON-RPC error
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "file_skeleton", "arguments": {"path": "does/not/exist.py"}},
+        })
+        r = _recv(proc)
+        assert r["id"] == 3
+        assert "error" not in r
+        assert r["result"]["isError"] is True
+
+        # 7. Clean shutdown
+        _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
+        r = _recv(proc)
+        assert r == {"jsonrpc": "2.0", "id": 99, "result": {}}
+        proc.stdin.close()
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
 
 
 def test_shutdown_then_eof_exits_zero(index_path: Path) -> None:

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -95,7 +95,7 @@ def test_stdio_multiple_requests(index_path: Path) -> None:
         r2 = _recv(proc)
         assert r2["id"] == 2
         tools = r2["result"]["tools"]
-        assert len(tools) == 7
+        assert len(tools) == 8
         assert all("name" in t and "inputSchema" in t for t in tools)
 
         # Third request — ping.


### PR DESCRIPTION
Closes #44

## What changed

Adds the `file_skeleton` MCP tool, which returns all top-level functions, classes, and methods defined in a given Python file — with their fully-qualified name, kind, first-line signature, and line number. This eliminates the need for agents to fall back to `Read` for structural navigation questions.

## Implementation walkthrough

### Skeleton extraction at build time (`analyzer/pipeline.py`)

**`_extract_skeletons(root, parsed)`** — iterates over already-parsed ASTs (reusing pass-1 results) and performs a two-level traversal: top-level nodes for functions/classes, then one level into class bodies for methods. Nested functions inside other functions are excluded (not part of the structural surface). Results are keyed by file path relative to repo root, sorted by lineno.

**`_first_def_line(node)`** — reconstructs the first `def` or `class` line from the AST using `ast.unparse`, without the body. This keeps token cost low (the whole point of the tool) and avoids needing to pass raw source lines around.

**`build_with_report`** now returns a 3-tuple `(raw, report, skeletons)`. All callers updated.

### Index schema change (`graph.py`)

**`CallGraphIndex`** gains a `skeletons` field (dict mapping relative path → symbol list). **`from_raw`** accepts an optional `skeletons` parameter. **`save`** writes `version: 2` with the skeletons section. **`load`** accepts both version 1 (backward compat, empty skeletons) and version 2.

**`CallGraphIndex.file_skeleton(path)`** — the query method. Returns `{results, truncated, total}` or `{isError: True, message}` for unknown paths. Cap is 50.

### MCP registration (`server.py`)

`file_skeleton` descriptor added to `_TOOL_LIST`. Dispatch branch added in `_dispatch_tool`. Unknown-path errors surface as `isError: true` results (not JSON-RPC errors), consistent with other tool error handling.

### CLI wiring (`cli.py`)

`cmd_build` unpacks the new 3-tuple and passes `skeletons` to `CallGraphIndex.from_raw`.

## Default execution path

**Before**: `build` → `from_raw(root, raw)` → `save(version=1, raw)`. No skeleton data. Agents needing file structure had to call `Read`.

**After**: `build` → `_extract_skeletons` → `from_raw(root, raw, skeletons)` → `save(version=2, raw, skeletons)`. Agents call `file_skeleton("path/to/file.py")` and receive a compact symbol list.

## Tier / approach

Tier 1 — Planner → Coder

## Acceptance criteria

- [x] `file_skeleton("path/to/file.py")` returns all top-level functions, classes, methods with fqn/kind/signature/lineno
- [x] Response sorted by line number
- [x] Capped at 50 with explicit `truncated` + `total` fields (machine-readable, not silent slice)
- [x] Unknown path returns `isError: true` with rebuild guidance
- [x] Index version bumps to 2; version 1 loads with empty skeletons (backward compat)
- [x] Tests pass: class+methods fixture, truncation at 51, isError for unknown path, round-trip save/load

🤖 Generated with [Claude Code](https://claude.com/claude-code)