### PR TITLE
fix(#60): completeness field — per-result signal when graph answer may be incomplete

### DIFF
--- a/src/pyscope_mcp/cli.py
+++ b/src/pyscope_mcp/cli.py
@@ -61,7 +61,22 @@ def cmd_build(args: argparse.Namespace) -> int:
     from pyscope_mcp.analyzer import build_with_report
 
     raw, miss_report, skeletons, file_shas = build_with_report(root, package=package or root.name)
-    idx = CallGraphIndex.from_raw(root, raw, skeletons=skeletons, file_shas=file_shas)
+
+    # Inline missed_callers into index.json at build time (Law 3: single artifact).
+    # Aggregate per-caller pattern counts from the flat unresolved_calls list.
+    # The miss_report["unresolved_calls"] is a flat list of dicts with keys:
+    #   "caller", "pattern", "file", "line", "snippet"
+    missed_callers: dict[str, dict[str, int]] = {}
+    for entry in miss_report.get("unresolved_calls", []):
+        caller = entry["caller"]
+        pattern = entry["pattern"]
+        if caller not in missed_callers:
+            missed_callers[caller] = {}
+        missed_callers[caller][pattern] = missed_callers[caller].get(pattern, 0) + 1
+
+    idx = CallGraphIndex.from_raw(
+        root, raw, skeletons=skeletons, file_shas=file_shas, missed_callers=missed_callers
+    )
     idx.save(out)
 
     # Write misses sidecar next to index.json

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 from pyscope_mcp.types import (
     CalleesResult,
     CallersResult,
+    Completeness,
     ModuleResult,
     NeighborhoodResult,
     SearchResult,
@@ -138,8 +139,12 @@ class CallGraphIndex:
     module_graph: _DiGraph = field(default_factory=_DiGraph)
     raw: dict[str, list[str]] = field(default_factory=dict)
     skeletons: dict[str, list[SymbolSummary]] = field(default_factory=dict)
-    # None = pre-v3 index (no hashes stored); dict = v3 index with per-file SHA256 digests.
+    # None = pre-v3 index (no hashes stored); dict = v3/v4 index with per-file SHA256 digests.
     file_shas: dict[str, str] | None = field(default=None)
+    # v4+: maps caller FQN → {pattern: count} for unresolved static-dispatch calls.
+    # Empty dict on v4 indexes with zero misses. Present only in v4+; absent from
+    # older indexes (which are rejected by load()).
+    missed_callers: dict[str, dict[str, int]] = field(default_factory=dict)
     # Derived at load/from_raw time: maps FQN → relative file path (inverted from skeletons).
     # Not serialised — rebuilt on every load.
     _fqn_to_file: dict[str, str] = field(default_factory=dict, repr=False)
@@ -151,6 +156,7 @@ class CallGraphIndex:
         raw: dict[str, list[str]],
         skeletons: dict[str, list[SymbolSummary]] | None = None,
         file_shas: dict[str, str] | None = None,
+        missed_callers: dict[str, dict[str, int]] | None = None,
     ) -> "CallGraphIndex":
         root = Path(root).resolve()
         fg = _DiGraph()
@@ -177,6 +183,7 @@ class CallGraphIndex:
             raw=raw,
             skeletons=skeletons,
             file_shas=file_shas,
+            missed_callers=missed_callers if missed_callers is not None else {},
             _fqn_to_file=fqn_to_file,
         )
 
@@ -184,11 +191,12 @@ class CallGraphIndex:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         payload: dict = {
-            "version": 3,
+            "version": 4,
             "root": str(self.root),
             "raw": self.raw,
             "skeletons": self.skeletons,
             "file_shas": self.file_shas if self.file_shas is not None else {},
+            "missed_callers": self.missed_callers,
         }
         path.write_text(json.dumps(payload))
         return path
@@ -198,20 +206,81 @@ class CallGraphIndex:
         path = Path(path)
         payload = json.loads(path.read_text())
         version = payload.get("version")
-        if version not in (1, 2, 3):
-            raise ValueError(f"unsupported index version: {version}")
+        if version != 4:
+            raise ValueError(
+                f"index schema is v{version}, server requires v4 — "
+                "run 'pyscope-mcp build' to regenerate"
+            )
         skeletons: dict[str, list[SymbolSummary]] = payload.get("skeletons", {})
-        # v1/v2: no file_shas stored — use None as sentinel to signal pre-v3.
-        # v3: read the stored file_shas dict.
-        file_shas: dict[str, str] | None = None if version < 3 else payload.get("file_shas", {})
+        file_shas: dict[str, str] = payload.get("file_shas", {})
+        missed_callers: dict[str, dict[str, int]] = payload.get("missed_callers", {})
         return cls.from_raw(
             Path(payload["root"]),
             payload["raw"],
             skeletons=skeletons,
             file_shas=file_shas,
+            missed_callers=missed_callers,
         )
 
     _STALE_ACTION = "Run 'pyscope-mcp build' then 'reload' to update the index."
+
+    @staticmethod
+    def _class_prefix(fqn: str) -> str | None:
+        """Return the class-level FQN prefix for a method FQN, or None.
+
+        A method FQN has ≥4 dotted segments (e.g. ``pkg.mod.MyClass.method``
+        → ``pkg.mod.MyClass``).  Top-level functions have ≤3 segments
+        (e.g. ``pkg.mod.func`` or ``pkg.func``) and return ``None`` —
+        they never trip the class-prefix path.
+
+        The "≥4 segments" rule derives from the minimum realistic Python FQN
+        for a method: ``<package>.<module>.<Class>.<method>``.  Three-segment
+        FQNs (e.g. ``pkg.mod.func``) are always top-level functions.
+
+        Examples:
+          ``pkg.mod.MyClass.method`` → ``pkg.mod.MyClass``  (4 segments)
+          ``a.b.c.D.method``         → ``a.b.c.D``          (5 segments)
+          ``pkg.mod.func``           → ``None``              (3 segments)
+          ``pkg.func``               → ``None``              (2 segments)
+        """
+        parts = fqn.split(".")
+        if len(parts) >= 4:
+            return ".".join(parts[:-1])
+        return None
+
+    def completeness_for(self, fqns: list[str]) -> Completeness:
+        """Return the completeness status for a set of traversed FQNs.
+
+        Returns ``"partial"`` if any FQN in *fqns* is:
+          - directly present as a key in ``self.missed_callers`` (direct hit), OR
+          - a method of a class (≥3 dotted segments) whose class prefix (all but
+            the last segment) is a prefix of any key in ``self.missed_callers``.
+            E.g. ``a.b.C.bar`` is partial if ``a.b.C.foo`` is in missed_callers,
+            because both share the class prefix ``a.b.C``.
+
+        Top-level functions (≤2 dotted segments) NEVER trip the class-prefix path;
+        they only return ``"partial"`` on a direct hit.
+
+        Returns ``"complete"`` when ``missed_callers`` is empty or no FQN in
+        *fqns* matches either condition.
+        """
+        if not self.missed_callers:
+            return "complete"
+        missed_keys = set(self.missed_callers.keys())
+        for fqn in fqns:
+            # Direct hit
+            if fqn in missed_keys:
+                return "partial"
+            # Class-prefix hit (methods only)
+            prefix = self._class_prefix(fqn)
+            if prefix is not None:
+                # Any missed_callers key that starts with "<prefix>." means a
+                # sibling method in the same class has unresolved calls.
+                prefix_dot = prefix + "."
+                for key in missed_keys:
+                    if key.startswith(prefix_dot):
+                        return "partial"
+        return "complete"
 
     def _staleness_for(self, fqns: list[str]) -> dict:
         """Compute result-scoped staleness for a list of FQNs.
@@ -335,7 +404,8 @@ class CallGraphIndex:
 
         Results are capped at 50; ``truncated`` signals when the cap fires.
         Response includes uniform staleness fields (``stale``, ``stale_files``,
-        and optionally ``stale_action`` / ``index_stale_reason``).
+        and optionally ``stale_action`` / ``index_stale_reason``) and a
+        ``completeness`` field (``"complete"`` or ``"partial"``).
         """
         all_results = _bfs(self.function_graph.reverse(copy=False), fqn, depth)
         truncated = len(all_results) > self._CALLERS_CALLEES_CAP
@@ -344,6 +414,7 @@ class CallGraphIndex:
         return CallersResult(
             results=results,
             truncated=truncated,
+            completeness=self.completeness_for(results),
             **staleness,  # type: ignore[arg-type]
         )
 
@@ -352,7 +423,8 @@ class CallGraphIndex:
 
         Results are capped at 50; ``truncated`` signals when the cap fires.
         Response includes uniform staleness fields (``stale``, ``stale_files``,
-        and optionally ``stale_action`` / ``index_stale_reason``).
+        and optionally ``stale_action`` / ``index_stale_reason``) and a
+        ``completeness`` field (``"complete"`` or ``"partial"``).
         """
         all_results = _bfs(self.function_graph, fqn, depth)
         truncated = len(all_results) > self._CALLERS_CALLEES_CAP
@@ -361,6 +433,7 @@ class CallGraphIndex:
         return CalleesResult(
             results=results,
             truncated=truncated,
+            completeness=self.completeness_for(results),
             **staleness,  # type: ignore[arg-type]
         )
 
@@ -438,6 +511,7 @@ class CallGraphIndex:
                 edges=[],
                 truncated=False,
                 token_budget_used=0,
+                completeness=self.completeness_for([symbol]),
             )
             result.update(staleness)  # type: ignore[arg-type]
             return result
@@ -510,6 +584,7 @@ class CallGraphIndex:
             edges=[[c, e] for c, e in kept_edges],
             truncated=truncated,
             token_budget_used=chars_used // 4,
+            completeness=self.completeness_for(unique_fqns),
         )
         result.update(staleness)  # type: ignore[arg-type]
         if truncated and depth_truncated is not None:
@@ -528,16 +603,19 @@ class CallGraphIndex:
 
         Staleness is result-scoped: module FQNs are expanded to file paths via
         prefix-matching against ``_fqn_to_file`` (find all symbol FQNs that start
-        with ``result_module + "."``).
+        with ``result_module + "."``).  Completeness is computed over the same
+        expanded symbol FQN set.
         """
         base = _prefix_module_bfs(
             self.module_graph.reverse(copy=False), self.module_graph, module, depth
         )
         result_modules: list[str] = base["results"]  # type: ignore[assignment]
         staleness = self._staleness_for_modules(result_modules)
+        symbol_fqns = self._expand_modules_to_symbols(result_modules)
         return ModuleResult(
             results=result_modules,
             truncated=base["truncated"],  # type: ignore[typeddict-item]
+            completeness=self.completeness_for(symbol_fqns),
             **staleness,  # type: ignore[arg-type]
         )
 
@@ -545,15 +623,33 @@ class CallGraphIndex:
         """Return callees of all modules whose FQN starts with *module* (prefix query).
 
         Symmetric to :meth:`module_callers` — see its docstring for semantics.
+        Completeness is computed over the expanded symbol FQNs of the result modules.
         """
         base = _prefix_module_bfs(self.module_graph, self.module_graph, module, depth)
         result_modules: list[str] = base["results"]  # type: ignore[assignment]
         staleness = self._staleness_for_modules(result_modules)
+        symbol_fqns = self._expand_modules_to_symbols(result_modules)
         return ModuleResult(
             results=result_modules,
             truncated=base["truncated"],  # type: ignore[typeddict-item]
+            completeness=self.completeness_for(symbol_fqns),
             **staleness,  # type: ignore[arg-type]
         )
+
+    def _expand_modules_to_symbols(self, module_fqns: list[str]) -> list[str]:
+        """Expand module FQNs to the symbol FQNs they contain.
+
+        Module FQNs (e.g. ``pkg.mod``) are not directly stored in ``_fqn_to_file``;
+        only function/class/method FQNs are.  Expansion finds all ``_fqn_to_file``
+        keys that start with ``module_fqn + "."``.
+        """
+        symbol_fqns: list[str] = []
+        for mod in module_fqns:
+            prefix = mod + "."
+            for fqn in self._fqn_to_file:
+                if fqn.startswith(prefix):
+                    symbol_fqns.append(fqn)
+        return symbol_fqns
 
     def _staleness_for_modules(self, module_fqns: list[str]) -> dict:
         """Expand module FQNs to symbol FQNs and delegate to ``_staleness_for``.
@@ -569,13 +665,7 @@ class CallGraphIndex:
                 "index_stale_reason": "index_format_incompatible",
                 "stale_action": self._STALE_ACTION,
             }
-        symbol_fqns: list[str] = []
-        for mod in module_fqns:
-            prefix = mod + "."
-            for fqn in self._fqn_to_file:
-                if fqn.startswith(prefix):
-                    symbol_fqns.append(fqn)
-        return self._staleness_for(symbol_fqns)
+        return self._staleness_for(self._expand_modules_to_symbols(module_fqns))
 
     def search(self, substring: str, limit: int = 50) -> SearchResult:
         """Substring search over known fully-qualified function names.

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -72,7 +72,12 @@ _TOOL_LIST = [
             "Results are capped at 50; when the cap triggers, `truncated` is true. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
-            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
+            "Response includes `completeness: 'complete' | 'partial'`. "
+            "'partial' means at least one result FQN has unresolved static-dispatch calls "
+            "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
+            "treating the result as exhaustive. "
+            "'complete' means no result FQN (or its class siblings) appears in the miss log. "
+            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -91,7 +96,12 @@ _TOOL_LIST = [
             "Results are capped at 50; when the cap triggers, `truncated` is true. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
-            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
+            "Response includes `completeness: 'complete' | 'partial'`. "
+            "'partial' means at least one result FQN has unresolved static-dispatch calls "
+            "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
+            "treating the result as exhaustive. "
+            "'complete' means no result FQN (or its class siblings) appears in the miss log. "
+            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -115,7 +125,11 @@ _TOOL_LIST = [
             "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
-            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
+            "Response includes `completeness: 'complete' | 'partial'`. "
+            "'partial' means at least one symbol in the result modules has unresolved "
+            "static-dispatch calls — verify with grep before treating as exhaustive. "
+            "'complete' means no symbol in the result modules appears in the miss log. "
+            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -142,7 +156,11 @@ _TOOL_LIST = [
             "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
-            "Returns {results: [...], truncated: bool, stale: bool, stale_files: [...]}."
+            "Response includes `completeness: 'complete' | 'partial'`. "
+            "'partial' means at least one symbol in the result modules has unresolved "
+            "static-dispatch calls — verify with grep before treating as exhaustive. "
+            "'complete' means no symbol in the result modules appears in the miss log. "
+            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -219,8 +237,12 @@ _TOOL_LIST = [
             "Default token_budget=1000. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
+            "Response includes `completeness: 'complete' | 'partial'`. "
+            "'partial' means at least one FQN in the neighborhood has unresolved "
+            "static-dispatch calls — verify with grep before treating as exhaustive. "
+            "'complete' means no FQN in the neighborhood appears in the miss log. "
             "Returns {symbol, depth_full, depth_truncated?, edges: [[caller, callee], ...], "
-            "truncated: bool, token_budget_used: int, stale: bool, stale_files: [...]}."
+            "truncated: bool, token_budget_used: int, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",

--- a/src/pyscope_mcp/types.py
+++ b/src/pyscope_mcp/types.py
@@ -8,7 +8,16 @@ existence when it houses multiple TypedDicts together rather than one in isolati
 
 from __future__ import annotations
 
-from typing import NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
+
+# Two-state completeness signal for every edge-traversing tool response.
+# "complete"  — none of the traversed FQNs appear in missed_callers (directly
+#               or via class-prefix match).  The result is probably the full picture.
+# "partial"   — at least one traversed FQN is directly in missed_callers, OR is
+#               a method (≥3 dotted segments) whose class prefix (e.g. a.b.C for
+#               a.b.C.method) matches a missed_callers key.  The result is
+#               definitely or likely incomplete — widen with grep.
+Completeness = Literal["complete", "partial"]
 
 
 class SearchResult(TypedDict):
@@ -37,6 +46,7 @@ class CallersResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    completeness: Completeness
     stale: bool
     stale_files: list[str]
     stale_action: NotRequired[str]
@@ -48,6 +58,7 @@ class CalleesResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    completeness: Completeness
     stale: bool
     stale_files: list[str]
     stale_action: NotRequired[str]
@@ -60,6 +71,7 @@ class ModuleResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    completeness: Completeness
     stale: bool
     stale_files: list[str]
     stale_action: NotRequired[str]
@@ -74,7 +86,7 @@ class NeighborhoodResult(TypedDict, total=False):
     ``depth_truncated`` is present **only** when ``truncated=True``; it is
     absent from the dict when ``truncated=False``.
     ``stale_action`` is present only when ``stale=True``.
-    ``index_stale_reason`` is present only on the pre-v3 index path.
+    ``index_stale_reason`` is present only on the pre-v3 (pre-v4) index path.
 
     ``total=False`` is used (rather than a base-class split) because multiple
     fields must be omitted entirely when not applicable — ``NotRequired`` marks
@@ -91,6 +103,7 @@ class NeighborhoodResult(TypedDict, total=False):
     edges: list[list[str]]  # list of [caller, callee] pairs
     truncated: bool
     token_budget_used: int
+    completeness: Completeness
     stale: bool
     stale_files: list[str]
     stale_action: NotRequired[str]

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,0 +1,409 @@
+"""Tests for the completeness field on all edge-traversing tools.
+
+Covers:
+  - completeness_for() helper directly
+  - callers_of completeness
+  - callees_of completeness
+  - neighborhood completeness (isolated node + main path)
+  - module_callers completeness (via symbol expansion)
+  - module_callees completeness
+  - v4 save/load round-trip for missed_callers
+  - v3 (and older) index rejection
+
+Acceptance scenarios from the refined spec (#60):
+  (a) "complete" when missed_callers={}
+  (b) "partial" on direct hit
+  (c) "partial" on class-prefix hit (method whose class sibling has misses)
+  (d) "complete" for top-level function whose module sibling has misses (negative case)
+  (e) all five tools route through completeness_for()
+  (f) completeness_for() exercised directly
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sym(fqn: str, kind: str = "function", lineno: int = 1) -> SymbolSummary:
+    return SymbolSummary(
+        fqn=fqn,
+        kind=kind,
+        signature=f"def {fqn.split('.')[-1]}(): ...",
+        lineno=lineno,
+    )
+
+
+def _make_idx(
+    raw: dict[str, list[str]],
+    missed_callers: dict[str, dict[str, int]] | None = None,
+    skeletons: dict[str, list[SymbolSummary]] | None = None,
+    file_shas: dict[str, str] | None = None,
+) -> CallGraphIndex:
+    return CallGraphIndex.from_raw(
+        "/tmp/test",
+        raw,
+        skeletons=skeletons or {},
+        file_shas=file_shas or {},
+        missed_callers=missed_callers or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. completeness_for() helper — direct unit tests (scenario f)
+# ---------------------------------------------------------------------------
+
+class TestCompletenessFor:
+    def test_empty_missed_callers_returns_complete(self) -> None:
+        """(a) No missed_callers → always 'complete'."""
+        idx = _make_idx({}, missed_callers={})
+        assert idx.completeness_for([]) == "complete"
+        assert idx.completeness_for(["pkg.mod.func"]) == "complete"
+        assert idx.completeness_for(["pkg.mod.MyClass.method"]) == "complete"
+
+    def test_direct_hit_returns_partial(self) -> None:
+        """(b) FQN directly in missed_callers → 'partial'."""
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx({}, missed_callers=missed)
+        assert idx.completeness_for(["pkg.mod.MyClass.foo"]) == "partial"
+
+    def test_class_prefix_hit_returns_partial(self) -> None:
+        """(c) Method whose class sibling is in missed_callers → 'partial'."""
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx({}, missed_callers=missed)
+        # pkg.mod.MyClass.bar is not directly missed, but shares class pkg.mod.MyClass
+        assert idx.completeness_for(["pkg.mod.MyClass.bar"]) == "partial"
+
+    def test_top_level_function_module_sibling_returns_complete(self) -> None:
+        """(d) Top-level function whose module sibling has misses → 'complete'.
+
+        Top-level functions (≤2 dotted segments after module part) NEVER trip the
+        class-prefix path — only direct hits flip them.
+        """
+        missed = {"pkg.mod.dirty_func": {"bare_name_unresolved": 1}}
+        idx = _make_idx({}, missed_callers=missed)
+        # pkg.mod.clean_func is top-level, same module — must NOT be flagged partial
+        assert idx.completeness_for(["pkg.mod.clean_func"]) == "complete"
+
+    def test_method_class_prefix_negative_no_sibling(self) -> None:
+        """Method with class prefix that doesn't match any missed key → 'complete'."""
+        missed = {"pkg.mod.OtherClass.method": {"getattr_nonliteral": 1}}
+        idx = _make_idx({}, missed_callers=missed)
+        # pkg.mod.MyClass.bar has class prefix pkg.mod.MyClass — no key starts with that
+        assert idx.completeness_for(["pkg.mod.MyClass.bar"]) == "complete"
+
+    def test_empty_fqn_list_returns_complete(self) -> None:
+        """Empty FQN list → 'complete' regardless of missed_callers."""
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx({}, missed_callers=missed)
+        assert idx.completeness_for([]) == "complete"
+
+    def test_multiple_fqns_one_hit_returns_partial(self) -> None:
+        """Mixed list: one direct hit → 'partial'."""
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx({}, missed_callers=missed)
+        assert idx.completeness_for(["pkg.other.clean", "pkg.mod.MyClass.foo"]) == "partial"
+
+
+# ---------------------------------------------------------------------------
+# 2. _class_prefix() helper
+# ---------------------------------------------------------------------------
+
+class TestClassPrefix:
+    def test_method_returns_class_prefix(self) -> None:
+        # 4 segments: pkg.mod.MyClass.method → pkg.mod.MyClass
+        assert CallGraphIndex._class_prefix("a.b.C.method") == "a.b.C"
+
+    def test_top_level_two_segments_returns_none(self) -> None:
+        assert CallGraphIndex._class_prefix("pkg.func") is None
+
+    def test_top_level_one_segment_returns_none(self) -> None:
+        assert CallGraphIndex._class_prefix("func") is None
+
+    def test_top_level_three_segments_returns_none(self) -> None:
+        # pkg.mod.func has 3 segments — top-level function, not a method
+        assert CallGraphIndex._class_prefix("pkg.mod.func") is None
+
+    def test_nested_class_method(self) -> None:
+        # a.b.c.D.method → prefix is a.b.c.D (5 segments)
+        assert CallGraphIndex._class_prefix("a.b.c.D.method") == "a.b.c.D"
+
+    def test_exactly_four_segments(self) -> None:
+        # pkg.mod.Cls.method → prefix is pkg.mod.Cls (4 segments = minimum method shape)
+        assert CallGraphIndex._class_prefix("pkg.mod.Cls.method") == "pkg.mod.Cls"
+
+
+# ---------------------------------------------------------------------------
+# 3. callers_of completeness (scenario e + acceptance scenario for callers_of)
+# ---------------------------------------------------------------------------
+
+class TestCallersOfCompleteness:
+    _RAW = {
+        "pkg.mod.MyClass.foo": ["pkg.mod.helper"],
+        "pkg.mod.bar": ["pkg.mod.helper"],
+        "pkg.mod.helper": [],
+    }
+
+    def test_complete_when_no_misses(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={})
+        result = idx.callers_of("pkg.mod.helper")
+        assert result["completeness"] == "complete"
+
+    def test_partial_when_result_has_direct_miss(self) -> None:
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx(self._RAW, missed_callers=missed)
+        result = idx.callers_of("pkg.mod.helper")
+        # pkg.mod.MyClass.foo is in results and directly in missed_callers
+        assert "pkg.mod.MyClass.foo" in result["results"]
+        assert result["completeness"] == "partial"
+
+    def test_partial_when_result_has_class_sibling_miss(self) -> None:
+        # pkg.mod.MyClass.bar is NOT in results but pkg.mod.MyClass.foo IS
+        # and they share the class prefix pkg.mod.MyClass
+        raw = {
+            "pkg.mod.MyClass.bar": ["pkg.mod.helper"],
+            "pkg.mod.helper": [],
+        }
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx(raw, missed_callers=missed)
+        result = idx.callers_of("pkg.mod.helper")
+        assert "pkg.mod.MyClass.bar" in result["results"]
+        assert result["completeness"] == "partial"
+
+    def test_complete_for_top_level_sibling_miss(self) -> None:
+        # Only pkg.mod.bar in results — a top-level func
+        # dirty_func is top-level sibling in same module — must not flag bar
+        raw = {
+            "pkg.mod.bar": ["pkg.mod.helper"],
+            "pkg.mod.helper": [],
+        }
+        missed = {"pkg.mod.dirty_func": {"bare_name_unresolved": 1}}
+        idx = _make_idx(raw, missed_callers=missed)
+        result = idx.callers_of("pkg.mod.helper")
+        assert result["completeness"] == "complete"
+
+    def test_completeness_field_always_present(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={})
+        result = idx.callers_of("pkg.mod.helper")
+        assert "completeness" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. callees_of completeness
+# ---------------------------------------------------------------------------
+
+class TestCalleesOfCompleteness:
+    _RAW = {
+        "pkg.mod.MyClass.foo": ["pkg.mod.helper", "pkg.mod.other"],
+        "pkg.mod.helper": [],
+        "pkg.mod.other": [],
+    }
+
+    def test_complete_when_no_misses(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={})
+        result = idx.callees_of("pkg.mod.MyClass.foo")
+        assert result["completeness"] == "complete"
+
+    def test_partial_when_result_has_direct_miss(self) -> None:
+        # helper itself has misses
+        missed = {"pkg.mod.helper": {"getattr_nonliteral": 1}}
+        idx = _make_idx(self._RAW, missed_callers=missed)
+        result = idx.callees_of("pkg.mod.MyClass.foo")
+        assert "pkg.mod.helper" in result["results"]
+        assert result["completeness"] == "partial"
+
+    def test_completeness_field_always_present(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={})
+        result = idx.callees_of("pkg.mod.MyClass.foo")
+        assert "completeness" in result
+
+
+# ---------------------------------------------------------------------------
+# 5. neighborhood completeness
+# ---------------------------------------------------------------------------
+
+class TestNeighborhoodCompleteness:
+    _RAW = {
+        "pkg.mod.MyClass.foo": ["pkg.mod.helper"],
+        "pkg.mod.helper": ["pkg.mod.leaf"],
+        "pkg.mod.leaf": [],
+    }
+
+    def test_complete_when_no_misses(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={})
+        result = idx.neighborhood("pkg.mod.helper")
+        assert result["completeness"] == "complete"
+
+    def test_partial_when_neighborhood_fqn_directly_missed(self) -> None:
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 2}}
+        idx = _make_idx(self._RAW, missed_callers=missed)
+        result = idx.neighborhood("pkg.mod.helper", depth=2)
+        assert result["completeness"] == "partial"
+
+    def test_isolated_node_completeness_present(self) -> None:
+        """Isolated-node path (symbol not in graph) still returns completeness."""
+        idx = _make_idx({}, missed_callers={})
+        result = idx.neighborhood("nonexistent.symbol")
+        assert "completeness" in result
+        assert result["completeness"] == "complete"
+
+    def test_isolated_node_partial_when_directly_missed(self) -> None:
+        missed = {"nonexistent.symbol": {"bare_name_unresolved": 1}}
+        idx = _make_idx({}, missed_callers=missed)
+        result = idx.neighborhood("nonexistent.symbol")
+        assert result["completeness"] == "partial"
+
+    def test_completeness_field_always_present(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={})
+        result = idx.neighborhood("pkg.mod.helper")
+        assert "completeness" in result
+
+
+# ---------------------------------------------------------------------------
+# 6. module_callers / module_callees completeness
+# ---------------------------------------------------------------------------
+
+class TestModuleCompleteness:
+    # Module graph: pkg.other → pkg.target (pkg.other.SomeClass.method calls pkg.target.helper)
+    _RAW = {
+        "pkg.other.SomeClass.method": ["pkg.target.helper"],
+        "pkg.target.helper": [],
+    }
+    _SKELETONS: dict[str, list[SymbolSummary]] = {
+        "pkg/other.py": [
+            _sym("pkg.other.SomeClass.method", kind="method"),
+        ],
+        "pkg/target.py": [
+            _sym("pkg.target.helper"),
+        ],
+    }
+
+    def test_module_callers_complete_when_no_misses(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={}, skeletons=self._SKELETONS)
+        result = idx.module_callers("pkg.target")
+        assert result["completeness"] == "complete"
+
+    def test_module_callers_partial_when_symbol_in_result_module_is_missed(self) -> None:
+        # pkg.other.SomeClass.method has unresolved calls;
+        # _module_of("pkg.other.SomeClass.method") == "pkg.other.SomeClass", so that
+        # is what appears in the module graph and in the module_callers result.
+        missed = {"pkg.other.SomeClass.method": {"getattr_nonliteral": 2}}
+        idx = _make_idx(self._RAW, missed_callers=missed, skeletons=self._SKELETONS)
+        result = idx.module_callers("pkg.target")
+        # The module graph reports the caller as "pkg.other.SomeClass"
+        assert "pkg.other.SomeClass" in result["results"]
+        assert result["completeness"] == "partial"
+
+    def test_module_callers_partial_via_class_prefix_expansion(self) -> None:
+        # pkg.other.SomeClass.other_method is in the same class as the missed FQN.
+        # Expanding pkg.other reveals both. Class-prefix match fires.
+        missed = {"pkg.other.SomeClass.foo": {"getattr_nonliteral": 1}}
+        skeletons: dict[str, list[SymbolSummary]] = {
+            "pkg/other.py": [
+                _sym("pkg.other.SomeClass.method", kind="method"),
+                _sym("pkg.other.SomeClass.bar", kind="method"),
+            ],
+            "pkg/target.py": [_sym("pkg.target.helper")],
+        }
+        idx = _make_idx(self._RAW, missed_callers=missed, skeletons=skeletons)
+        result = idx.module_callers("pkg.target")
+        assert result["completeness"] == "partial"
+
+    def test_module_callees_complete_when_no_misses(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={}, skeletons=self._SKELETONS)
+        result = idx.module_callees("pkg.other")
+        assert result["completeness"] == "complete"
+
+    def test_module_callees_partial_when_callee_module_symbol_missed(self) -> None:
+        # pkg.target.helper has misses; pkg.target is in result of module_callees("pkg.other")
+        missed = {"pkg.target.helper": {"bare_name_unresolved": 1}}
+        idx = _make_idx(self._RAW, missed_callers=missed, skeletons=self._SKELETONS)
+        result = idx.module_callees("pkg.other")
+        assert "pkg.target" in result["results"]
+        assert result["completeness"] == "partial"
+
+    def test_module_completeness_field_always_present(self) -> None:
+        idx = _make_idx(self._RAW, missed_callers={}, skeletons=self._SKELETONS)
+        result = idx.module_callers("pkg.target")
+        assert "completeness" in result
+        result2 = idx.module_callees("pkg.other")
+        assert "completeness" in result2
+
+
+# ---------------------------------------------------------------------------
+# 7. save/load v4 round-trip + v3 rejection
+# ---------------------------------------------------------------------------
+
+class TestV4Schema:
+    def test_save_writes_version_4(self, tmp_path: Path) -> None:
+        idx = _make_idx(
+            {"pkg.mod.func": ["pkg.mod.other"]},
+            missed_callers={"pkg.mod.func": {"getattr_nonliteral": 2}},
+        )
+        out = tmp_path / "index.json"
+        idx.save(out)
+        payload = json.loads(out.read_text())
+        assert payload["version"] == 4
+
+    def test_save_writes_missed_callers(self, tmp_path: Path) -> None:
+        missed = {"pkg.mod.func": {"getattr_nonliteral": 2, "bare_name_unresolved": 1}}
+        idx = _make_idx({}, missed_callers=missed)
+        out = tmp_path / "index.json"
+        idx.save(out)
+        payload = json.loads(out.read_text())
+        assert "missed_callers" in payload
+        assert payload["missed_callers"] == missed
+
+    def test_load_v4_populates_missed_callers(self, tmp_path: Path) -> None:
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx({}, missed_callers=missed)
+        out = tmp_path / "index.json"
+        idx.save(out)
+        loaded = CallGraphIndex.load(out)
+        assert loaded.missed_callers == missed
+
+    def test_load_v4_completeness_for_works_after_roundtrip(self, tmp_path: Path) -> None:
+        missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
+        idx = _make_idx({}, missed_callers=missed)
+        out = tmp_path / "index.json"
+        idx.save(out)
+        loaded = CallGraphIndex.load(out)
+        assert loaded.completeness_for(["pkg.mod.MyClass.bar"]) == "partial"
+        assert loaded.completeness_for(["pkg.other.func"]) == "complete"
+
+    def test_load_v4_empty_missed_callers(self, tmp_path: Path) -> None:
+        idx = _make_idx({}, missed_callers={})
+        out = tmp_path / "index.json"
+        idx.save(out)
+        loaded = CallGraphIndex.load(out)
+        assert loaded.missed_callers == {}
+        assert loaded.completeness_for(["anything"]) == "complete"
+
+    @pytest.mark.parametrize("old_version", [1, 2, 3])
+    def test_load_rejects_old_versions(self, tmp_path: Path, old_version: int) -> None:
+        payload = {
+            "version": old_version,
+            "root": "/tmp/test",
+            "raw": {},
+            "skeletons": {},
+            "file_shas": {},
+        }
+        out = tmp_path / "index.json"
+        out.write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="v4"):
+            CallGraphIndex.load(out)
+
+    def test_load_rejects_unknown_version(self, tmp_path: Path) -> None:
+        payload = {"version": 99, "root": "/tmp", "raw": {}, "skeletons": {}, "file_shas": {}}
+        out = tmp_path / "index.json"
+        out.write_text(json.dumps(payload))
+        with pytest.raises(ValueError, match="v4"):
+            CallGraphIndex.load(out)

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -265,13 +265,13 @@ def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
     assert result["truncated"] is False
 
 
-def test_save_version_is_3(tmp_path: Path) -> None:
-    """Saved index must have version=3 (bumped from 2 in this release)."""
+def test_save_version_is_4(tmp_path: Path) -> None:
+    """Saved index must have version=4 (bumped from 3 to carry missed_callers)."""
     idx = CallGraphIndex.from_raw("/tmp/test", {})
     out = tmp_path / "index.json"
     idx.save(out)
     payload = _json.loads(out.read_text())
-    assert payload["version"] == 3
+    assert payload["version"] == 4
 
 
 def test_save_includes_file_shas(tmp_path: Path) -> None:
@@ -295,40 +295,43 @@ def test_save_load_roundtrip_file_shas(tmp_path: Path) -> None:
     assert loaded.file_shas == shas
 
 
-def test_load_version_1_backward_compat(tmp_path: Path) -> None:
-    """Version 1 index loads successfully; file_shas is None (pre-v3 sentinel)."""
+def test_load_version_1_raises(tmp_path: Path) -> None:
+    """Version 1 index raises a clear error naming v4 (no backward compat)."""
     payload = {"version": 1, "root": "/tmp/test", "raw": {}, "skeletons": {"any.py": []}}
     out = tmp_path / "v1_index.json"
     out.write_text(_json.dumps(payload))
 
-    loaded = CallGraphIndex.load(out)
-    assert loaded.skeletons == {"any.py": []}
-    assert loaded.file_shas is None
-    # Querying any known path on a pre-v3 index → stale: index_format_incompatible (uniform shape)
-    result = loaded.file_skeleton("any.py")
-    assert result["stale"] is True
-    assert result["stale_files"] == []
-    assert result["index_stale_reason"] == "index_format_incompatible"
-    assert "staleness_info" not in result
+    with pytest.raises(ValueError, match="v4"):
+        CallGraphIndex.load(out)
 
 
-def test_load_version_2_backward_compat(tmp_path: Path) -> None:
-    """Version 2 index loads successfully; file_shas is None (pre-v3 sentinel)."""
+def test_load_version_2_raises(tmp_path: Path) -> None:
+    """Version 2 index raises a clear error naming v4 (no backward compat)."""
     payload = {"version": 2, "root": "/tmp/test", "raw": {}, "skeletons": {}}
     out = tmp_path / "v2_index.json"
     out.write_text(_json.dumps(payload))
 
-    loaded = CallGraphIndex.load(out)
-    assert loaded.file_shas is None
+    with pytest.raises(ValueError, match="v4"):
+        CallGraphIndex.load(out)
+
+
+def test_load_version_3_raises(tmp_path: Path) -> None:
+    """Version 3 index raises a clear error naming v4 (no backward compat)."""
+    payload = {"version": 3, "root": "/tmp/test", "raw": {}, "skeletons": {}, "file_shas": {}}
+    out = tmp_path / "v3_index.json"
+    out.write_text(_json.dumps(payload))
+
+    with pytest.raises(ValueError, match="v4"):
+        CallGraphIndex.load(out)
 
 
 def test_load_version_future_raises(tmp_path: Path) -> None:
-    """Version > 3 raises ValueError (unknown format)."""
-    payload = {"version": 4, "root": "/tmp/test", "raw": {}, "skeletons": {}, "file_shas": {}}
-    out = tmp_path / "v4_index.json"
+    """Unknown version > 4 raises ValueError."""
+    payload = {"version": 5, "root": "/tmp/test", "raw": {}, "skeletons": {}, "file_shas": {}}
+    out = tmp_path / "v5_index.json"
     out.write_text(_json.dumps(payload))
 
-    with pytest.raises(ValueError, match="unsupported index version: 4"):
+    with pytest.raises(ValueError, match="v4"):
         CallGraphIndex.load(out)
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -54,10 +54,13 @@ def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     loaded = CallGraphIndex.load(out)
     assert loaded.stats() == idx.stats()
     # Compare only the query results (not staleness — the original idx has file_shas=None
-    # which produces a pre-v3 stale signal, while the saved+loaded index is v3 with no
-    # stored hashes and the symbol files aren't on disk, so staleness differs by design).
+    # while the saved+loaded v4 index has file_shas={} with no stored hashes and the
+    # symbol files aren't on disk, so staleness differs by design).
     assert loaded.search("helper")["results"] == idx.search("helper")["results"]
     assert loaded.search("helper")["truncated"] == idx.search("helper")["truncated"]
+    # v4 schema: missed_callers round-trips correctly (default is empty)
+    assert loaded.missed_callers == {}
+    assert loaded.completeness_for(["sample.a.top"]) == "complete"
 
 
 def _prefix_raw() -> dict[str, list[str]]:

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -572,3 +572,101 @@ def test_shutdown_then_eof_exits_zero(index_path: Path) -> None:
         if proc.poll() is None:
             proc.kill()
             proc.wait(timeout=2)
+
+
+def test_completeness_field_e2e(tmp_path: Path) -> None:
+    """E2E: build → serve → callers_of returns completeness='partial' when missed_callers present.
+
+    The package has two symbols:
+      - foo: called via getattr(obj, method_name)() in bar — unresolvable, ends up in missed_callers
+      - baz: never called dynamically — completeness='complete'
+
+    Verifies the full pipeline: analyzer miss-log → CLI aggregation → index v4 →
+    server completeness_for() → wire response.
+    """
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "core.py").write_text(
+        "def foo(): pass\n"
+        "\n"
+        "def bar(obj, method_name):\n"
+        "    foo()  # static edge: bar → foo, so bar appears as a caller of foo\n"
+        "    getattr(obj, method_name)()  # unresolved → bar ends up in missed_callers\n"
+        "\n"
+        "def baz(): return 1\n"
+    )
+
+    index_file = tmp_path / ".pyscope-mcp" / "index.json"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+
+    build_result = subprocess.run(
+        [sys.executable, "-m", "pyscope_mcp.cli", "build",
+         "--root", str(tmp_path), "--package", "mypkg",
+         "--output", str(index_file)],
+        capture_output=True, env=env,
+    )
+    assert build_result.returncode == 0, f"build failed: {build_result.stderr.decode()}"
+
+    payload = json.loads(index_file.read_text())
+    assert payload["version"] == 4, f"expected v4 index; got version={payload.get('version')}"
+    assert "missed_callers" in payload, "index must contain missed_callers"
+    # bar has an unresolvable getattr call — it must appear in missed_callers
+    assert "mypkg.core.bar" in payload["missed_callers"], (
+        f"expected mypkg.core.bar in missed_callers; got keys: {list(payload['missed_callers'])}"
+    )
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "pyscope_mcp.cli", "serve",
+         "--root", str(tmp_path), "--index", str(index_file)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                       "clientInfo": {"name": "e2e-completeness", "version": "0"}},
+        })
+        r = _recv(proc)
+        assert r["id"] == 1
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        # foo's callers include bar, which has missed dynamic calls → partial
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.foo"}},
+        })
+        r2 = _recv(proc)
+        assert r2["id"] == 2
+        assert "error" not in r2, f"unexpected JSON-RPC error: {r2}"
+        body2 = json.loads(r2["result"]["content"][0]["text"])
+        assert body2["completeness"] == "partial", (
+            f"expected partial (bar has a getattr miss); got completeness={body2.get('completeness')!r}\n"
+            f"full body: {body2}"
+        )
+
+        # baz has no callers and no missed_callers entry → complete
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.baz"}},
+        })
+        r3 = _recv(proc)
+        assert r3["id"] == 3
+        assert "error" not in r3, f"unexpected JSON-RPC error: {r3}"
+        body3 = json.loads(r3["result"]["content"][0]["text"])
+        assert body3["completeness"] == "complete", (
+            f"expected complete for baz; got completeness={body3.get('completeness')!r}\n"
+            f"full body: {body3}"
+        )
+
+        _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
+        r = _recv(proc)
+        assert r == {"jsonrpc": "2.0", "id": 99, "result": {}}
+        proc.stdin.close()
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -319,10 +319,11 @@ def test_file_skeleton_build_serve_e2e(tmp_path: Path) -> None:
     )
     assert build_result.returncode == 0, f"build failed: {build_result.stderr.decode()}"
 
-    # 3. Index is version 3 and contains skeletons + file_shas for core.py
+    # 3. Index is version 4 and contains skeletons + file_shas + missed_callers for core.py
     payload = json.loads(index_file.read_text())
-    assert payload["version"] == 3
-    assert "file_shas" in payload, "version 3 index must contain file_shas"
+    assert payload["version"] == 4
+    assert "file_shas" in payload, "version 4 index must contain file_shas"
+    assert "missed_callers" in payload, "version 4 index must contain missed_callers"
     rel = "mypkg/core.py"
     assert rel in payload["skeletons"], (
         f"expected '{rel}' in skeletons; got keys: {list(payload['skeletons'])}"


### PR DESCRIPTION
Closes #60

## What changed

Every edge-traversing tool (`callers_of`, `callees_of`, `module_callers`, `module_callees`, `neighborhood`) now returns a `completeness` field with value `"complete"` or `"partial"`. This closes a Law 1 gap: consuming agents could not previously distinguish "this is the full picture" from "this is what static analysis could prove." The fix inlines the miss-log data into `index.json` at build time (schema v4), keeping the serve path single-file with no startup penalty.

## Implementation walkthrough

### New / modified functions

**`CallGraphIndex._class_prefix(fqn: str) -> str | None` in `src/pyscope_mcp/graph.py`** — Static helper that extracts the class-level FQN prefix from a method FQN. Returns the prefix (`a.b.C` for `a.b.C.method`) when the FQN has ≥4 dotted segments (the minimum for a method: `<pkg>.<mod>.<Class>.<method>`). Returns `None` for top-level functions (≤3 segments). This is the key rule that prevents the "procedural module over-flagging" failure mode identified in Round 2 of the intent interview.

**`CallGraphIndex.completeness_for(fqns: list[str]) -> Completeness` in `src/pyscope_mcp/graph.py`** — Accepts a list of FQNs from a result set and returns `"partial"` if any FQN is directly in `missed_callers` (direct hit) or if any method-shaped FQN has a class prefix that is a prefix of any `missed_callers` key (class-prefix hit). Returns `"complete"` otherwise. The class-prefix rule fires only for methods (≥4 segments); top-level functions only flip status on a direct hit. Time complexity is O(|fqns| × |missed_callers|) in the worst case — both sets are small in practice.

**`CallGraphIndex.missed_callers: dict[str, dict[str, int]]`** — New dataclass field, default `{}`. Maps caller FQN → `{pattern: count}` for unresolved static-dispatch calls. Populated from `from_raw(missed_callers=...)` and round-tripped through `save()`/`load()`.

**`CallGraphIndex._expand_modules_to_symbols(module_fqns)` in `src/pyscope_mcp/graph.py`** — Extracted from `_staleness_for_modules()` (previously inlined). Expands module-level FQNs (e.g. `pkg.mod`) to the symbol FQNs they contain by prefix-matching against `_fqn_to_file`. Reused by both the staleness helper and `completeness_for()` for the module tools, routing module results through the same class-prefix logic as function results — no special-case code path.

**`CallGraphIndex.save()` / `CallGraphIndex.load()`** — `save()` now writes `"version": 4` and includes `"missed_callers"` in the payload. `load()` accepts only v4; older versions raise `ValueError: "index schema is vN, server requires v4 — run 'pyscope-mcp build' to regenerate"`. No silent backward-compatibility branch — a silent fallback would advertise `"complete"` on a stale index, which is the Law 1 violation this PR is closing.

**`cmd_build()` in `src/pyscope_mcp/cli.py`** — After `build_with_report()`, aggregates the flat `unresolved_calls` list from the miss report into `{caller_fqn: {pattern: count}}` and passes it as `missed_callers=` to `CallGraphIndex.from_raw()`. The pattern-count detail is retained on disk even though responses don't surface it; this means adding a `reason` field later is a server-only change with no rebuild required.

### How components interact

Build path: `build_with_report()` → aggregate `unresolved_calls` list → `CallGraphIndex.from_raw(missed_callers=...)` → `idx.save()` writes v4 JSON with `missed_callers` inlined.

Serve path (per query): `callers_of(fqn)` → BFS → `completeness_for(results)` → `"complete"` or `"partial"` → included in response alongside `stale` and `truncated`.

Module tools expand the module result set to symbol FQNs via `_expand_modules_to_symbols()` before calling `completeness_for()`, so the class-prefix logic applies uniformly.

### Default execution path

**Before**: `callers_of("pkg.mod.helper")` → `{results: [...], truncated: bool, stale: bool, stale_files: []}`. No signal about whether the result set might be incomplete due to unresolved dynamic dispatch.

**After**: `callers_of("pkg.mod.helper")` → `{results: [...], truncated: bool, completeness: "complete"|"partial", stale: bool, stale_files: []}`. When `completeness: "partial"`, the consumer knows to widen with grep before treating the result as exhaustive.

### Edge cases and error handling

- **Empty result set**: `completeness_for([])` always returns `"complete"` — no FQNs to check.
- **Empty `missed_callers`**: short-circuits immediately to `"complete"` on the first check.
- **Isolated node in `neighborhood`**: the isolated-node early-return path also computes `completeness_for([symbol])` and includes it in the response.
- **Pre-v4 index loaded**: `load()` raises `ValueError` with a message naming v4. No silent false `"complete"`.
- **Module tools with no skeletons**: `_expand_modules_to_symbols()` returns `[]` → `completeness_for([])` → `"complete"`. Correct: without skeletons there is no `_fqn_to_file` mapping, so the index cannot associate module FQNs with symbol FQNs.

### What was intentionally not changed

- **`reason` field**: descoped. The response carries `completeness` only (`"complete"` or `"partial"`). Naming the offending caller is consumer-debugging UX that can be added as an additive schema change later without a version bump.
- **Three-state design** (`complete` / `likely_partial` / `known_partial`): collapsed to two states because consumer action for both partial sub-states converges on "widen with grep," and the three-state design introduced an ambiguous degrade path for top-level functions that Round 2 of the intent interview explicitly rejected.
- **`call_chain` (#57) and `impact` (#58)**: `completeness_for()` is designed so they call it trivially when they land.
- **`search`, `stats`, `file_skeleton`, `reload`**: not edge-traversing tools; no `completeness` field needed.

## Tier / approach

Tier 2 — Planner → Coder (single wave, four source files + new test file, clear requirements, no open architecture questions)

## Acceptance criteria

- [x] `misses.json` caller set inlined into `index.json` as `missed_callers` at build time
- [x] `CallGraphIndex` has `missed_callers: dict[str, dict[str, int]]` field
- [x] `CallGraphIndex.completeness_for(fqns)` returns `"complete"` or `"partial"`
- [x] `callers_of`, `callees_of`, `module_callers`, `module_callees`, `neighborhood` all include `completeness` in response
- [x] `"complete"` fires when no traversed FQN has misses
- [x] `"partial"` fires when a traversed FQN is directly listed in `missed_callers`
- [x] `"partial"` fires for class-sibling methods (class-prefix match)
- [x] Top-level function with a module sibling that has misses → `"complete"` (no over-flagging)
- [x] v4 schema; v1/v2/v3 raise clear error naming v4
- [x] Tests covering all acceptance scenarios (41 new tests in `test_completeness.py`)
- [x] Tool descriptions updated to document the `completeness` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)