### PR TITLE
fix(#51): Apply SHA file-staleness check to all query surfaces

### DIFF
--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 from pyscope_mcp.types import (
     CalleesResult,
     CallersResult,
+    ModuleResult,
     NeighborhoodResult,
     SearchResult,
     StatsResult,
@@ -139,6 +140,9 @@ class CallGraphIndex:
     skeletons: dict[str, list[SymbolSummary]] = field(default_factory=dict)
     # None = pre-v3 index (no hashes stored); dict = v3 index with per-file SHA256 digests.
     file_shas: dict[str, str] | None = field(default=None)
+    # Derived at load/from_raw time: maps FQN → relative file path (inverted from skeletons).
+    # Not serialised — rebuilt on every load.
+    _fqn_to_file: dict[str, str] = field(default_factory=dict, repr=False)
 
     @classmethod
     def from_raw(
@@ -160,13 +164,20 @@ class CallGraphIndex:
                 tm = _module_of(callee)
                 if cm != tm:
                     mg.add_edge(cm, tm)
+        skeletons = skeletons or {}
+        # Invert skeletons → _fqn_to_file: {fqn: rel_path}
+        fqn_to_file: dict[str, str] = {}
+        for rel_path, symbols in skeletons.items():
+            for sym in symbols:
+                fqn_to_file[sym["fqn"]] = rel_path
         return cls(
             root=root,
             function_graph=fg,
             module_graph=mg,
             raw=raw,
-            skeletons=skeletons or {},
+            skeletons=skeletons,
             file_shas=file_shas,
+            _fqn_to_file=fqn_to_file,
         )
 
     def save(self, path: str | Path) -> Path:
@@ -202,6 +213,53 @@ class CallGraphIndex:
 
     _STALE_ACTION = "Run 'pyscope-mcp build' then 'reload' to update the index."
 
+    def _staleness_for(self, fqns: list[str]) -> dict:
+        """Compute result-scoped staleness for a list of FQNs.
+
+        Returns a dict with uniform staleness shape:
+          - ``{"stale": False, "stale_files": []}`` when all backing files are clean.
+          - ``{"stale": True, "stale_files": [...], "stale_action": ...}`` when any
+            file backing a result FQN has changed since the last build.
+          - ``{"stale": True, "stale_files": [], "index_stale_reason": "index_format_incompatible",
+            "stale_action": ...}`` for pre-v3 indexes (file_shas is None).
+
+        Only files that back the provided FQNs are checked (result-scoped).
+        Files in the index that do not appear in the result set are ignored.
+        """
+        if self.file_shas is None:
+            return {
+                "stale": True,
+                "stale_files": [],
+                "index_stale_reason": "index_format_incompatible",
+                "stale_action": self._STALE_ACTION,
+            }
+
+        # Collect the unique file paths that back the provided FQNs.
+        result_files: set[str] = set()
+        for fqn in fqns:
+            rel = self._fqn_to_file.get(fqn)
+            if rel is not None:
+                result_files.add(rel)
+
+        stale_files: list[str] = []
+        for rel in sorted(result_files):
+            stored_sha = self.file_shas.get(rel)
+            live_file = self.root / rel
+            if not live_file.exists():
+                stale_files.append(rel)
+                continue
+            live_sha = hashlib.sha256(live_file.read_bytes()).hexdigest()
+            if stored_sha is None or live_sha != stored_sha:
+                stale_files.append(rel)
+
+        if stale_files:
+            return {
+                "stale": True,
+                "stale_files": stale_files,
+                "stale_action": self._STALE_ACTION,
+            }
+        return {"stale": False, "stale_files": []}
+
     def file_skeleton(self, path: str, cap: int = _SKELETON_CAP) -> dict:
         """Return a compact symbol list for the given relative file path.
 
@@ -210,39 +268,24 @@ class CallGraphIndex:
           - ``truncated``: True when the full symbol count exceeds *cap*
           - ``total``: total number of symbols before capping
           - ``stale``: True when the live file differs from what was indexed
-          - ``staleness_info``: dict with ``reason`` and ``action`` when ``stale`` is True
-
-        Staleness reasons:
-          - ``file_changed``: file exists but content has changed since build
-          - ``file_not_found``: file was in the index but no longer exists on disk
-          - ``file_not_in_index``: path not in index (also sets ``isError: True``)
-          - ``index_format_incompatible``: index is pre-v3 and has no stored hashes
+          - ``stale_files``: list of stale relative paths (the queried file, or [])
+          - ``stale_action``: guidance on how to fix staleness (present only when stale=True)
+          - ``index_stale_reason``: ``"index_format_incompatible"`` for pre-v3 indexes
 
         Results are always returned when the path is in the index, even when stale.
         If the path is not in the index, returns an error dict with ``isError: True``.
         """
-        # Scenario D / Scenario E (isError cases that may also carry stale info)
+        # Scenario D / isError: path not in skeletons
         if path not in self.skeletons:
-            if self.file_shas is None:
-                # Pre-v3 index: stale, but we can't distinguish not-in-index from
-                # index_format_incompatible for paths absent from skeletons.
-                # Since the path isn't in skeletons either, use file_not_in_index.
-                return {
-                    "isError": True,
-                    "stale": True,
-                    "staleness_info": {
-                        "reason": "file_not_in_index",
-                        "action": self._STALE_ACTION,
-                    },
-                }
-            return {
+            result: dict = {
                 "isError": True,
                 "stale": True,
-                "staleness_info": {
-                    "reason": "file_not_in_index",
-                    "action": self._STALE_ACTION,
-                },
+                "stale_files": [],
+                "stale_action": self._STALE_ACTION,
             }
+            if self.file_shas is None:
+                result["index_stale_reason"] = "index_format_incompatible"
+            return result
 
         symbols = self.skeletons[path]
         total = len(symbols)
@@ -256,10 +299,9 @@ class CallGraphIndex:
         # Scenario E: pre-v3 index — no hashes available.
         if self.file_shas is None:
             base_result["stale"] = True
-            base_result["staleness_info"] = {
-                "reason": "index_format_incompatible",
-                "action": self._STALE_ACTION,
-            }
+            base_result["stale_files"] = []
+            base_result["index_stale_reason"] = "index_format_incompatible"
+            base_result["stale_action"] = self._STALE_ACTION
             return base_result
 
         # Scenarios A/B/C: v3 index — compare live file hash against stored hash.
@@ -267,10 +309,8 @@ class CallGraphIndex:
         if not live_file.exists():
             # Scenario C: file deleted since build.
             base_result["stale"] = True
-            base_result["staleness_info"] = {
-                "reason": "file_not_found",
-                "action": self._STALE_ACTION,
-            }
+            base_result["stale_files"] = [path]
+            base_result["stale_action"] = self._STALE_ACTION
             return base_result
 
         stored_sha = self.file_shas.get(path)
@@ -279,14 +319,13 @@ class CallGraphIndex:
         if stored_sha is None or live_sha != stored_sha:
             # Scenario B: file changed.
             base_result["stale"] = True
-            base_result["staleness_info"] = {
-                "reason": "file_changed",
-                "action": self._STALE_ACTION,
-            }
+            base_result["stale_files"] = [path]
+            base_result["stale_action"] = self._STALE_ACTION
             return base_result
 
         # Scenario A: fresh — hashes match.
         base_result["stale"] = False
+        base_result["stale_files"] = []
         return base_result
 
     _CALLERS_CALLEES_CAP = 50
@@ -295,24 +334,34 @@ class CallGraphIndex:
         """Return functions that (transitively, up to depth) call *fqn*.
 
         Results are capped at 50; ``truncated`` signals when the cap fires.
+        Response includes uniform staleness fields (``stale``, ``stale_files``,
+        and optionally ``stale_action`` / ``index_stale_reason``).
         """
         all_results = _bfs(self.function_graph.reverse(copy=False), fqn, depth)
         truncated = len(all_results) > self._CALLERS_CALLEES_CAP
+        results = all_results[: self._CALLERS_CALLEES_CAP]
+        staleness = self._staleness_for(results)
         return CallersResult(
-            results=all_results[: self._CALLERS_CALLEES_CAP],
+            results=results,
             truncated=truncated,
+            **staleness,  # type: ignore[arg-type]
         )
 
     def callees_of(self, fqn: str, depth: int = 1) -> CalleesResult:
         """Return functions (transitively, up to depth) called by *fqn*.
 
         Results are capped at 50; ``truncated`` signals when the cap fires.
+        Response includes uniform staleness fields (``stale``, ``stale_files``,
+        and optionally ``stale_action`` / ``index_stale_reason``).
         """
         all_results = _bfs(self.function_graph, fqn, depth)
         truncated = len(all_results) > self._CALLERS_CALLEES_CAP
+        results = all_results[: self._CALLERS_CALLEES_CAP]
+        staleness = self._staleness_for(results)
         return CalleesResult(
-            results=all_results[: self._CALLERS_CALLEES_CAP],
+            results=results,
             truncated=truncated,
+            **staleness,  # type: ignore[arg-type]
         )
 
     def neighborhood(
@@ -382,13 +431,16 @@ class CallGraphIndex:
 
         if not edge_depths:
             # Symbol not in graph or isolated node — return minimal result
-            return NeighborhoodResult(
+            staleness = self._staleness_for([symbol])
+            result = NeighborhoodResult(
                 symbol=symbol,
                 depth_full=0,
                 edges=[],
                 truncated=False,
                 token_budget_used=0,
             )
+            result.update(staleness)  # type: ignore[arg-type]
+            return result
 
         # ------------------------------------------------------------------
         # Phase 2: rank edges deterministically
@@ -446,6 +498,12 @@ class CallGraphIndex:
         # ------------------------------------------------------------------
         # Phase 4: assemble result
         # ------------------------------------------------------------------
+        # Collect unique FQNs from kept edges for result-scoped staleness check.
+        unique_fqns: list[str] = list(
+            {fqn for edge in kept_edges for fqn in edge}
+        )
+        staleness = self._staleness_for(unique_fqns)
+
         result = NeighborhoodResult(
             symbol=symbol,
             depth_full=depth_full,
@@ -453,30 +511,71 @@ class CallGraphIndex:
             truncated=truncated,
             token_budget_used=chars_used // 4,
         )
+        result.update(staleness)  # type: ignore[arg-type]
         if truncated and depth_truncated is not None:
             result["depth_truncated"] = depth_truncated
 
         return result
 
-    def module_callers(self, module: str, depth: int = 1) -> dict[str, object]:
+    def module_callers(self, module: str, depth: int = 1) -> ModuleResult:
         """Return callers of all modules whose FQN starts with *module* (prefix query).
 
         An exact FQN is a degenerate prefix and behaves identically to the
         pre-change implementation.  Results are capped at 50 items; the
         ``truncated`` key in the returned dict signals when the cap triggers.
         An empty-string prefix matches all modules.  A prefix that matches no
-        module nodes returns ``{"results": [], "truncated": false}``.
+        module nodes returns ``{"results": [], "truncated": false, "stale": ..., "stale_files": []}``.
+
+        Staleness is result-scoped: module FQNs are expanded to file paths via
+        prefix-matching against ``_fqn_to_file`` (find all symbol FQNs that start
+        with ``result_module + "."``).
         """
-        return _prefix_module_bfs(
+        base = _prefix_module_bfs(
             self.module_graph.reverse(copy=False), self.module_graph, module, depth
         )
+        result_modules: list[str] = base["results"]  # type: ignore[assignment]
+        staleness = self._staleness_for_modules(result_modules)
+        return ModuleResult(
+            results=result_modules,
+            truncated=base["truncated"],  # type: ignore[typeddict-item]
+            **staleness,  # type: ignore[arg-type]
+        )
 
-    def module_callees(self, module: str, depth: int = 1) -> dict[str, object]:
+    def module_callees(self, module: str, depth: int = 1) -> ModuleResult:
         """Return callees of all modules whose FQN starts with *module* (prefix query).
 
         Symmetric to :meth:`module_callers` — see its docstring for semantics.
         """
-        return _prefix_module_bfs(self.module_graph, self.module_graph, module, depth)
+        base = _prefix_module_bfs(self.module_graph, self.module_graph, module, depth)
+        result_modules: list[str] = base["results"]  # type: ignore[assignment]
+        staleness = self._staleness_for_modules(result_modules)
+        return ModuleResult(
+            results=result_modules,
+            truncated=base["truncated"],  # type: ignore[typeddict-item]
+            **staleness,  # type: ignore[arg-type]
+        )
+
+    def _staleness_for_modules(self, module_fqns: list[str]) -> dict:
+        """Expand module FQNs to symbol FQNs and delegate to ``_staleness_for``.
+
+        Module FQNs (e.g. ``pkg.mod``) are not stored in ``_fqn_to_file``; only
+        function/class/method FQNs are.  We expand by finding all ``_fqn_to_file``
+        keys that start with ``module_fqn + "."``.
+        """
+        if self.file_shas is None:
+            return {
+                "stale": True,
+                "stale_files": [],
+                "index_stale_reason": "index_format_incompatible",
+                "stale_action": self._STALE_ACTION,
+            }
+        symbol_fqns: list[str] = []
+        for mod in module_fqns:
+            prefix = mod + "."
+            for fqn in self._fqn_to_file:
+                if fqn.startswith(prefix):
+                    symbol_fqns.append(fqn)
+        return self._staleness_for(symbol_fqns)
 
     def search(self, substring: str, limit: int = 50) -> SearchResult:
         """Substring search over known fully-qualified function names.
@@ -485,14 +584,18 @@ class CallGraphIndex:
           - ``results``: list of matching FQNs (capped at *limit*)
           - ``truncated``: True when the full match count exceeds *limit*
           - ``total_matched``: count of all matches before capping
+          - ``stale``, ``stale_files``: result-scoped staleness info
         """
         s = substring.lower()
         all_matches = [n for n in self.function_graph.nodes if s in n.lower()]
         total = len(all_matches)
+        results = all_matches[:limit]
+        staleness = self._staleness_for(results)
         return SearchResult(
-            results=all_matches[:limit],
+            results=results,
             truncated=total > limit,
             total_matched=total,
+            **staleness,  # type: ignore[arg-type]
         )
 
     def stats(self) -> StatsResult:

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -70,7 +70,9 @@ _TOOL_LIST = [
         "description": (
             "List functions that (transitively, up to depth) call the given function. "
             "Results are capped at 50; when the cap triggers, `truncated` is true. "
-            "Returns {results: [...], truncated: bool}."
+            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
+            "and `stale_action: str` when stale is true. "
+            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -87,7 +89,9 @@ _TOOL_LIST = [
         "description": (
             "List functions (transitively, up to depth) called by the given function. "
             "Results are capped at 50; when the cap triggers, `truncated` is true. "
-            "Returns {results: [...], truncated: bool}."
+            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
+            "and `stale_action: str` when stale is true. "
+            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -109,7 +113,9 @@ _TOOL_LIST = [
             "An empty string matches all modules. "
             "Results are capped at 50 and deduplicated; when the cap triggers, "
             "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
-            "Returns {results: [...], truncated: bool}."
+            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
+            "and `stale_action: str` when stale is true. "
+            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -134,7 +140,9 @@ _TOOL_LIST = [
             "An empty string matches all modules. "
             "Results are capped at 50 and deduplicated; when the cap triggers, "
             "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
-            "Returns {results: [...], truncated: bool}."
+            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
+            "and `stale_action: str` when stale is true. "
+            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -154,7 +162,9 @@ _TOOL_LIST = [
         "description": (
             "Substring search over known fully-qualified function names. "
             "Results are capped at `limit` (default 50); use a more specific query if `truncated` is true. "
-            "Returns {results: [...], truncated: bool, total_matched: int}."
+            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
+            "and `stale_action: str` when stale is true. "
+            "Returns {results: [...], truncated: bool, total_matched: int, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -175,13 +185,13 @@ _TOOL_LIST = [
             "signature (first def-line only, no body), and lineno. "
             "Results are sorted by lineno and capped at 50; when the cap triggers, "
             "`truncated` is true and `total` holds the full count. "
-            "Response always includes `stale: bool`. When stale is true, `staleness_info` "
-            "provides a machine-readable `reason` (file_changed | file_not_found | "
-            "file_not_in_index | index_format_incompatible) and an `action` string. "
-            "If the file was added after the last build (file_not_in_index), returns "
-            "isError:true alongside stale fields. "
-            "Returns {results: [...], truncated: bool, total: int, stale: bool, "
-            "staleness_info?: {reason, action}} or {isError: true, stale: true, staleness_info: {...}}."
+            "Response always includes `stale: bool` and `stale_files: list[str]`. "
+            "When stale is true, `stale_files` lists the relative paths of changed files "
+            "and `stale_action` provides a remediation string. "
+            "If the file was added after the last build, returns isError:true alongside stale fields. "
+            "For pre-v3 indexes, `index_stale_reason: 'index_format_incompatible'` is set. "
+            "Returns {results: [...], truncated: bool, total: int, stale: bool, stale_files: [...], "
+            "stale_action?: str} or {isError: true, stale: true, stale_files: [], stale_action: str}."
         ),
         "inputSchema": {
             "type": "object",
@@ -207,8 +217,10 @@ _TOOL_LIST = [
             "level where dropping started, and `depth_full` indicates the deepest level with "
             "complete data. "
             "Default token_budget=1000. "
+            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
+            "and `stale_action: str` when stale is true. "
             "Returns {symbol, depth_full, depth_truncated?, edges: [[caller, callee], ...], "
-            "truncated: bool, token_budget_used: int}."
+            "truncated: bool, token_budget_used: int, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -352,7 +364,7 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
             return _error_result("file_skeleton requires 'path'")
         result = idx.file_skeleton(path)
         if result.get("isError"):
-            # Emit the full dict (including stale/staleness_info) so callers can
+            # Emit the full dict (including stale/stale_files) so callers can
             # branch on machine-readable staleness fields, not just the message string.
             return {"content": [{"type": "text", "text": _json.dumps(result, indent=2)}], "isError": True}
         return _text(result)

--- a/src/pyscope_mcp/types.py
+++ b/src/pyscope_mcp/types.py
@@ -17,6 +17,10 @@ class SearchResult(TypedDict):
     results: list[str]
     truncated: bool
     total_matched: int
+    stale: bool
+    stale_files: list[str]
+    stale_action: NotRequired[str]
+    index_stale_reason: NotRequired[str]
 
 
 class StatsResult(TypedDict):
@@ -33,6 +37,10 @@ class CallersResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    stale: bool
+    stale_files: list[str]
+    stale_action: NotRequired[str]
+    index_stale_reason: NotRequired[str]
 
 
 class CalleesResult(TypedDict):
@@ -40,19 +48,37 @@ class CalleesResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    stale: bool
+    stale_files: list[str]
+    stale_action: NotRequired[str]
+    index_stale_reason: NotRequired[str]
+
+
+class ModuleResult(TypedDict):
+    """Return shape for :meth:`CallGraphIndex.module_callers` and
+    :meth:`CallGraphIndex.module_callees`."""
+
+    results: list[str]
+    truncated: bool
+    stale: bool
+    stale_files: list[str]
+    stale_action: NotRequired[str]
+    index_stale_reason: NotRequired[str]
 
 
 class NeighborhoodResult(TypedDict, total=False):
     """Return shape for :meth:`CallGraphIndex.neighborhood`.
 
-    All fields except ``depth_truncated`` are **always present**.
+    All fields except ``depth_truncated``, ``stale_action``, and
+    ``index_stale_reason`` are **always present**.
     ``depth_truncated`` is present **only** when ``truncated=True``; it is
     absent from the dict when ``truncated=False``.
+    ``stale_action`` is present only when ``stale=True``.
+    ``index_stale_reason`` is present only on the pre-v3 index path.
 
-    ``total=False`` is used (rather than a base-class split) because
-    ``depth_truncated`` must be omitted entirely (not set to ``None``) in
-    the non-truncated path — ``NotRequired`` marks it as the sole optional
-    field while the remaining fields are always constructed by
+    ``total=False`` is used (rather than a base-class split) because multiple
+    fields must be omitted entirely when not applicable — ``NotRequired`` marks
+    them as optional while the remaining fields are always constructed by
     :meth:`CallGraphIndex.neighborhood`.
 
     ``token_budget_used`` reflects the serialised character count / 4
@@ -65,3 +91,7 @@ class NeighborhoodResult(TypedDict, total=False):
     edges: list[list[str]]  # list of [caller, callee] pairs
     truncated: bool
     token_budget_used: int
+    stale: bool
+    stale_files: list[str]
+    stale_action: NotRequired[str]
+    index_stale_reason: NotRequired[str]

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -181,20 +181,23 @@ def test_file_skeleton_returns_symbols() -> None:
     assert result["truncated"] is False
     assert result["total"] == 3
     assert len(result["results"]) == 3
-    # Pre-v3: stale=True with index_format_incompatible
+    # Pre-v3: stale=True with index_format_incompatible (uniform shape)
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "index_format_incompatible"
+    assert result["stale_files"] == []
+    assert result["index_stale_reason"] == "index_format_incompatible"
+    assert "staleness_info" not in result
 
 
 def test_file_skeleton_unknown_path_returns_error() -> None:
-    """Unknown path returns isError:true AND stale:true with reason file_not_in_index."""
+    """Unknown path returns isError:true AND stale:true with stale_files=[]."""
     idx = _make_index_with_skeletons({"mod.py": []}, file_shas={})
     result = idx.file_skeleton("nonexistent/file.py")
 
     assert result["isError"] is True
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "file_not_in_index"
-    assert "build" in result["staleness_info"]["action"].lower()
+    assert result["stale_files"] == []
+    assert "build" in result["stale_action"].lower()
+    assert "staleness_info" not in result
 
 
 def test_file_skeleton_truncation_at_50() -> None:
@@ -301,10 +304,12 @@ def test_load_version_1_backward_compat(tmp_path: Path) -> None:
     loaded = CallGraphIndex.load(out)
     assert loaded.skeletons == {"any.py": []}
     assert loaded.file_shas is None
-    # Querying any known path on a pre-v3 index → stale: index_format_incompatible
+    # Querying any known path on a pre-v3 index → stale: index_format_incompatible (uniform shape)
     result = loaded.file_skeleton("any.py")
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "index_format_incompatible"
+    assert result["stale_files"] == []
+    assert result["index_stale_reason"] == "index_format_incompatible"
+    assert "staleness_info" not in result
 
 
 def test_load_version_2_backward_compat(tmp_path: Path) -> None:
@@ -347,12 +352,14 @@ def test_file_skeleton_stale_sha_match(tmp_path: Path) -> None:
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is False
-    assert "staleness_info" not in result or result.get("staleness_info") is None
+    assert result["stale_files"] == []
+    assert "staleness_info" not in result
+    assert "stale_action" not in result
     assert len(result["results"]) == 1
 
 
 def test_file_skeleton_stale_sha_mismatch(tmp_path: Path) -> None:
-    """Scenario B: v3 index, file on disk has different content → stale: true, file_changed."""
+    """Scenario B: v3 index, file on disk has different content → stale: true, stale_files=[path]."""
     original = b"def foo(): pass\n"
     live_file = tmp_path / "mod.py"
     live_file.write_bytes(b"def foo(): return 42\n")  # different content
@@ -363,14 +370,15 @@ def test_file_skeleton_stale_sha_mismatch(tmp_path: Path) -> None:
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "file_changed"
-    assert "build" in result["staleness_info"]["action"].lower()
+    assert result["stale_files"] == ["mod.py"]
+    assert "build" in result["stale_action"].lower()
+    assert "staleness_info" not in result
     # Results are still returned
     assert len(result["results"]) == 1
 
 
 def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
-    """Scenario C: v3 index, file absent from disk → stale: true, file_not_found."""
+    """Scenario C: v3 index, file absent from disk → stale: true, stale_files=[path]."""
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": "somehex"}
     # Don't create the file on disk
@@ -378,19 +386,21 @@ def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "file_not_found"
+    assert result["stale_files"] == ["mod.py"]
+    assert "staleness_info" not in result
     # Results still returned (from index)
     assert len(result["results"]) == 1
 
 
 def test_file_skeleton_stale_file_not_in_index(tmp_path: Path) -> None:
-    """Scenario D: v3 index, path not in skeletons → isError: true, stale: true, file_not_in_index."""
+    """Scenario D: v3 index, path not in skeletons → isError: true, stale: true, stale_files=[]."""
     idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
 
     result = idx.file_skeleton("new_mod.py")
     assert result["isError"] is True
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "file_not_in_index"
+    assert result["stale_files"] == []
+    assert "staleness_info" not in result
 
 
 def test_file_skeleton_stale_pre_v3_index(tmp_path: Path) -> None:
@@ -401,7 +411,9 @@ def test_file_skeleton_stale_pre_v3_index(tmp_path: Path) -> None:
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
-    assert result["staleness_info"]["reason"] == "index_format_incompatible"
+    assert result["stale_files"] == []
+    assert result["index_stale_reason"] == "index_format_incompatible"
+    assert "staleness_info" not in result
     # Results are still returned
     assert len(result["results"]) == 1
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -53,7 +53,11 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
 
     loaded = CallGraphIndex.load(out)
     assert loaded.stats() == idx.stats()
-    assert loaded.search("helper") == idx.search("helper")
+    # Compare only the query results (not staleness — the original idx has file_shas=None
+    # which produces a pre-v3 stale signal, while the saved+loaded index is v3 with no
+    # stored hashes and the symbol files aren't on disk, so staleness differs by design).
+    assert loaded.search("helper")["results"] == idx.search("helper")["results"]
+    assert loaded.search("helper")["truncated"] == idx.search("helper")["truncated"]
 
 
 def _prefix_raw() -> dict[str, list[str]]:
@@ -110,14 +114,18 @@ def test_module_callers_no_match() -> None:
     """A prefix matching no module nodes returns empty results, no error."""
     idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
     result = idx.module_callers("nonexistent.pkg")
-    assert result == {"results": [], "truncated": False}
+    assert result["results"] == []
+    assert result["truncated"] is False
+    assert "stale" in result  # staleness fields always present
 
 
 def test_module_callees_no_match() -> None:
     """A prefix matching no module nodes returns empty results, no error."""
     idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
     result = idx.module_callees("nonexistent.pkg")
-    assert result == {"results": [], "truncated": False}
+    assert result["results"] == []
+    assert result["truncated"] is False
+    assert "stale" in result
 
 
 def test_module_callers_empty_prefix() -> None:

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -462,7 +462,79 @@ def test_file_skeleton_stale_e2e_wire(tmp_path: Path) -> None:
 
         body = json.loads(r["result"]["content"][0]["text"])
         assert body["stale"] is True, f"expected stale=true; got {body}"
-        assert body["staleness_info"]["reason"] == "file_changed"
+        assert body["stale_files"] == [rel], f"expected stale_files=[{rel!r}]; got {body}"
+        assert "staleness_info" not in body, f"staleness_info should not be present; got {body}"
+
+        _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
+        r = _recv(proc)
+        assert r == {"jsonrpc": "2.0", "id": 99, "result": {}}
+        proc.stdin.close()
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def test_callers_of_stale_e2e_wire(tmp_path: Path) -> None:
+    """E2E: build real index, modify source file, call callers_of → stale: true over the wire."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    core_file = pkg / "core.py"
+    core_file.write_text("def foo(): pass\n\ndef bar(): return foo()\n")
+
+    index_file = tmp_path / ".pyscope-mcp" / "index.json"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+    build_result = subprocess.run(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "build",
+            "--root", str(tmp_path),
+            "--package", "mypkg",
+            "--output", str(index_file),
+        ],
+        capture_output=True, env=env,
+    )
+    assert build_result.returncode == 0, f"build failed: {build_result.stderr.decode()}"
+
+    # Modify core.py after build so SHA will differ
+    core_file.write_text("def foo(): return 42\n\ndef bar(): return foo()\n")
+
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "serve",
+            "--root", str(tmp_path),
+            "--index", str(index_file),
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-stale-callers", "version": "0"},
+            },
+        })
+        r = _recv(proc)
+        assert r["id"] == 1
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.foo"}},
+        })
+        r = _recv(proc)
+        assert r["id"] == 2
+        assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+        body = json.loads(r["result"]["content"][0]["text"])
+        assert body["stale"] is True, f"expected stale=true; got {body}"
+        assert "mypkg/core.py" in body["stale_files"], f"expected core.py in stale_files; got {body}"
+        assert "staleness_info" not in body, f"staleness_info should not be present; got {body}"
 
         _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
         r = _recv(proc)

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -1,0 +1,375 @@
+"""Unit tests for staleness helpers and per-tool stale/clean paths.
+
+Covers:
+  - _fqn_to_file population after from_raw()
+  - _staleness_for() helper: dirty-in-result, dirty-not-in-result, pre-v3
+  - callers_of / callees_of stale and clean paths
+  - search stale and clean paths
+  - neighborhood stale and clean paths
+  - module_callers / module_callees stale and clean paths
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sym(fqn: str, kind: str = "function", lineno: int = 1) -> SymbolSummary:
+    return SymbolSummary(fqn=fqn, kind=kind, signature=f"def {fqn.split('.')[-1]}(): ...", lineno=lineno)
+
+
+def _make_idx(
+    tmp_path: Path,
+    raw: dict[str, list[str]],
+    skeletons: dict[str, list[SymbolSummary]],
+    file_shas: dict[str, str] | None,
+) -> CallGraphIndex:
+    return CallGraphIndex.from_raw(str(tmp_path), raw, skeletons=skeletons, file_shas=file_shas)
+
+
+# ---------------------------------------------------------------------------
+# 1. _fqn_to_file population
+# ---------------------------------------------------------------------------
+
+def test_fqn_to_file_populated(tmp_path: Path) -> None:
+    """_fqn_to_file is built by inverting skeletons at from_raw() time."""
+    skeletons = {
+        "src/pkg/mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")],
+        "src/pkg/other.py": [_sym("pkg.other.fn_c")],
+    }
+    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons=skeletons, file_shas={})
+    assert idx._fqn_to_file["pkg.mod.fn_a"] == "src/pkg/mod.py"
+    assert idx._fqn_to_file["pkg.mod.fn_b"] == "src/pkg/mod.py"
+    assert idx._fqn_to_file["pkg.other.fn_c"] == "src/pkg/other.py"
+
+
+def test_fqn_to_file_empty_skeletons(tmp_path: Path) -> None:
+    """Empty skeletons produce an empty _fqn_to_file."""
+    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
+    assert idx._fqn_to_file == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. _staleness_for() helper
+# ---------------------------------------------------------------------------
+
+def test_staleness_for_clean(tmp_path: Path) -> None:
+    """Clean file backing a result FQN → stale: false, stale_files: []."""
+    content = b"def fn_a(): pass\n"
+    (tmp_path / "mod.py").write_bytes(content)
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a")]}
+    shas = {"mod.py": _sha256(content)}
+    idx = _make_idx(tmp_path, {}, skeletons, shas)
+
+    result = idx._staleness_for(["pkg.mod.fn_a"])
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+    assert "stale_action" not in result
+
+
+def test_staleness_for_dirty_file_in_result(tmp_path: Path) -> None:
+    """Dirty file that backs a result FQN appears in stale_files."""
+    (tmp_path / "mod.py").write_bytes(b"def fn_a(): return 42\n")
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a")]}
+    shas = {"mod.py": _sha256(b"def fn_a(): pass\n")}  # stored hash differs
+    idx = _make_idx(tmp_path, {}, skeletons, shas)
+
+    result = idx._staleness_for(["pkg.mod.fn_a"])
+    assert result["stale"] is True
+    assert "mod.py" in result["stale_files"]
+    assert "build" in result["stale_action"].lower()
+
+
+def test_staleness_for_dirty_file_not_in_result(tmp_path: Path) -> None:
+    """Dirty file that backs NO result FQN must NOT appear in stale_files."""
+    content_a = b"def fn_a(): pass\n"
+    (tmp_path / "mod_a.py").write_bytes(content_a)
+    (tmp_path / "mod_b.py").write_bytes(b"def fn_b(): return 99\n")  # dirty
+    skeletons = {
+        "mod_a.py": [_sym("pkg.mod_a.fn_a")],
+        "mod_b.py": [_sym("pkg.mod_b.fn_b")],
+    }
+    shas = {
+        "mod_a.py": _sha256(content_a),
+        "mod_b.py": _sha256(b"def fn_b(): pass\n"),  # stored hash differs from disk
+    }
+    idx = _make_idx(tmp_path, {}, skeletons, shas)
+
+    # Only asking about fn_a — mod_b.py is dirty but not in the result set
+    result = idx._staleness_for(["pkg.mod_a.fn_a"])
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+def test_staleness_for_pre_v3_index(tmp_path: Path) -> None:
+    """Pre-v3 index (file_shas=None) → short-circuit to index_format_incompatible."""
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a")]}
+    idx = _make_idx(tmp_path, {}, skeletons, file_shas=None)
+
+    result = idx._staleness_for(["pkg.mod.fn_a"])
+    assert result["stale"] is True
+    assert result["stale_files"] == []
+    assert result["index_stale_reason"] == "index_format_incompatible"
+
+
+def test_staleness_for_fqn_not_in_skeletons(tmp_path: Path) -> None:
+    """FQN with no skeleton entry (not in _fqn_to_file) yields clean result."""
+    idx = _make_idx(tmp_path, {}, skeletons={}, file_shas={})
+    result = idx._staleness_for(["pkg.mod.fn_unknown"])
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+# ---------------------------------------------------------------------------
+# 3. callers_of / callees_of
+# ---------------------------------------------------------------------------
+
+def _raw_ab() -> dict[str, list[str]]:
+    return {
+        "pkg.mod.fn_a": ["pkg.mod.fn_b"],
+        "pkg.mod.fn_b": [],
+    }
+
+
+def test_callers_of_clean(tmp_path: Path) -> None:
+    """callers_of returns stale: false when backing files are clean."""
+    content = b"def fn_b(): pass\n"
+    (tmp_path / "mod.py").write_bytes(content)
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")]}
+    shas = {"mod.py": _sha256(content)}
+    idx = _make_idx(tmp_path, _raw_ab(), skeletons, shas)
+
+    result = idx.callers_of("pkg.mod.fn_b", depth=1)
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+def test_callers_of_stale(tmp_path: Path) -> None:
+    """callers_of returns stale: true when a backing file changed."""
+    (tmp_path / "mod.py").write_bytes(b"def fn_a(): return fn_b()\n")
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")]}
+    shas = {"mod.py": _sha256(b"def fn_a(): pass\n")}  # stored differs from disk
+    idx = _make_idx(tmp_path, _raw_ab(), skeletons, shas)
+
+    result = idx.callers_of("pkg.mod.fn_b", depth=1)
+    assert result["stale"] is True
+    assert "mod.py" in result["stale_files"]
+
+
+def test_callees_of_clean(tmp_path: Path) -> None:
+    """callees_of returns stale: false when backing files are clean."""
+    content = b"def fn_a(): pass\n"
+    (tmp_path / "mod.py").write_bytes(content)
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")]}
+    shas = {"mod.py": _sha256(content)}
+    idx = _make_idx(tmp_path, _raw_ab(), skeletons, shas)
+
+    result = idx.callees_of("pkg.mod.fn_a", depth=1)
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+def test_callees_of_stale(tmp_path: Path) -> None:
+    """callees_of returns stale: true when a backing file changed."""
+    (tmp_path / "mod.py").write_bytes(b"def fn_b(): return 42\n")
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")]}
+    shas = {"mod.py": _sha256(b"def fn_b(): pass\n")}  # stored differs from disk
+    idx = _make_idx(tmp_path, _raw_ab(), skeletons, shas)
+
+    result = idx.callees_of("pkg.mod.fn_a", depth=1)
+    assert result["stale"] is True
+    assert "mod.py" in result["stale_files"]
+
+
+def test_callers_of_pre_v3(tmp_path: Path) -> None:
+    """callers_of pre-v3 index returns index_format_incompatible."""
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")]}
+    idx = _make_idx(tmp_path, _raw_ab(), skeletons, file_shas=None)
+    result = idx.callers_of("pkg.mod.fn_b")
+    assert result["stale"] is True
+    assert result["index_stale_reason"] == "index_format_incompatible"
+
+
+# ---------------------------------------------------------------------------
+# 4. search
+# ---------------------------------------------------------------------------
+
+def test_search_clean(tmp_path: Path) -> None:
+    """search returns stale: false when backing files are clean."""
+    content = b"def fn_a(): pass\n"
+    (tmp_path / "mod.py").write_bytes(content)
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a")]}
+    shas = {"mod.py": _sha256(content)}
+    idx = _make_idx(tmp_path, {"pkg.mod.fn_a": []}, skeletons, shas)
+
+    result = idx.search("fn_a")
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+    assert "stale_action" not in result
+
+
+def test_search_stale(tmp_path: Path) -> None:
+    """search returns stale: true when a matched FQN's file changed."""
+    (tmp_path / "mod.py").write_bytes(b"def fn_a(): return 42\n")
+    skeletons = {"mod.py": [_sym("pkg.mod.fn_a")]}
+    shas = {"mod.py": _sha256(b"def fn_a(): pass\n")}
+    idx = _make_idx(tmp_path, {"pkg.mod.fn_a": []}, skeletons, shas)
+
+    result = idx.search("fn_a")
+    assert result["stale"] is True
+    assert "mod.py" in result["stale_files"]
+
+
+def test_search_dirty_non_result_not_included(tmp_path: Path) -> None:
+    """search stale_files excludes dirty files not backing any matched FQN."""
+    content_a = b"def fn_a(): pass\n"
+    (tmp_path / "mod_a.py").write_bytes(content_a)
+    (tmp_path / "mod_b.py").write_bytes(b"def fn_b(): return 99\n")  # dirty
+    skeletons = {
+        "mod_a.py": [_sym("pkg.mod_a.fn_a")],
+        "mod_b.py": [_sym("pkg.mod_b.fn_b")],
+    }
+    shas = {
+        "mod_a.py": _sha256(content_a),
+        "mod_b.py": _sha256(b"def fn_b(): pass\n"),
+    }
+    idx = _make_idx(tmp_path, {"pkg.mod_a.fn_a": [], "pkg.mod_b.fn_b": []}, skeletons, shas)
+
+    # Search only matches fn_a; fn_b is in a dirty file but not in results
+    result = idx.search("fn_a")
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+# ---------------------------------------------------------------------------
+# 5. neighborhood
+# ---------------------------------------------------------------------------
+
+def _raw_neighborhood() -> dict[str, list[str]]:
+    return {
+        "pkg.mod.hub": ["pkg.mod.spoke_a", "pkg.mod.spoke_b"],
+        "pkg.mod.spoke_a": [],
+        "pkg.mod.spoke_b": [],
+    }
+
+
+def test_neighborhood_clean(tmp_path: Path) -> None:
+    """neighborhood returns stale: false when backing files are clean."""
+    content = b"def hub(): pass\n"
+    (tmp_path / "mod.py").write_bytes(content)
+    skeletons = {
+        "mod.py": [
+            _sym("pkg.mod.hub"),
+            _sym("pkg.mod.spoke_a"),
+            _sym("pkg.mod.spoke_b"),
+        ]
+    }
+    shas = {"mod.py": _sha256(content)}
+    idx = _make_idx(tmp_path, _raw_neighborhood(), skeletons, shas)
+
+    result = idx.neighborhood("pkg.mod.hub", depth=1)
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+def test_neighborhood_stale(tmp_path: Path) -> None:
+    """neighborhood returns stale: true when an edge node's file changed."""
+    (tmp_path / "mod.py").write_bytes(b"def hub(): return spoke_a()\n")
+    skeletons = {
+        "mod.py": [
+            _sym("pkg.mod.hub"),
+            _sym("pkg.mod.spoke_a"),
+            _sym("pkg.mod.spoke_b"),
+        ]
+    }
+    shas = {"mod.py": _sha256(b"def hub(): pass\n")}
+    idx = _make_idx(tmp_path, _raw_neighborhood(), skeletons, shas)
+
+    result = idx.neighborhood("pkg.mod.hub", depth=1)
+    assert result["stale"] is True
+    assert "mod.py" in result["stale_files"]
+
+
+# ---------------------------------------------------------------------------
+# 6. module_callers / module_callees
+# ---------------------------------------------------------------------------
+
+def _raw_module() -> dict[str, list[str]]:
+    """pkg.core calls pkg.util functions."""
+    return {
+        "pkg.core.run": ["pkg.util.helper"],
+        "pkg.util.helper": [],
+    }
+
+
+def test_module_callers_clean(tmp_path: Path) -> None:
+    """module_callers returns stale: false when backing files are clean."""
+    content = b"def run(): pass\n"
+    (tmp_path / "core.py").write_bytes(content)
+    skeletons = {"core.py": [_sym("pkg.core.run")]}
+    shas = {"core.py": _sha256(content)}
+    idx = _make_idx(tmp_path, _raw_module(), skeletons, shas)
+
+    # pkg.core calls pkg.util; module_callers("pkg.util") → ["pkg.core"]
+    result = idx.module_callers("pkg.util")
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+def test_module_callers_stale(tmp_path: Path) -> None:
+    """module_callers returns stale: true when a result module's file changed."""
+    (tmp_path / "core.py").write_bytes(b"def run(): return helper()\n")
+    skeletons = {"core.py": [_sym("pkg.core.run")]}
+    shas = {"core.py": _sha256(b"def run(): pass\n")}
+    idx = _make_idx(tmp_path, _raw_module(), skeletons, shas)
+
+    result = idx.module_callers("pkg.util")
+    assert result["stale"] is True
+    assert "core.py" in result["stale_files"]
+
+
+def test_module_callees_clean(tmp_path: Path) -> None:
+    """module_callees returns stale: false when backing files are clean."""
+    content = b"def helper(): pass\n"
+    (tmp_path / "util.py").write_bytes(content)
+    skeletons = {"util.py": [_sym("pkg.util.helper")]}
+    shas = {"util.py": _sha256(content)}
+    idx = _make_idx(tmp_path, _raw_module(), skeletons, shas)
+
+    # module_callees("pkg.core") → ["pkg.util"]
+    result = idx.module_callees("pkg.core")
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+
+
+def test_module_callees_stale(tmp_path: Path) -> None:
+    """module_callees returns stale: true when a result module's file changed."""
+    (tmp_path / "util.py").write_bytes(b"def helper(): return 42\n")
+    skeletons = {"util.py": [_sym("pkg.util.helper")]}
+    shas = {"util.py": _sha256(b"def helper(): pass\n")}
+    idx = _make_idx(tmp_path, _raw_module(), skeletons, shas)
+
+    result = idx.module_callees("pkg.core")
+    assert result["stale"] is True
+    assert "util.py" in result["stale_files"]
+
+
+def test_module_callers_pre_v3(tmp_path: Path) -> None:
+    """module_callers with pre-v3 index returns index_format_incompatible."""
+    skeletons = {"core.py": [_sym("pkg.core.run")]}
+    idx = _make_idx(tmp_path, _raw_module(), skeletons, file_shas=None)
+    result = idx.module_callers("pkg.util")
+    assert result["stale"] is True
+    assert result["index_stale_reason"] == "index_format_incompatible"


### PR DESCRIPTION
Closes #51
Closes #52

## What changed

Before this PR, only `file_skeleton` reported whether its source file had changed since the last build, using a nested `staleness_info` dict with a free-form `reason` field. Every other query tool (`callers_of`, `callees_of`, `module_callers`, `module_callees`, `search`, `neighborhood`) returned results with no indication of whether those results were current.

This PR adds a uniform staleness shape to all 7 data-returning tools. The staleness check is result-scoped: only the files that back the actual returned FQNs are SHA-checked, not the entire index. This keeps the latency cost proportional to the result set rather than index size.

## Implementation walkthrough

### New / modified functions

**`CallGraphIndex._fqn_to_file: dict[str, str]` in `src/pyscope_mcp/graph.py`** — A non-serialised dataclass field built at `from_raw()` time by inverting `skeletons`. For each `(rel_path, symbols)` entry in skeletons, each `sym["fqn"]` maps to `rel_path`. This gives O(1) lookup of "which file does this FQN live in?" without a schema change (skeletons were already present in v3 indexes).

**`CallGraphIndex._staleness_for(fqns: list[str]) -> dict`** — The core staleness helper. Looks up each FQN in `_fqn_to_file` to find the backing file set, then SHA256-checks those files against `file_shas`. Returns the uniform shape: `{"stale": False, "stale_files": []}` on clean; `{"stale": True, "stale_files": [...], "stale_action": "..."}` on dirty; `{"stale": True, "stale_files": [], "index_stale_reason": "index_format_incompatible", "stale_action": "..."}` when `file_shas is None` (pre-v3 index). The pre-v3 path short-circuits before any disk access.

**`CallGraphIndex._staleness_for_modules(module_fqns: list[str]) -> dict`** — Module FQNs (e.g. `pkg.mod`) are not in `_fqn_to_file` — only function/class/method FQNs are. This helper expands each module FQN to symbol FQNs by prefix-matching: finds all `_fqn_to_file` keys starting with `module_fqn + "."`, then delegates to `_staleness_for`. A split-module (one module across multiple files) is handled correctly — all files are checked.

**`CallGraphIndex.file_skeleton()` migration** — Replaced the `staleness_info: {reason, action}` nested dict with the uniform shape. All four previous `reason` strings (`file_changed`, `file_not_found`, `file_not_in_index`, `index_format_incompatible`) are now represented via `stale_files` (populated or empty) and `index_stale_reason` (present or absent). The `isError` path still sets `isError: True` alongside the new stale fields.

### How components interact

At `from_raw()` / `load()` time: skeletons → `_fqn_to_file` (one-time O(symbols) pass).

At query time for each tool:
1. Tool runs its BFS / search / neighborhood logic as before, producing a list of result FQNs.
2. Tool calls `_staleness_for(result_fqns)` (or `_staleness_for_modules` for module tools).
3. Helper looks up file paths, SHA-checks only those files, returns stale dict.
4. Tool merges stale dict into its return value via `**staleness`.

### Default execution path

**Before**: `callers_of("pkg.mod.fn")` → `_bfs(...)` → `CallersResult(results=[...], truncated=...)`. No staleness information.

**After**: `callers_of("pkg.mod.fn")` → `_bfs(...)` → `_staleness_for(results)` → SHA-check files backing results → `CallersResult(results=[...], truncated=..., stale=..., stale_files=[...])`. Stale fields always present; `stale_action` present only when `stale=True`.

### Edge cases and error handling

- **FQN not in skeletons**: `_staleness_for` silently skips FQNs with no `_fqn_to_file` entry. If all result FQNs are unmapped (e.g. when skeletons are empty), the result is `stale: false, stale_files: []` — conservative clean.
- **File deleted post-build**: `_staleness_for` checks `live_file.exists()` before SHA — a missing file is treated as stale.
- **Pre-v3 index**: All tools short-circuit through the `file_shas is None` guard, returning `index_stale_reason: "index_format_incompatible"` without any disk access.
- **Module tools with no skeleton entries for result modules**: `_staleness_for_modules` finds no symbol FQNs for the module prefix → `_staleness_for([])` → returns clean. This is not a Law 1 violation because no result FQNs were mappable — absence of evidence is not evidence of freshness, but the tool cannot do better without schema changes.

### What was intentionally not changed

- `stats` and `reload` are exempt (stats returns aggregate integers with no addressable FQNs; reload produces a definitionally fresh index).
- Index schema stays at v3 — `_fqn_to_file` is rebuilt at load time, not stored.
- No in-memory SHA cache between queries (not needed per spec).
- No per-edge staleness annotation within neighborhood results.

## Tier / approach

Tier 2 — Planner → single Coder wave → full test suite validation

## Acceptance criteria

- [x] `_fqn_to_file` populated by inverting `skeletons` at `from_raw()` time
- [x] `_staleness_for()` returns uniform shape; pre-v3 short-circuits
- [x] `callers_of` / `callees_of` include stale fields after BFS
- [x] `search` includes stale fields after match collection
- [x] `neighborhood` includes stale fields from unique FQNs in kept edges
- [x] `module_callers` / `module_callees` expand module FQNs via prefix matching
- [x] `file_skeleton` migrated from `staleness_info` to uniform shape (breaking, accepted)
- [x] `types.py` TypedDicts updated; new `ModuleResult` TypedDict added
- [x] `server.py` tool descriptions updated; `staleness_info` reference removed from comment
- [x] `test_file_skeleton.py` stale assertions updated to new shape; no `staleness_info` references remain in production code
- [x] New `tests/test_staleness.py`: unit tests for `_fqn_to_file`, `_staleness_for`, per-tool stale/clean paths
- [x] New E2E test: modify source post-build, call `callers_of` over wire, assert `stale: true`
- [x] All 517 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)