### PR TITLE
fix(#59): depth-aware BFS ranking + dropped field for callers_of/callees_of/module_callers/module_callees

### DIFF
--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -406,21 +406,58 @@ class CallGraphIndex:
 
     _CALLERS_CALLEES_CAP = 50
 
+    def _rank_bfs_results(
+        self,
+        bfs_result: dict[str, int],
+        graph: _DiGraph | _DiGraphReverseView,
+    ) -> list[str]:
+        """Rank BFS result nodes by (hop_depth ASC, -total_degree DESC, fqn ASC).
+
+        ``total_degree`` = in-degree + out-degree of the result node in the
+        underlying function graph.  Uses the same ranking convention as
+        :meth:`neighborhood`.
+
+        For a ``_DiGraphReverseView``, the backing ``_DiGraph`` (``graph._g``)
+        is used to look up both in-degree and out-degree so the degree reflects
+        the real graph topology regardless of traversal direction.
+        """
+        # Resolve the underlying forward graph for degree computation.
+        fwd: _DiGraph = graph._g if isinstance(graph, _DiGraphReverseView) else graph  # type: ignore[assignment]
+
+        def total_degree(n: str) -> int:
+            out_deg = sum(1 for _ in fwd.successors(n))
+            in_deg = sum(1 for _ in fwd._pred.get(n, ()))
+            return out_deg + in_deg
+
+        degree_cache: dict[str, int] = {n: total_degree(n) for n in bfs_result}
+        return sorted(
+            bfs_result,
+            key=lambda n: (bfs_result[n], -degree_cache[n], n),
+        )
+
     def callers_of(self, fqn: str, depth: int = 1) -> CallersResult:
         """Return functions that (transitively, up to depth) call *fqn*.
 
         Results are capped at 50; ``truncated`` signals when the cap fires.
+        ``dropped`` is the number of results cut by the cap (always present; 0
+        when the cap does not fire).  Results are ranked by
+        ``(hop_depth ASC, -total_degree DESC, fqn ASC)`` so depth-1 callers
+        always precede depth-2 ones regardless of alphabetical order.
         Response includes uniform staleness fields (``stale``, ``stale_files``,
         and optionally ``stale_action`` / ``index_stale_reason``) and a
         ``completeness`` field (``"complete"`` or ``"partial"``).
         """
-        all_results = _bfs(self.function_graph.reverse(copy=False), fqn, depth)
-        truncated = len(all_results) > self._CALLERS_CALLEES_CAP
-        results = all_results[: self._CALLERS_CALLEES_CAP]
+        rev_fg = self.function_graph.reverse(copy=False)
+        bfs_result = _bfs(rev_fg, fqn, depth)
+        ranked = self._rank_bfs_results(bfs_result, rev_fg)
+        dropped = max(0, len(ranked) - self._CALLERS_CALLEES_CAP)
+        truncated = dropped > 0
+        results = ranked[: self._CALLERS_CALLEES_CAP]
         staleness = self._staleness_for(results)
         return CallersResult(
             results=results,
             truncated=truncated,
+            dropped=dropped,
             completeness=self.completeness_for(results),
             **staleness,  # type: ignore[arg-type]
         )
@@ -429,17 +466,25 @@ class CallGraphIndex:
         """Return functions (transitively, up to depth) called by *fqn*.
 
         Results are capped at 50; ``truncated`` signals when the cap fires.
+        ``dropped`` is the number of results cut by the cap (always present; 0
+        when the cap does not fire).  Results are ranked by
+        ``(hop_depth ASC, -total_degree DESC, fqn ASC)`` so depth-1 callees
+        always precede depth-2 ones regardless of alphabetical order.
         Response includes uniform staleness fields (``stale``, ``stale_files``,
         and optionally ``stale_action`` / ``index_stale_reason``) and a
         ``completeness`` field (``"complete"`` or ``"partial"``).
         """
-        all_results = _bfs(self.function_graph, fqn, depth)
-        truncated = len(all_results) > self._CALLERS_CALLEES_CAP
-        results = all_results[: self._CALLERS_CALLEES_CAP]
+        fg = self.function_graph
+        bfs_result = _bfs(fg, fqn, depth)
+        ranked = self._rank_bfs_results(bfs_result, fg)
+        dropped = max(0, len(ranked) - self._CALLERS_CALLEES_CAP)
+        truncated = dropped > 0
+        results = ranked[: self._CALLERS_CALLEES_CAP]
         staleness = self._staleness_for(results)
         return CalleesResult(
             results=results,
             truncated=truncated,
+            dropped=dropped,
             completeness=self.completeness_for(results),
             **staleness,  # type: ignore[arg-type]
         )
@@ -643,14 +688,42 @@ class CallGraphIndex:
 
         return result
 
+    def _rank_module_bfs_results(
+        self,
+        bfs_result: dict[str, int],
+        module_graph: _DiGraph,
+    ) -> list[str]:
+        """Rank module BFS result nodes by (hop_depth ASC, -total_degree DESC, fqn ASC).
+
+        ``total_degree`` = in-degree + out-degree of the result module node in
+        *module_graph*.  Uses the same ranking convention as :meth:`neighborhood`.
+        """
+        rev_mg = module_graph.reverse(copy=False)
+
+        def total_degree(n: str) -> int:
+            return (
+                sum(1 for _ in module_graph.successors(n))
+                + sum(1 for _ in rev_mg.successors(n))
+            )
+
+        degree_cache: dict[str, int] = {n: total_degree(n) for n in bfs_result}
+        return sorted(
+            bfs_result,
+            key=lambda n: (bfs_result[n], -degree_cache[n], n),
+        )
+
     def module_callers(self, module: str, depth: int = 1) -> ModuleResult:
         """Return callers of all modules whose FQN starts with *module* (prefix query).
 
         An exact FQN is a degenerate prefix and behaves identically to the
         pre-change implementation.  Results are capped at 50 items; the
         ``truncated`` key in the returned dict signals when the cap triggers.
+        ``dropped`` is the number of results cut by the cap (always present; 0
+        when the cap does not fire).  Results are ranked by
+        ``(hop_depth ASC, -total_degree DESC, fqn ASC)`` so depth-1 module
+        callers always precede depth-2 ones regardless of alphabetical order.
         An empty-string prefix matches all modules.  A prefix that matches no
-        module nodes returns ``{"results": [], "truncated": false, "stale": ..., "stale_files": []}``.
+        module nodes returns ``{"results": [], "truncated": false, "dropped": 0, ...}``.
 
         Staleness is result-scoped: module FQNs are expanded to file paths via
         prefix-matching against ``_fqn_to_file`` (find all symbol FQNs that start
@@ -660,12 +733,17 @@ class CallGraphIndex:
         base = _prefix_module_bfs(
             self.module_graph.reverse(copy=False), self.module_graph, module, depth
         )
-        result_modules: list[str] = base["results"]  # type: ignore[assignment]
+        raw_union: dict[str, int] = base["results"]  # type: ignore[assignment]
+        ranked = self._rank_module_bfs_results(raw_union, self.module_graph)
+        cap = _MODULE_BFS_CAP
+        dropped: int = base["dropped"]  # type: ignore[assignment]
+        result_modules = ranked[:cap]
         staleness = self._staleness_for_modules(result_modules)
         symbol_fqns = self._expand_modules_to_symbols(result_modules)
         return ModuleResult(
             results=result_modules,
             truncated=base["truncated"],  # type: ignore[typeddict-item]
+            dropped=dropped,
             completeness=self.completeness_for(symbol_fqns),
             **staleness,  # type: ignore[arg-type]
         )
@@ -674,15 +752,24 @@ class CallGraphIndex:
         """Return callees of all modules whose FQN starts with *module* (prefix query).
 
         Symmetric to :meth:`module_callers` — see its docstring for semantics.
+        ``dropped`` is the number of results cut by the cap (always present; 0
+        when the cap does not fire).  Results are ranked by
+        ``(hop_depth ASC, -total_degree DESC, fqn ASC)`` so depth-1 module
+        callees always precede depth-2 ones regardless of alphabetical order.
         Completeness is computed over the expanded symbol FQNs of the result modules.
         """
         base = _prefix_module_bfs(self.module_graph, self.module_graph, module, depth)
-        result_modules: list[str] = base["results"]  # type: ignore[assignment]
+        raw_union: dict[str, int] = base["results"]  # type: ignore[assignment]
+        ranked = self._rank_module_bfs_results(raw_union, self.module_graph)
+        cap = _MODULE_BFS_CAP
+        dropped: int = base["dropped"]  # type: ignore[assignment]
+        result_modules = ranked[:cap]
         staleness = self._staleness_for_modules(result_modules)
         symbol_fqns = self._expand_modules_to_symbols(result_modules)
         return ModuleResult(
             results=result_modules,
             truncated=base["truncated"],  # type: ignore[typeddict-item]
+            dropped=dropped,
             completeness=self.completeness_for(symbol_fqns),
             **staleness,  # type: ignore[arg-type]
         )
@@ -794,46 +881,57 @@ def _prefix_module_bfs(
     Results from each matched seed node are unioned and deduplicated.  The matched
     seed nodes themselves are excluded from the result set (same semantics as _bfs).
     Results are capped at *cap*; ``truncated`` reflects whether the full union
-    exceeded the cap.
+    exceeded the cap.  ``dropped`` is the number of results cut by the cap (always
+    present; 0 when the cap does not fire).
+
+    When a result node is reachable from multiple seeds, its hop depth is the
+    minimum across all seeds (closest path wins).
 
     ``prefix=""`` matches all module nodes.
     """
     # Collect all module nodes that start with the given prefix
     matched_seeds = [n for n in node_graph.nodes if n.startswith(prefix)]
 
-    # Union BFS results across all matched seeds, excluding the seeds themselves
+    # Union BFS results across all matched seeds, excluding the seeds themselves.
+    # Track min hop depth per result node.
     seed_set = set(matched_seeds)
-    union: set[str] = set()
+    union: dict[str, int] = {}  # fqn -> min hop depth
     for seed in matched_seeds:
-        for node in _bfs(query_graph, seed, depth):
+        for node, hop in _bfs(query_graph, seed, depth).items():
             if node not in seed_set:
-                union.add(node)
+                if node not in union or hop < union[node]:
+                    union[node] = hop
 
-    results_all = sorted(union)
-    truncated = len(results_all) > cap
+    dropped = max(0, len(union) - cap)
+    truncated = dropped > 0
     return {
-        "results": results_all[:cap],
+        "results": union,  # raw dict returned; callers apply ranking + slice
         "truncated": truncated,
+        "dropped": dropped,
     }
 
 
-def _bfs(g: _DiGraph | _DiGraphReverseView, start: str, depth: int) -> list[str]:
+def _bfs(g: _DiGraph | _DiGraphReverseView, start: str, depth: int) -> dict[str, int]:
     """BFS from *start* up to *depth* hops.
 
-    ``depth=0`` returns ``[]``.  ``depth=1`` returns direct neighbours only.
+    ``depth=0`` returns ``{}``.  ``depth=1`` returns direct neighbours only.
     ``depth=N`` returns all nodes reachable within N hops (excluding *start*).
+
+    Returns a ``dict[fqn, min_hop_depth]`` mapping each reachable FQN to its
+    minimum hop distance from *start*.  The traversal set is identical to the
+    previous ``sorted(seen)`` implementation; only ordering and depth metadata
+    are new.
     """
     if depth <= 0 or start not in g:
-        return []
-    seen: set[str] = {start}
+        return {}
+    seen: dict[str, int] = {}
     frontier = [start]
-    for _ in range(depth):
+    for hop in range(1, depth + 1):
         nxt: list[str] = []
         for n in frontier:
             for s in g.successors(n):
-                if s not in seen:
-                    seen.add(s)
+                if s not in seen and s != start:
+                    seen[s] = hop
                     nxt.append(s)
         frontier = nxt
-    seen.discard(start)
-    return sorted(seen)
+    return seen

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -69,7 +69,11 @@ _TOOL_LIST = [
         "name": "callers_of",
         "description": (
             "List functions that (transitively, up to depth) call the given function. "
-            "Results are capped at 50; when the cap triggers, `truncated` is true. "
+            "Results are capped at 50 and ranked by (hop_depth ASC, -total_degree DESC, fqn ASC) "
+            "so depth-1 callers always appear before depth-2 ones. "
+            "When the cap triggers, `truncated` is true and `dropped` is the number of results cut. "
+            "`dropped` is always present (0 when cap does not fire) — use it to detect partial views "
+            "and narrow your query or escalate accordingly. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
             "Response includes `completeness: 'complete' | 'partial'`. "
@@ -77,7 +81,7 @@ _TOOL_LIST = [
             "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
             "treating the result as exhaustive. "
             "'complete' means no result FQN (or its class siblings) appears in the miss log. "
-            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
+            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -93,7 +97,11 @@ _TOOL_LIST = [
         "name": "callees_of",
         "description": (
             "List functions (transitively, up to depth) called by the given function. "
-            "Results are capped at 50; when the cap triggers, `truncated` is true. "
+            "Results are capped at 50 and ranked by (hop_depth ASC, -total_degree DESC, fqn ASC) "
+            "so depth-1 callees always appear before depth-2 ones. "
+            "When the cap triggers, `truncated` is true and `dropped` is the number of results cut. "
+            "`dropped` is always present (0 when cap does not fire) — use it to detect partial views "
+            "and narrow your query or escalate accordingly. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
             "Response includes `completeness: 'complete' | 'partial'`. "
@@ -101,7 +109,7 @@ _TOOL_LIST = [
             "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
             "treating the result as exhaustive. "
             "'complete' means no result FQN (or its class siblings) appears in the miss log. "
-            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
+            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -121,15 +129,19 @@ _TOOL_LIST = [
             "FQN (e.g. `pkg.mod`) for an exact match, or a package prefix "
             "(e.g. `pkg.agents`) to aggregate callers across all matching modules. "
             "An empty string matches all modules. "
-            "Results are capped at 50 and deduplicated; when the cap triggers, "
-            "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
+            "Results are capped at 50, deduplicated, and ranked by "
+            "(hop_depth ASC, -total_degree DESC, fqn ASC) so depth-1 module callers "
+            "always appear before depth-2 ones. "
+            "When the cap triggers, `truncated` is true and `dropped` is the number of results cut. "
+            "`dropped` is always present (0 when cap does not fire) — use it to detect partial views "
+            "and narrow the prefix or escalate accordingly. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
             "Response includes `completeness: 'complete' | 'partial'`. "
             "'partial' means at least one symbol in the result modules has unresolved "
             "static-dispatch calls — verify with grep before treating as exhaustive. "
             "'complete' means no symbol in the result modules appears in the miss log. "
-            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
+            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",
@@ -152,15 +164,19 @@ _TOOL_LIST = [
             "FQN (e.g. `pkg.mod`) for an exact match, or a package prefix "
             "(e.g. `pkg.agents`) to aggregate callees across all matching modules. "
             "An empty string matches all modules. "
-            "Results are capped at 50 and deduplicated; when the cap triggers, "
-            "`truncated` is true — narrow the prefix or increase `depth` to explore further. "
+            "Results are capped at 50, deduplicated, and ranked by "
+            "(hop_depth ASC, -total_degree DESC, fqn ASC) so depth-1 module callees "
+            "always appear before depth-2 ones. "
+            "When the cap triggers, `truncated` is true and `dropped` is the number of results cut. "
+            "`dropped` is always present (0 when cap does not fire) — use it to detect partial views "
+            "and narrow the prefix or escalate accordingly. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
             "Response includes `completeness: 'complete' | 'partial'`. "
             "'partial' means at least one symbol in the result modules has unresolved "
             "static-dispatch calls — verify with grep before treating as exhaustive. "
             "'complete' means no symbol in the result modules appears in the miss log. "
-            "Returns {results: [...], truncated: bool, completeness: str, stale: bool, stale_files: [...]}."
+            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...]}."
         ),
         "inputSchema": {
             "type": "object",

--- a/src/pyscope_mcp/types.py
+++ b/src/pyscope_mcp/types.py
@@ -46,6 +46,7 @@ class CallersResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    dropped: int  # number of results cut by the cap; 0 when cap does not fire
     completeness: Completeness
     stale: bool
     stale_files: list[str]
@@ -58,6 +59,7 @@ class CalleesResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    dropped: int  # number of results cut by the cap; 0 when cap does not fire
     completeness: Completeness
     stale: bool
     stale_files: list[str]
@@ -71,6 +73,7 @@ class ModuleResult(TypedDict):
 
     results: list[str]
     truncated: bool
+    dropped: int  # number of results cut by the cap; 0 when cap does not fire
     completeness: Completeness
     stale: bool
     stale_files: list[str]

--- a/tests/test_bfs_ranking_integration.py
+++ b/tests/test_bfs_ranking_integration.py
@@ -1,0 +1,211 @@
+"""Integration test: depth-aware BFS ranking + dropped field through the analyzer.
+
+Tests the issue #59 fix end-to-end: real Python source -> build_raw() ->
+CallGraphIndex -> callers_of/callees_of.  Existing tests in test_graph.py cover
+the ranking via from_raw() with hand-crafted dicts; this test exercises the
+analyzer pipeline so that any analyzer-level edge-resolution bug would surface
+as a failure here, not just at the graph layer.
+
+Fixture topology (callers direction)
+------------------------------------
+  target.target_fn          <- called by 3 depth-1 callers in zdepth1.py
+  zdepth1.z_caller_01..03   <- called by 55 depth-2 callers in adepth2.py
+
+Total reachable from target_fn (reverse BFS, depth=2): 3 + 55 = 58
+Cap = 50, so dropped = 8.  ``a_caller_*`` sorts alphabetically BEFORE
+``z_caller_*``, so an unranked impl would keep 50 a_caller_* (depth-2) and
+drop all three z_caller_* (depth-1) — the exact bug from issue #59.
+
+Symmetric topology (callees direction)
+--------------------------------------
+  source.source_fn -> 3 depth-1 callees in zdepth1_callees.py
+  zdepth1_callees.z_callee_01..03 -> 55 depth-2 callees in adepth2_callees.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pyscope_mcp.analyzer import build_raw
+from pyscope_mcp.graph import CallGraphIndex
+
+
+_N_DEPTH1 = 3
+_N_DEPTH2 = 55  # > (50 - _N_DEPTH1) so the cap fires and would drop depth-1 without ranking
+_CAP = 50
+_EXPECTED_DROPPED = (_N_DEPTH1 + _N_DEPTH2) - _CAP
+
+
+def _make_callers_fixture(tmp_path: Path, pkg: str) -> Path:
+    root = tmp_path / pkg
+    root.mkdir()
+    (root / "__init__.py").write_text("")
+
+    (root / "target.py").write_text(
+        "def target_fn():\n"
+        "    pass\n"
+    )
+
+    zlines = [f"from {pkg}.target import target_fn\n\n"]
+    for i in range(1, _N_DEPTH1 + 1):
+        zlines.append(f"def z_caller_{i:02d}():\n    target_fn()\n\n")
+    (root / "zdepth1.py").write_text("".join(zlines))
+
+    alines = [f"from {pkg}.zdepth1 import " + ", ".join(
+        f"z_caller_{i:02d}" for i in range(1, _N_DEPTH1 + 1)
+    ) + "\n\n"]
+    for i in range(1, _N_DEPTH2 + 1):
+        # round-robin each a_caller across the depth-1 callers
+        z_target = f"z_caller_{((i - 1) % _N_DEPTH1) + 1:02d}"
+        alines.append(f"def a_caller_{i:02d}():\n    {z_target}()\n\n")
+    (root / "adepth2.py").write_text("".join(alines))
+
+    return tmp_path
+
+
+def _make_callees_fixture(tmp_path: Path, pkg: str) -> Path:
+    root = tmp_path / pkg
+    root.mkdir()
+    (root / "__init__.py").write_text("")
+
+    alines = []
+    for i in range(1, _N_DEPTH2 + 1):
+        alines.append(f"def a_callee_{i:02d}():\n    pass\n\n")
+    (root / "adepth2_callees.py").write_text("".join(alines))
+
+    zlines = [f"from {pkg}.adepth2_callees import " + ", ".join(
+        f"a_callee_{i:02d}" for i in range(1, _N_DEPTH2 + 1)
+    ) + "\n\n"]
+    for i in range(1, _N_DEPTH1 + 1):
+        body = "\n".join(
+            f"    a_callee_{j:02d}()"
+            for j in range(1, _N_DEPTH2 + 1)
+            if (j - 1) % _N_DEPTH1 == (i - 1)
+        )
+        zlines.append(f"def z_callee_{i:02d}():\n{body}\n\n")
+    (root / "zdepth1_callees.py").write_text("".join(zlines))
+
+    src = [f"from {pkg}.zdepth1_callees import " + ", ".join(
+        f"z_callee_{i:02d}" for i in range(1, _N_DEPTH1 + 1)
+    ) + "\n\n"]
+    src.append("def source_fn():\n")
+    for i in range(1, _N_DEPTH1 + 1):
+        src.append(f"    z_callee_{i:02d}()\n")
+    (root / "source.py").write_text("".join(src))
+
+    return tmp_path
+
+
+@pytest.fixture()
+def callers_idx(tmp_path: Path) -> CallGraphIndex:
+    pkg = "ranking_callers_fixture"
+    root = _make_callers_fixture(tmp_path, pkg)
+    raw = build_raw(root, pkg)
+    return CallGraphIndex.from_raw(str(root), raw)
+
+
+@pytest.fixture()
+def callees_idx(tmp_path: Path) -> CallGraphIndex:
+    pkg = "ranking_callees_fixture"
+    root = _make_callees_fixture(tmp_path, pkg)
+    raw = build_raw(root, pkg)
+    return CallGraphIndex.from_raw(str(root), raw)
+
+
+def test_analyzer_resolves_all_depth1_callers(callers_idx: CallGraphIndex) -> None:
+    """Sanity: analyzer must produce edges from each depth-1 caller into target_fn.
+
+    If the analyzer fails to resolve the cross-module call, the ranking test
+    below would pass for the wrong reason (depth-1 callers absent because the
+    edge never existed).
+    """
+    target = "ranking_callers_fixture.target.target_fn"
+    direct_callers = {
+        fqn for fqn, callees in callers_idx.raw.items() if target in callees
+    }
+    expected = {f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}"
+                for i in range(1, _N_DEPTH1 + 1)}
+    missing = expected - direct_callers
+    assert not missing, (
+        f"Analyzer failed to resolve depth-1 caller edges into target_fn: "
+        f"missing={missing}. Ranking test below would not be meaningful."
+    )
+
+
+def test_callers_of_preserves_depth1_under_cap_via_analyzer(
+    callers_idx: CallGraphIndex,
+) -> None:
+    """Issue #59 regression: depth-1 callers must survive the 50-item cap
+    even when 55 depth-2 callers sort alphabetically before them."""
+    result = callers_idx.callers_of(
+        "ranking_callers_fixture.target.target_fn", depth=2
+    )
+
+    assert result["truncated"] is True
+    assert len(result["results"]) == _CAP
+    assert result["dropped"] == _EXPECTED_DROPPED
+
+    for i in range(1, _N_DEPTH1 + 1):
+        fqn = f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}"
+        assert fqn in result["results"], (
+            f"depth-1 caller {fqn} dropped by cap — ranking did not run "
+            f"before truncation"
+        )
+
+    z_indices = [
+        result["results"].index(f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}")
+        for i in range(1, _N_DEPTH1 + 1)
+    ]
+    last_depth1 = max(z_indices)
+    for item in result["results"]:
+        if "adepth2.a_caller_" in item:
+            assert result["results"].index(item) > last_depth1, (
+                f"depth-2 caller {item} ranked before a depth-1 caller"
+            )
+
+
+def test_callees_of_preserves_depth1_under_cap_via_analyzer(
+    callees_idx: CallGraphIndex,
+) -> None:
+    """Symmetric regression test for callees_of through the analyzer."""
+    result = callees_idx.callees_of(
+        "ranking_callees_fixture.source.source_fn", depth=2
+    )
+
+    assert result["truncated"] is True
+    assert len(result["results"]) == _CAP
+    assert result["dropped"] == _EXPECTED_DROPPED
+
+    for i in range(1, _N_DEPTH1 + 1):
+        fqn = f"ranking_callees_fixture.zdepth1_callees.z_callee_{i:02d}"
+        assert fqn in result["results"], (
+            f"depth-1 callee {fqn} dropped by cap — ranking did not run "
+            f"before truncation"
+        )
+
+    z_indices = [
+        result["results"].index(
+            f"ranking_callees_fixture.zdepth1_callees.z_callee_{i:02d}"
+        )
+        for i in range(1, _N_DEPTH1 + 1)
+    ]
+    last_depth1 = max(z_indices)
+    for item in result["results"]:
+        if "adepth2_callees.a_callee_" in item:
+            assert result["results"].index(item) > last_depth1, (
+                f"depth-2 callee {item} ranked before a depth-1 callee"
+            )
+
+
+def test_callers_of_dropped_zero_when_under_cap_via_analyzer(
+    callers_idx: CallGraphIndex,
+) -> None:
+    """Querying a depth-1-only result set must yield dropped=0, not absent."""
+    result = callers_idx.callers_of(
+        "ranking_callers_fixture.target.target_fn", depth=1
+    )
+    assert result["truncated"] is False
+    assert result["dropped"] == 0
+    assert len(result["results"]) == _N_DEPTH1

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -160,7 +160,7 @@ def test_module_callers_truncation() -> None:
     # Build a graph where one "target" module has 60 distinct callers
     raw: dict[str, list[str]] = {}
     for i in range(60):
-        raw[f"callers.mod{i}.fn"] = [f"target.core.fn"]
+        raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
     idx = CallGraphIndex.from_raw("/tmp/sample", raw)
     result = idx.module_callers("target")
@@ -258,6 +258,228 @@ def test_callees_of_truncation() -> None:
     result = idx.callees_of("source.mod.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
+
+
+# ---------------------------------------------------------------------------
+# dropped field — callers_of / callees_of
+# ---------------------------------------------------------------------------
+
+def test_callers_of_dropped_zero_when_not_truncated() -> None:
+    """dropped=0 when results fit within cap."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    result = idx.callers_of("sample.b.helper", depth=1)
+    assert "dropped" in result
+    assert result["dropped"] == 0
+    assert result["truncated"] is False
+
+
+def test_callees_of_dropped_zero_when_not_truncated() -> None:
+    """dropped=0 when results fit within cap."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    result = idx.callees_of("sample.a.top", depth=1)
+    assert "dropped" in result
+    assert result["dropped"] == 0
+    assert result["truncated"] is False
+
+
+def test_callers_of_dropped_correct_when_truncated() -> None:
+    """dropped equals the number of results beyond the 50-item cap."""
+    raw: dict[str, list[str]] = {}
+    for i in range(57):
+        raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
+    raw["target.core.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.callers_of("target.core.fn", depth=1)
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+    assert result["dropped"] == 7
+
+
+def test_callees_of_dropped_correct_when_truncated() -> None:
+    """dropped equals the number of results beyond the 50-item cap."""
+    raw: dict[str, list[str]] = {
+        "source.mod.fn": [f"target.mod{i}.fn" for i in range(57)]
+    }
+    for i in range(57):
+        raw[f"target.mod{i}.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.callees_of("source.mod.fn", depth=1)
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+    assert result["dropped"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Ranking: depth-1 results precede depth-2 when alphabetical order would invert
+# ---------------------------------------------------------------------------
+
+def _ranking_raw_callers() -> dict[str, list[str]]:
+    """Graph for ranking test.
+
+    target.fn is called by:
+      - depth-1 callers: z_depth1.mod.fn, y_depth1.mod.fn  (sort AFTER depth-2 alphabetically)
+      - depth-2 callers: a_depth2.mod.fn ... (55 of them, sort BEFORE depth-1 alphabetically)
+
+    Without ranking fix, the cap would keep 50 alphabetically-first a_depth2 callers and
+    drop the depth-1 z_depth1 and y_depth1 callers.  With the fix, depth-1 callers appear first.
+    """
+    raw: dict[str, list[str]] = {}
+    # depth-2 callers: call bridge.fn which calls target.fn
+    for i in range(55):
+        raw[f"a_depth2.mod{i}.fn"] = ["bridge.mod.fn"]
+    raw["bridge.mod.fn"] = ["target.fn"]
+    # depth-1 callers: directly call target.fn (sort alphabetically AFTER a_depth2)
+    raw["z_depth1.mod.fn"] = ["target.fn"]
+    raw["y_depth1.mod.fn"] = ["target.fn"]
+    raw["target.fn"] = []
+    return raw
+
+
+def test_callers_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
+    """Depth-1 callers appear before depth-2 callers in results, even when alphabetically later."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _ranking_raw_callers())
+    result = idx.callers_of("target.fn", depth=2)
+
+    # depth-1 callers must be present despite sorting alphabetically after a_depth2 nodes
+    assert "z_depth1.mod.fn" in result["results"], (
+        "depth-1 caller z_depth1.mod.fn absent — cap dropped it before depth-2 entries"
+    )
+    assert "y_depth1.mod.fn" in result["results"], (
+        "depth-1 caller y_depth1.mod.fn absent — cap dropped it before depth-2 entries"
+    )
+
+    # depth-1 callers must appear in the first part of the list
+    z_idx = result["results"].index("z_depth1.mod.fn")
+    y_idx = result["results"].index("y_depth1.mod.fn")
+    # All depth-2 nodes that appear must come after both depth-1 callers
+    for item in result["results"]:
+        if item.startswith("a_depth2"):
+            item_idx = result["results"].index(item)
+            assert item_idx > z_idx and item_idx > y_idx, (
+                f"depth-2 caller {item!r} at index {item_idx} appears before depth-1 callers"
+            )
+
+    # Total reachable: 55 a_depth2 + bridge.mod.fn + z_depth1.mod.fn + y_depth1.mod.fn = 58
+    # dropped = 58 - 50 = 8
+    assert result["dropped"] == 8
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+
+
+def _ranking_raw_callees() -> dict[str, list[str]]:
+    """Symmetric to _ranking_raw_callers but for callees direction."""
+    raw: dict[str, list[str]] = {}
+    # source.fn calls bridge.mod.fn (depth-1 callee) which calls 55 a_depth2 callees
+    raw["source.fn"] = ["bridge.mod.fn", "z_depth1.mod.fn", "y_depth1.mod.fn"]
+    raw["bridge.mod.fn"] = [f"a_depth2.mod{i}.fn" for i in range(55)]
+    for i in range(55):
+        raw[f"a_depth2.mod{i}.fn"] = []
+    raw["z_depth1.mod.fn"] = []
+    raw["y_depth1.mod.fn"] = []
+    return raw
+
+
+def test_callees_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
+    """Depth-1 callees appear before depth-2 callees, even when alphabetically later."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _ranking_raw_callees())
+    result = idx.callees_of("source.fn", depth=2)
+
+    # depth-1 callees: bridge.mod.fn, z_depth1.mod.fn, y_depth1.mod.fn
+    assert "z_depth1.mod.fn" in result["results"], (
+        "depth-1 callee z_depth1.mod.fn absent"
+    )
+    assert "y_depth1.mod.fn" in result["results"], (
+        "depth-1 callee y_depth1.mod.fn absent"
+    )
+    assert "bridge.mod.fn" in result["results"], (
+        "depth-1 callee bridge.mod.fn absent"
+    )
+
+    # All three depth-1 callees must appear before depth-2 ones
+    depth1_max_idx = max(
+        result["results"].index(n)
+        for n in ["bridge.mod.fn", "z_depth1.mod.fn", "y_depth1.mod.fn"]
+    )
+    for item in result["results"]:
+        if item.startswith("a_depth2"):
+            item_idx = result["results"].index(item)
+            assert item_idx > depth1_max_idx, (
+                f"depth-2 callee {item!r} at index {item_idx} appears before depth-1 callees"
+            )
+
+
+# ---------------------------------------------------------------------------
+# dropped field — module_callers / module_callees
+# ---------------------------------------------------------------------------
+
+def test_module_callers_dropped_zero_when_not_truncated() -> None:
+    """module_callers: dropped=0 when results fit within cap."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callers("pkg.agents")
+    assert "dropped" in result
+    assert result["dropped"] == 0
+    assert result["truncated"] is False
+
+
+def test_module_callees_dropped_zero_when_not_truncated() -> None:
+    """module_callees: dropped=0 when results fit within cap."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    result = idx.module_callees("pkg.agents")
+    assert "dropped" in result
+    assert result["dropped"] == 0
+    assert result["truncated"] is False
+
+
+def test_module_callers_dropped_correct_when_truncated() -> None:
+    """module_callers: dropped equals number of results beyond cap."""
+    raw: dict[str, list[str]] = {}
+    for i in range(57):
+        raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
+    raw["target.core.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.module_callers("target")
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+    assert result["dropped"] == 7
+
+
+def test_module_callees_dropped_correct_when_truncated() -> None:
+    """module_callees: dropped equals number of results beyond cap."""
+    raw: dict[str, list[str]] = {
+        "source.mod.fn": [f"target.mod{i}.fn" for i in range(57)]
+    }
+    for i in range(57):
+        raw[f"target.mod{i}.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.module_callees("source")
+    assert result["truncated"] is True
+    assert len(result["results"]) == 50
+    assert result["dropped"] == 7
+
+
+def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
+    """Depth-1 module callers appear before depth-2 ones, even when alphabetically later."""
+    raw: dict[str, list[str]] = {}
+    # depth-2 module callers: a_depth2.modN.fn → bridge.mod.fn → target.fn
+    for i in range(55):
+        raw[f"a_depth2.mod{i}.fn"] = ["bridge.mod.fn"]
+    raw["bridge.mod.fn"] = ["target.fn"]
+    # depth-1 module callers: z_depth1.mod.fn → target.fn (alphabetically after a_depth2)
+    raw["z_depth1.mod.fn"] = ["target.fn"]
+    raw["y_depth1.mod.fn"] = ["target.fn"]
+    raw["target.fn"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.module_callers("target", depth=2)
+
+    assert "z_depth1.mod" in result["results"], (
+        "depth-1 module caller z_depth1.mod absent — ranking failed"
+    )
+    assert "y_depth1.mod" in result["results"], (
+        "depth-1 module caller y_depth1.mod absent — ranking failed"
+    )
+    assert result["truncated"] is True
+    # 55 a_depth2 modules + bridge.mod + z_depth1.mod + y_depth1.mod = 58 - 50 = 8
+    assert result["dropped"] == 8
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #59

## What changed

The bug in `callers_of`, `callees_of`, `module_callers`, and `module_callees` was not the cap size — it was ranking. `_bfs` returned `sorted(seen)` (alphabetical order), which meant depth-1 callers/callees could be silently dropped when 50+ depth-2 nodes sorted alphabetically earlier. This PR fixes the ranking bug, adds `dropped: int` to all four tool responses, and updates the TypedDicts and server descriptions to match.

## Implementation walkthrough

### `_bfs(g, start, depth)` in `src/pyscope_mcp/graph.py`

Changed return type from `list[str]` to `dict[str, int]` (fqn → min_hop_depth). The BFS loop now records the hop index (1-based) for each newly discovered node as it expands layer by layer. The set of reachable nodes is identical to before; only the return type and depth metadata are new. All three call sites (`callers_of`, `callees_of`, `_prefix_module_bfs`) are updated simultaneously.

### `_rank_bfs_results(bfs_result, graph)` in `src/pyscope_mcp/graph.py`

New helper on `CallGraphIndex`. Takes the `dict[str, int]` from `_bfs` and sorts nodes by `(hop_depth ASC, -total_degree DESC, fqn ASC)` — the same convention used by `neighborhood`. Total degree (in + out) is computed from the underlying forward `_DiGraph` (`graph._g` for `_DiGraphReverseView` inputs). A degree cache is precomputed over result nodes before sorting to avoid O(N×degree) redundant traversals.

### `_rank_module_bfs_results(bfs_result, module_graph)` in `src/pyscope_mcp/graph.py`

Symmetric helper for module-level tools. Uses `module_graph` for degree computation (module in-degree + out-degree), consistent with module-level semantics.

### `_prefix_module_bfs(...)` in `src/pyscope_mcp/graph.py`

Updated to union BFS results using `min(existing_depth, new_depth)` when a result node appears under multiple seeds (closest path wins). Returns a raw `dict[str, int]` under the `results` key (previously a `list[str]`). Also returns `dropped: int` computed before the slice, so callers can pass it through without recomputing. The actual cap+slice is now applied by the callers (`module_callers`, `module_callees`) after ranking.

### `callers_of`, `callees_of` in `src/pyscope_mcp/graph.py`

Both now call `_bfs` → `_rank_bfs_results` → slice. `dropped = max(0, len(ranked) - cap)` is computed on the ranked list before slicing, and both `truncated` and `dropped` are included in the returned `CallersResult`/`CalleesResult`.

### `module_callers`, `module_callees` in `src/pyscope_mcp/graph.py`

Both call `_prefix_module_bfs` → `_rank_module_bfs_results` → slice. The `dropped` value is forwarded from `_prefix_module_bfs` (already computed over the full union) and included in the returned `ModuleResult`.

### `CallersResult`, `CalleesResult`, `ModuleResult` in `src/pyscope_mcp/types.py`

All three TypedDicts gain a required `dropped: int` field. It is always present — not `NotRequired` — because consumers should always be able to read it without a key-existence check.

### Server tool descriptions in `src/pyscope_mcp/server.py`

All four tool descriptions updated to document the new `dropped: int` field, the ranking order, and the consumer-facing guidance ("use `dropped` to detect partial views and narrow your query or escalate accordingly").

## Default execution path

**Before**: `_bfs` → `sorted(seen)` → `[:50]` → respond. Alphabetical truncation could silently drop all depth-1 callers if 50 depth-2 nodes sorted earlier.

**After**: `_bfs` → `dict[fqn, hop]` → rank by `(hop ASC, -degree DESC, fqn ASC)` → `dropped = len - 50` → `[:50]` → respond with `dropped`. Depth-1 results always appear first regardless of FQN alphabetical order; consumers see `dropped > 0` and know the view is partial.

## Edge cases and error handling

- `dropped=0` is explicitly returned when results fit within the cap — consumers can always read the field without checking `truncated` first.
- When `_bfs` returns an empty dict (unknown start node or depth ≤ 0), `dropped=0` and `truncated=False`.
- `_prefix_module_bfs` with no matching seeds returns `{"results": {}, "truncated": False, "dropped": 0}` — all four module methods handle this correctly.

## What was intentionally not changed

- The cap value stays at 50 for all four tools — no configurable parameter per spec.
- `neighborhood` is untouched — it has its own ranking and budget logic.
- `_bfs` traversal logic (which nodes are visited) is identical — only the return type changed.
- `truncated: bool` semantics unchanged.

## Tier / approach

Tier 1 — Planner → Coder (single commit, all changes in graph.py / types.py / server.py / tests/test_graph.py)

## Acceptance criteria

- [x] `callers_of(depth=2)` on a high-fanout symbol returns ≤50 results
- [x] `callees_of(depth=2)` same
- [x] Results ranked `(hop_depth ASC, -total_degree DESC, fqn ASC)` — depth-1 before depth-2
- [x] Response includes `dropped: int` always present, equals number of results beyond cap
- [x] `dropped=0` when not truncated
- [x] Existing depth=1 tests unaffected (577 → 588 tests, all pass)
- [x] New tests: ranking + dropped correct for all four tools (`callers_of`, `callees_of`, `module_callers`, `module_callees`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)