### PR TITLE
fix(#62): lightweight internal query logging on the serve path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,56 @@ Errors out if no index exists. Env-var equivalents: `PYSCOPE_MCP_ROOT`, `PYSCOPE
   }
 }
 ```
+
+## Query logging (opt-in)
+
+Every `tools/call` dispatch can append a structured JSONL entry to a local rotating log file so you can measure tool-use patterns, truncation rates, hub-suppression hits, and latency without parsing claude's session transcripts.
+
+**During pre-release the logger is enabled by default** (`PYSCOPE_MCP_LOG=1`). Before the first public release this default will flip to off.
+
+### Log location
+
+Default: `.pyscope-mcp/query.jsonl` next to the index file (already `.gitignore`d).  
+Override: `PYSCOPE_MCP_LOG_PATH=/abs/path/to/query.jsonl`.
+
+### Enable / disable
+
+```bash
+# Disable
+PYSCOPE_MCP_LOG=0 pyscope-mcp serve ...
+
+# Enable explicitly
+PYSCOPE_MCP_LOG=1 pyscope-mcp serve ...
+```
+
+### Log entry schema (v1)
+
+```json
+{
+  "v": 1,
+  "ts": "2026-04-25T21:00:00.000+00:00",
+  "server_id": "550e8400-e29b-41d4-a716-446655440000",
+  "rpc_id": 3,
+  "tool": "neighborhood",
+  "args": {"symbol": "pkg.mod.Foo.run", "depth": 2, "token_budget": 500},
+  "duration_ms": 12,
+  "is_error": false,
+  "truncated": true,
+  "result_count": null,
+  "edge_count": 7,
+  "hub_suppressed_count": 2,
+  "depth_full": 1,
+  "token_budget_used": 487,
+  "index_version": 5,
+  "index_git_sha": "a1b2c3d4...",
+  "index_content_hash": "abcdef12..."
+}
+```
+
+`server_id` partitions entries by session (the MCP server is spawned per-session as a stdio subprocess by Claude Code). To join log entries with claude's own session transcript, match by `(ts, tool, args)` or `rpc_id`.
+
+Rotation: files rotate at 10 MB; up to 5 historical files are kept (`query.jsonl.1` … `query.jsonl.5`), giving a ~50 MB ceiling.
+
+### Index schema v5 note
+
+The index format was bumped from v4 to v5 to add `git_sha` and `content_hash` header fields (used by the logger to tie each log entry to a specific graph version). Existing v4 index files are **not migrated** — re-run `pyscope-mcp build` to generate a v5 index.

--- a/src/pyscope_mcp/_log.py
+++ b/src/pyscope_mcp/_log.py
@@ -1,0 +1,257 @@
+"""Lightweight JSONL query logger for the pyscope-mcp serve path.
+
+Each tools/call dispatch appends one structured entry describing inputs,
+response shape stats, latency, error state, and the loaded index identity.
+
+The log is write-only from the server's perspective and never feeds back into
+tool responses.  It is synchronous (one write+flush per call); async/buffered
+writes are deferred to a future follow-up.
+
+Configuration (env vars, read at init time):
+  PYSCOPE_MCP_LOG      "1" to enable, "0" to disable.
+                       # PRE-RELEASE DEFAULT: flip to off before public release.
+                       Defaults to "1" during pre-release.
+  PYSCOPE_MCP_LOG_PATH Path to the log file.
+                       Default: <index_dir>/.pyscope-mcp/query.jsonl
+                       (The .pyscope-mcp/ dir is already .gitignored.)
+
+Rotation: when the log file exceeds LOG_MAX_BYTES (10 MB), it is renamed to
+``query.jsonl.1`` … ``query.jsonl.5`` (max 5 historical files); the oldest is
+deleted when a 6th rotation would occur.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyscope_mcp.graph import CallGraphIndex
+
+logger = logging.getLogger(__name__)
+
+LOG_MAX_BYTES: int = 10 * 1024 * 1024  # 10 MB
+LOG_BACKUP_COUNT: int = 5
+LOG_SCHEMA_VERSION: int = 1
+
+
+class QueryLogger:
+    """Appends JSONL entries to a rotating log file.
+
+    Thread-safety: not required — the serve path is single-threaded (serial
+    asyncio dispatch).
+
+    Instantiate via :func:`init`.  Check :data:`_LOGGER` before calling
+    :func:`log_call`; when logging is disabled the module-level singleton is
+    ``None`` and the check is a single ``is None`` guard.
+    """
+
+    def __init__(self, log_path: Path) -> None:
+        self._log_path = log_path
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._warned = False  # emit at most one warning per session on I/O failure
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def write(
+        self,
+        *,
+        server_id: str,
+        rpc_id: Any,
+        tool: str,
+        args: dict,
+        duration_ms: int,
+        result: dict,
+        index: "CallGraphIndex | None",
+    ) -> None:
+        """Build and append one JSONL entry.  Swallows all exceptions internally."""
+        try:
+            entry = self._build_entry(
+                server_id=server_id,
+                rpc_id=rpc_id,
+                tool=tool,
+                args=args,
+                duration_ms=duration_ms,
+                result=result,
+                index=index,
+            )
+            self._append(json.dumps(entry, separators=(",", ":")))
+        except Exception as exc:  # noqa: BLE001
+            if not self._warned:
+                logger.warning("QueryLogger: failed to write log entry: %s", exc)
+                self._warned = True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_entry(
+        self,
+        *,
+        server_id: str,
+        rpc_id: Any,
+        tool: str,
+        args: dict,
+        duration_ms: int,
+        result: dict,
+        index: "CallGraphIndex | None",
+    ) -> dict:
+        is_error: bool = bool(result.get("isError", False))
+
+        # Extract response payload from MCP tool-result envelope.
+        # _text() wraps the real payload in {"content": [{"type": "text", "text": "..."}], "isError": False}.
+        payload: dict = {}
+        if not is_error:
+            try:
+                import json as _json
+                content = result.get("content", [])
+                if content and content[0].get("type") == "text":
+                    payload = _json.loads(content[0]["text"])
+            except Exception:  # noqa: BLE001
+                payload = {}
+
+        # Shape stats — derived from payload fields by name.
+        truncated: bool | None = payload.get("truncated") if "truncated" in payload else None
+        result_count: int | None = None
+        if "results" in payload and isinstance(payload["results"], list):
+            result_count = len(payload["results"])
+        edge_count: int | None = None
+        if "edges" in payload and isinstance(payload["edges"], list):
+            edge_count = len(payload["edges"])
+        hub_suppressed_count: int | None = None
+        if "hub_suppressed" in payload and isinstance(payload["hub_suppressed"], list):
+            hub_suppressed_count = len(payload["hub_suppressed"])
+        depth_full: int | None = payload.get("depth_full")
+        token_budget_used: int | None = payload.get("token_budget_used")
+
+        entry: dict = {
+            "v": LOG_SCHEMA_VERSION,
+            "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="milliseconds"),
+            "server_id": server_id,
+            "rpc_id": rpc_id,
+            "tool": tool,
+            "args": args,
+            "duration_ms": duration_ms,
+            "is_error": is_error,
+            "truncated": truncated,
+            "result_count": result_count,
+            "edge_count": edge_count,
+            "hub_suppressed_count": hub_suppressed_count,
+            "depth_full": depth_full,
+            "token_budget_used": token_budget_used,
+            "index_version": _index_version(index),
+            "index_git_sha": index.git_sha if index is not None else None,
+            "index_content_hash": index.content_hash if index is not None else None,
+        }
+        if is_error:
+            # Extract error message text.
+            try:
+                content = result.get("content", [])
+                if content and content[0].get("type") == "text":
+                    entry["error_msg"] = content[0]["text"]
+            except Exception:  # noqa: BLE001
+                entry["error_msg"] = str(result)
+
+        return entry
+
+    def _append(self, line: str) -> None:
+        """Write one line to the log file, rotating if necessary."""
+        self._maybe_rotate()
+        with self._log_path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            fh.flush()
+
+    def _maybe_rotate(self) -> None:
+        """Rotate the log file if it has reached LOG_MAX_BYTES."""
+        try:
+            size = self._log_path.stat().st_size if self._log_path.exists() else 0
+        except OSError:
+            size = 0
+        if size < LOG_MAX_BYTES:
+            return
+        # Delete the oldest backup if at the limit.
+        oldest = self._log_path.with_suffix(self._log_path.suffix + f".{LOG_BACKUP_COUNT}")
+        if oldest.exists():
+            oldest.unlink()
+        # Shift existing backups up by one.
+        for i in range(LOG_BACKUP_COUNT - 1, 0, -1):
+            src = self._log_path.with_suffix(self._log_path.suffix + f".{i}")
+            dst = self._log_path.with_suffix(self._log_path.suffix + f".{i + 1}")
+            if src.exists():
+                src.rename(dst)
+        # Rename current log to .1
+        if self._log_path.exists():
+            self._log_path.rename(self._log_path.with_suffix(self._log_path.suffix + ".1"))
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton and public interface
+# ---------------------------------------------------------------------------
+
+def _index_version(index: "CallGraphIndex | None") -> int | None:
+    """Return INDEX_VERSION from the graph module (avoids circular import at module level)."""
+    if index is None:
+        return None
+    try:
+        from pyscope_mcp.graph import INDEX_VERSION
+        return INDEX_VERSION
+    except Exception:  # noqa: BLE001
+        return None
+
+
+_LOGGER: QueryLogger | None = None
+
+
+def init(log_path: Path) -> None:
+    """Initialise the module-level logger singleton.
+
+    Safe to call multiple times; subsequent calls replace the previous instance.
+    No-op when ``PYSCOPE_MCP_LOG`` is ``"0"``.
+    """
+    global _LOGGER
+    enabled = _is_enabled()
+    if not enabled:
+        _LOGGER = None
+        return
+    _LOGGER = QueryLogger(log_path)
+
+
+def _is_enabled() -> bool:
+    """Return True when logging is enabled.
+
+    # PRE-RELEASE DEFAULT: flip to off before public release.
+    """
+    return os.environ.get("PYSCOPE_MCP_LOG", "1") not in ("0", "false", "False", "no", "No")
+
+
+def log_call(
+    *,
+    server_id: str,
+    rpc_id: Any,
+    tool: str,
+    args: dict,
+    duration_ms: int,
+    result: dict,
+    index: "CallGraphIndex | None",
+) -> None:
+    """Append a log entry if the logger is initialised.  Never raises."""
+    if _LOGGER is None:
+        return
+    try:
+        _LOGGER.write(
+            server_id=server_id,
+            rpc_id=rpc_id,
+            tool=tool,
+            args=args,
+            duration_ms=duration_ms,
+            result=result,
+            index=index,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("QueryLogger.write failed (log_call guard): %s", exc)

--- a/src/pyscope_mcp/cli.py
+++ b/src/pyscope_mcp/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -74,8 +75,25 @@ def cmd_build(args: argparse.Namespace) -> int:
             missed_callers[caller] = {}
         missed_callers[caller][pattern] = missed_callers[caller].get(pattern, 0) + 1
 
+    # Capture git SHA at build time (Law 3: git-in-sync graph).
+    # Failure to capture (not a git checkout, git absent) → git_sha=None, not an error.
+    git_sha: str | None = None
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            git_sha = result.stdout.strip() or None
+    except FileNotFoundError:
+        pass  # git binary not installed
+
     idx = CallGraphIndex.from_raw(
-        root, raw, skeletons=skeletons, file_shas=file_shas, missed_callers=missed_callers
+        root, raw, skeletons=skeletons, file_shas=file_shas, missed_callers=missed_callers,
+        git_sha=git_sha,
     )
     idx.save(out)
 

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict
 
+INDEX_VERSION = 5
+
 from pyscope_mcp.types import (
     CalleesResult,
     CallersResult,
@@ -121,6 +123,19 @@ class _DiGraphReverseView:
         )
 
 
+def _compute_content_hash(raw: dict[str, list[str]]) -> str:
+    """Return SHA-256 hex digest of the deterministically serialised *raw* dict.
+
+    Sorted keys and sorted callee lists ensure the same graph always yields
+    the same hash, regardless of insertion order.
+    """
+    canonical = json.dumps(
+        {k: sorted(v) for k, v in sorted(raw.items())},
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(canonical).hexdigest()
+
+
 @dataclass
 class CallGraphIndex:
     """Function- and module-level call graph over a Python repo.
@@ -139,12 +154,17 @@ class CallGraphIndex:
     module_graph: _DiGraph = field(default_factory=_DiGraph)
     raw: dict[str, list[str]] = field(default_factory=dict)
     skeletons: dict[str, list[SymbolSummary]] = field(default_factory=dict)
-    # None = pre-v3 index (no hashes stored); dict = v3/v4 index with per-file SHA256 digests.
+    # None = pre-v3 index (no hashes stored); dict = v3/v5 index with per-file SHA256 digests.
     file_shas: dict[str, str] | None = field(default=None)
     # v4+: maps caller FQN → {pattern: count} for unresolved static-dispatch calls.
     # Empty dict on v4 indexes with zero misses. Present only in v4+; absent from
     # older indexes (which are rejected by load()).
     missed_callers: dict[str, dict[str, int]] = field(default_factory=dict)
+    # v5+: git SHA of the repo at build time (None when build runs outside a git checkout).
+    git_sha: str | None = field(default=None)
+    # v5+: SHA-256 hex digest of the deterministically serialised raw dict.
+    # Computed at from_raw time; persisted in the index header.
+    content_hash: str = field(default="")
     # Derived at load/from_raw time: maps FQN → relative file path (inverted from skeletons).
     # Not serialised — rebuilt on every load.
     _fqn_to_file: dict[str, str] = field(default_factory=dict, repr=False)
@@ -160,6 +180,7 @@ class CallGraphIndex:
         skeletons: dict[str, list[SymbolSummary]] | None = None,
         file_shas: dict[str, str] | None = None,
         missed_callers: dict[str, dict[str, int]] | None = None,
+        git_sha: str | None = None,
     ) -> "CallGraphIndex":
         root = Path(root).resolve()
         fg = _DiGraph()
@@ -182,6 +203,9 @@ class CallGraphIndex:
         # Compute in-degree threshold: p99 of in-degree distribution, floor of 10.
         # One-time O(N) cost at index load; cached for O(1) lookup during BFS.
         in_degree_threshold = _compute_in_degree_threshold(fg)
+        # Compute content_hash: SHA-256 of the deterministically serialised raw dict.
+        # Sorted keys + sorted callee lists ensure same raw → same hash.
+        content_hash = _compute_content_hash(raw)
         return cls(
             root=root,
             function_graph=fg,
@@ -190,6 +214,8 @@ class CallGraphIndex:
             skeletons=skeletons,
             file_shas=file_shas,
             missed_callers=missed_callers if missed_callers is not None else {},
+            git_sha=git_sha,
+            content_hash=content_hash,
             _fqn_to_file=fqn_to_file,
             _in_degree_threshold=in_degree_threshold,
         )
@@ -198,12 +224,14 @@ class CallGraphIndex:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         payload: dict = {
-            "version": 4,
+            "version": INDEX_VERSION,
             "root": str(self.root),
             "raw": self.raw,
             "skeletons": self.skeletons,
             "file_shas": self.file_shas if self.file_shas is not None else {},
             "missed_callers": self.missed_callers,
+            "git_sha": self.git_sha,
+            "content_hash": self.content_hash,
         }
         path.write_text(json.dumps(payload))
         return path
@@ -213,20 +241,22 @@ class CallGraphIndex:
         path = Path(path)
         payload = json.loads(path.read_text())
         version = payload.get("version")
-        if version != 4:
+        if version != INDEX_VERSION:
             raise ValueError(
-                f"index schema is v{version}, server requires v4 — "
+                f"index schema is v{version}, server requires v{INDEX_VERSION} — "
                 "run 'pyscope-mcp build' to regenerate"
             )
         skeletons: dict[str, list[SymbolSummary]] = payload.get("skeletons", {})
         file_shas: dict[str, str] = payload.get("file_shas", {})
         missed_callers: dict[str, dict[str, int]] = payload.get("missed_callers", {})
+        git_sha: str | None = payload.get("git_sha")
         return cls.from_raw(
             Path(payload["root"]),
             payload["raw"],
             skeletons=skeletons,
             file_shas=file_shas,
             missed_callers=missed_callers,
+            git_sha=git_sha,
         )
 
     _STALE_ACTION = "Run 'pyscope-mcp build' then 'reload' to update the index."

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import logging
+import time
+import uuid
 from pathlib import Path
 
 from pyscope_mcp import __version__
@@ -33,6 +35,11 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 _INDEX: CallGraphIndex | None = None
 _INDEX_PATH: Path | None = None
+
+# UUID generated once at module import (= server startup).
+# Since the MCP server is spawned per-session as a stdio subprocess,
+# this naturally partitions log entries by session.
+_SERVER_ID: str = str(uuid.uuid4())
 
 # ---------------------------------------------------------------------------
 # Server instance
@@ -371,15 +378,41 @@ async def _tools_call(id, params):  # noqa: A002
 
     if not isinstance(name, str) or name not in _TOOL_NAMES:
         # Unknown tool name → isError:true in result, NOT a JSON-RPC error
-        return _error_result(f"unknown tool: {name!r}")
+        result = _error_result(f"unknown tool: {name!r}")
+        from pyscope_mcp import _log
+        _log.log_call(
+            server_id=_SERVER_ID,
+            rpc_id=id,
+            tool=str(name),
+            args=arguments,
+            duration_ms=0,
+            result=result,
+            index=_INDEX,
+        )
+        return result
 
     try:
-        return await _dispatch_tool(name, arguments)
+        t0 = time.perf_counter()
+        result = await _dispatch_tool(name, arguments)
+        duration_ms = int((time.perf_counter() - t0) * 1000)
     except RpcError:
         raise  # propagate JSON-RPC level errors (e.g. missing index path)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Tool %r raised: %s", name, exc)
-        return _error_result(str(exc))
+        result = _error_result(str(exc))
+        duration_ms = 0
+
+    from pyscope_mcp import _log
+    _log.log_call(
+        server_id=_SERVER_ID,
+        rpc_id=id,
+        tool=name,
+        args=arguments,
+        duration_ms=duration_ms,
+        result=result,
+        index=_INDEX,
+    )
+    return result
 
 
 async def _dispatch_tool(name: str, arguments: dict) -> dict:
@@ -460,4 +493,15 @@ def run_stdio(index_path: Path) -> None:
     global _INDEX_PATH, _INDEX
     _INDEX_PATH = Path(index_path)
     _INDEX = CallGraphIndex.load(_INDEX_PATH)
+
+    # Initialise query logger (no-op when PYSCOPE_MCP_LOG=0).
+    from pyscope_mcp import _log
+    import os
+    log_path_str = os.environ.get("PYSCOPE_MCP_LOG_PATH")
+    if log_path_str:
+        log_path = Path(log_path_str)
+    else:
+        log_path = _INDEX_PATH.parent / "query.jsonl"
+    _log.init(log_path)
+
     asyncio.run(_SERVER.run())

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -47,6 +47,7 @@ def _make_idx(
     missed_callers: dict[str, dict[str, int]] | None = None,
     skeletons: dict[str, list[SymbolSummary]] | None = None,
     file_shas: dict[str, str] | None = None,
+    git_sha: str | None = None,
 ) -> CallGraphIndex:
     return CallGraphIndex.from_raw(
         "/tmp/test",
@@ -54,6 +55,7 @@ def _make_idx(
         skeletons=skeletons or {},
         file_shas=file_shas or {},
         missed_callers=missed_callers or {},
+        git_sha=git_sha,
     )
 
 
@@ -339,11 +341,12 @@ class TestModuleCompleteness:
 
 
 # ---------------------------------------------------------------------------
-# 7. save/load v4 round-trip + v3 rejection
+# 7. save/load v5 round-trip + old-version rejection
 # ---------------------------------------------------------------------------
 
-class TestV4Schema:
-    def test_save_writes_version_4(self, tmp_path: Path) -> None:
+class TestV5Schema:
+    def test_save_writes_current_version(self, tmp_path: Path) -> None:
+        from pyscope_mcp.graph import INDEX_VERSION
         idx = _make_idx(
             {"pkg.mod.func": ["pkg.mod.other"]},
             missed_callers={"pkg.mod.func": {"getattr_nonliteral": 2}},
@@ -351,7 +354,7 @@ class TestV4Schema:
         out = tmp_path / "index.json"
         idx.save(out)
         payload = json.loads(out.read_text())
-        assert payload["version"] == 4
+        assert payload["version"] == INDEX_VERSION
 
     def test_save_writes_missed_callers(self, tmp_path: Path) -> None:
         missed = {"pkg.mod.func": {"getattr_nonliteral": 2, "bare_name_unresolved": 1}}
@@ -362,7 +365,16 @@ class TestV4Schema:
         assert "missed_callers" in payload
         assert payload["missed_callers"] == missed
 
-    def test_load_v4_populates_missed_callers(self, tmp_path: Path) -> None:
+    def test_save_writes_git_sha_and_content_hash(self, tmp_path: Path) -> None:
+        """v5: git_sha and content_hash are present in the saved payload."""
+        idx = _make_idx({"pkg.mod.func": []}, git_sha="deadbeef" * 5)
+        out = tmp_path / "index.json"
+        idx.save(out)
+        payload = json.loads(out.read_text())
+        assert payload["git_sha"] == "deadbeef" * 5
+        assert isinstance(payload["content_hash"], str) and len(payload["content_hash"]) == 64
+
+    def test_load_populates_missed_callers(self, tmp_path: Path) -> None:
         missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
         idx = _make_idx({}, missed_callers=missed)
         out = tmp_path / "index.json"
@@ -370,7 +382,7 @@ class TestV4Schema:
         loaded = CallGraphIndex.load(out)
         assert loaded.missed_callers == missed
 
-    def test_load_v4_completeness_for_works_after_roundtrip(self, tmp_path: Path) -> None:
+    def test_load_completeness_for_works_after_roundtrip(self, tmp_path: Path) -> None:
         missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
         idx = _make_idx({}, missed_callers=missed)
         out = tmp_path / "index.json"
@@ -379,7 +391,7 @@ class TestV4Schema:
         assert loaded.completeness_for(["pkg.mod.MyClass.bar"]) == "partial"
         assert loaded.completeness_for(["pkg.other.func"]) == "complete"
 
-    def test_load_v4_empty_missed_callers(self, tmp_path: Path) -> None:
+    def test_load_empty_missed_callers(self, tmp_path: Path) -> None:
         idx = _make_idx({}, missed_callers={})
         out = tmp_path / "index.json"
         idx.save(out)
@@ -387,8 +399,9 @@ class TestV4Schema:
         assert loaded.missed_callers == {}
         assert loaded.completeness_for(["anything"]) == "complete"
 
-    @pytest.mark.parametrize("old_version", [1, 2, 3])
+    @pytest.mark.parametrize("old_version", [1, 2, 3, 4])
     def test_load_rejects_old_versions(self, tmp_path: Path, old_version: int) -> None:
+        from pyscope_mcp.graph import INDEX_VERSION
         payload = {
             "version": old_version,
             "root": "/tmp/test",
@@ -398,12 +411,12 @@ class TestV4Schema:
         }
         out = tmp_path / "index.json"
         out.write_text(json.dumps(payload))
-        with pytest.raises(ValueError, match="v4"):
+        with pytest.raises(ValueError, match=f"v{old_version}"):
             CallGraphIndex.load(out)
 
     def test_load_rejects_unknown_version(self, tmp_path: Path) -> None:
         payload = {"version": 99, "root": "/tmp", "raw": {}, "skeletons": {}, "file_shas": {}}
         out = tmp_path / "index.json"
         out.write_text(json.dumps(payload))
-        with pytest.raises(ValueError, match="v4"):
+        with pytest.raises(ValueError, match="v99"):
             CallGraphIndex.load(out)

--- a/tests/test_component_issue62.py
+++ b/tests/test_component_issue62.py
@@ -1,0 +1,414 @@
+"""Component tests for issue #62 (query logging) — impact-set boundary coverage.
+
+These tests focus on module boundaries that consume graph.py and are in the
+assessment IMPACT_SET: test_rpc_server.py, test_hub_suppression_integration.py,
+test_staleness.py, and src/pyscope_mcp/__init__.py.
+
+Cross-cutting changes validated here:
+  - INDEX_VERSION v4 → v5 (save/load round-trip for new fields)
+  - New required ``git_sha`` and ``content_hash`` fields on CallGraphIndex
+  - ``_bfs`` return type change list → dict[str, int] (consumed by callers_of /
+    callees_of / module_callers / module_callees)
+  - New ``dropped`` field on CallersResult / CalleesResult / ModuleResult
+  - RPC layer: ``dropped`` field present in JSON payloads from callers_of,
+    callees_of, module_callers, module_callees tool calls
+
+Negative control: test_version_mismatch_raises uses a hard-coded v4 index
+to prove that load() rejects old indexes — this verifies the test runner can
+detect a regression if INDEX_VERSION is reverted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_minimal_raw() -> dict[str, list[str]]:
+    return {
+        "pkg.mod.foo": ["pkg.mod.bar"],
+        "pkg.mod.bar": [],
+        "pkg.other.baz": ["pkg.mod.foo"],
+    }
+
+
+def _make_index(tmp_path: Path, raw: dict[str, list[str]] | None = None) -> CallGraphIndex:
+    if raw is None:
+        raw = _make_minimal_raw()
+    return CallGraphIndex.from_raw(str(tmp_path), raw)
+
+
+# ---------------------------------------------------------------------------
+# A. INDEX_VERSION = 5 round-trip (save/load)
+# ---------------------------------------------------------------------------
+
+def test_index_version_is_five() -> None:
+    """INDEX_VERSION must equal 5 on the fix/issue-62-query-logging branch."""
+    assert INDEX_VERSION == 5, (
+        f"INDEX_VERSION={INDEX_VERSION}; expected 5. "
+        "This test exists to pin the version and detect silent regressions."
+    )
+
+
+def test_save_writes_version_five(tmp_path: Path) -> None:
+    """CallGraphIndex.save() must write version=5 to disk."""
+    idx = _make_index(tmp_path)
+    saved = idx.save(tmp_path / "index.json")
+    payload = json.loads(saved.read_text())
+    assert payload["version"] == 5, (
+        f"Saved index version={payload['version']}, expected 5"
+    )
+
+
+def test_load_rejects_v4_index(tmp_path: Path) -> None:
+    """CallGraphIndex.load() must raise ValueError for a v4 index."""
+    old_payload = {
+        "version": 4,
+        "root": str(tmp_path),
+        "raw": _make_minimal_raw(),
+        "skeletons": {},
+        "file_shas": {},
+        "missed_callers": {},
+    }
+    idx_path = tmp_path / "old_index.json"
+    idx_path.write_text(json.dumps(old_payload))
+    with pytest.raises(ValueError, match="v4"):
+        CallGraphIndex.load(idx_path)
+
+
+def test_load_accepts_v5_index(tmp_path: Path) -> None:
+    """CallGraphIndex.load() must succeed for a freshly saved v5 index."""
+    idx = _make_index(tmp_path)
+    saved = idx.save(tmp_path / "index.json")
+    loaded = CallGraphIndex.load(saved)
+    assert loaded.function_graph.number_of_nodes() == idx.function_graph.number_of_nodes()
+
+
+# ---------------------------------------------------------------------------
+# B. git_sha and content_hash fields
+# ---------------------------------------------------------------------------
+
+def test_from_raw_populates_content_hash(tmp_path: Path) -> None:
+    """content_hash is computed and non-empty after from_raw()."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    assert isinstance(idx.content_hash, str)
+    assert len(idx.content_hash) == 64, "SHA-256 hex digest must be 64 chars"
+
+
+def test_content_hash_is_deterministic(tmp_path: Path) -> None:
+    """Same raw dict always produces the same content_hash."""
+    raw = _make_minimal_raw()
+    idx1 = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx2 = CallGraphIndex.from_raw(str(tmp_path), raw)
+    assert idx1.content_hash == idx2.content_hash
+
+
+def test_content_hash_changes_with_raw(tmp_path: Path) -> None:
+    """Different raw dicts produce different content_hashes."""
+    raw_a = {"pkg.a": ["pkg.b"], "pkg.b": []}
+    raw_b = {"pkg.a": ["pkg.c"], "pkg.c": []}
+    idx_a = CallGraphIndex.from_raw(str(tmp_path), raw_a)
+    idx_b = CallGraphIndex.from_raw(str(tmp_path), raw_b)
+    assert idx_a.content_hash != idx_b.content_hash
+
+
+def test_git_sha_defaults_to_none(tmp_path: Path) -> None:
+    """git_sha defaults to None when not provided to from_raw()."""
+    idx = _make_index(tmp_path)
+    assert idx.git_sha is None
+
+
+def test_git_sha_roundtrips_through_save_load(tmp_path: Path) -> None:
+    """git_sha is persisted on save and restored on load."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha="abc123def456")
+    saved = idx.save(tmp_path / "index.json")
+    loaded = CallGraphIndex.load(saved)
+    assert loaded.git_sha == "abc123def456"
+
+
+def test_git_sha_none_roundtrips_through_save_load(tmp_path: Path) -> None:
+    """git_sha=None round-trips correctly (persisted as null, restored as None)."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=None)
+    saved = idx.save(tmp_path / "index.json")
+    loaded = CallGraphIndex.load(saved)
+    assert loaded.git_sha is None
+
+
+def test_content_hash_roundtrips_through_save_load(tmp_path: Path) -> None:
+    """content_hash is persisted on save and identical after load."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    saved = idx.save(tmp_path / "index.json")
+    loaded = CallGraphIndex.load(saved)
+    assert loaded.content_hash == idx.content_hash
+    assert len(loaded.content_hash) == 64
+
+
+def test_saved_payload_has_git_sha_and_content_hash_keys(tmp_path: Path) -> None:
+    """Serialised index JSON must contain git_sha and content_hash keys."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha="deadbeef")
+    saved = idx.save(tmp_path / "index.json")
+    payload = json.loads(saved.read_text())
+    assert "git_sha" in payload, "git_sha must be present in saved index"
+    assert "content_hash" in payload, "content_hash must be present in saved index"
+    assert payload["git_sha"] == "deadbeef"
+    assert payload["content_hash"] == idx.content_hash
+
+
+# ---------------------------------------------------------------------------
+# C. dropped field on callers_of / callees_of (graph.py boundary)
+# ---------------------------------------------------------------------------
+
+def test_callers_of_has_dropped_field(tmp_path: Path) -> None:
+    """callers_of result always contains a 'dropped' key (0 when not truncated)."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    result = idx.callers_of("pkg.mod.bar", depth=1)
+    assert "dropped" in result, "callers_of must include 'dropped' in result dict"
+    assert isinstance(result["dropped"], int)
+    assert result["dropped"] == 0  # small fixture, no truncation
+
+
+def test_callees_of_has_dropped_field(tmp_path: Path) -> None:
+    """callees_of result always contains a 'dropped' key (0 when not truncated)."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    result = idx.callees_of("pkg.mod.foo", depth=1)
+    assert "dropped" in result, "callees_of must include 'dropped' in result dict"
+    assert isinstance(result["dropped"], int)
+    assert result["dropped"] == 0
+
+
+def test_module_callers_has_dropped_field(tmp_path: Path) -> None:
+    """module_callers result always contains a 'dropped' key (0 when not truncated)."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    result = idx.module_callers("pkg.mod", depth=1)
+    assert "dropped" in result, "module_callers must include 'dropped' in result dict"
+    assert isinstance(result["dropped"], int)
+    assert result["dropped"] == 0
+
+
+def test_module_callees_has_dropped_field(tmp_path: Path) -> None:
+    """module_callees result always contains a 'dropped' key (0 when not truncated)."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    result = idx.module_callees("pkg.other", depth=1)
+    assert "dropped" in result, "module_callees must include 'dropped' in result dict"
+    assert isinstance(result["dropped"], int)
+    assert result["dropped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# D. RPC layer: dropped field present in JSON tool responses
+# (boundary: test_rpc_server.py-style harness against server.py)
+# ---------------------------------------------------------------------------
+
+class _FakeReader:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+        self._pos = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._pos >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._pos]
+        self._pos += 1
+        return line + b"\n"
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.chunks.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def responses(self) -> list[dict]:
+        result = []
+        for chunk in self.chunks:
+            for line in chunk.split(b"\n"):
+                line = line.strip()
+                if line:
+                    result.append(json.loads(line))
+        return result
+
+
+def _req(method: str, params: Any = None, req_id: int = 1) -> bytes:
+    msg: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        msg["params"] = params
+    return json.dumps(msg).encode()
+
+
+async def _run_server(server, lines: list[bytes]) -> list[dict]:
+    reader = _FakeReader(lines)
+    writer = _FakeWriter()
+    await server._loop(reader, writer)
+    return writer.responses()
+
+
+@pytest.fixture()
+def _server_with_index(tmp_path: Path):
+    """A server fixture wired to a fresh minimal index."""
+    raw = _make_minimal_raw()
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx_path = tmp_path / "index.json"
+    idx.save(idx_path)
+
+    import pyscope_mcp.server as srv
+    srv._INDEX_PATH = idx_path
+    srv._INDEX = None  # force lazy reload
+    srv._SERVER._shutdown_requested = False
+    yield srv._SERVER
+    srv._INDEX = None
+
+
+@pytest.mark.asyncio
+async def test_rpc_callers_of_response_has_dropped(_server_with_index) -> None:
+    """callers_of tool response JSON must include 'dropped' key."""
+    lines = [_req("tools/call", {"name": "callers_of", "arguments": {"fqn": "pkg.mod.bar"}}, req_id=1)]
+    responses = await _run_server(_server_with_index, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "dropped" in payload, (
+        "callers_of RPC response must include 'dropped' field — "
+        "types.CallersResult was updated in issue #62 but server serialisation may be missing it"
+    )
+    assert isinstance(payload["dropped"], int)
+    assert payload["dropped"] == 0  # small fixture, no cap triggered
+
+
+@pytest.mark.asyncio
+async def test_rpc_callees_of_response_has_dropped(_server_with_index) -> None:
+    """callees_of tool response JSON must include 'dropped' key."""
+    lines = [_req("tools/call", {"name": "callees_of", "arguments": {"fqn": "pkg.mod.foo"}}, req_id=1)]
+    responses = await _run_server(_server_with_index, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "dropped" in payload, (
+        "callees_of RPC response must include 'dropped' field"
+    )
+    assert isinstance(payload["dropped"], int)
+    assert payload["dropped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rpc_module_callers_response_has_dropped(_server_with_index) -> None:
+    """module_callers tool response JSON must include 'dropped' key."""
+    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "pkg.mod"}}, req_id=1)]
+    responses = await _run_server(_server_with_index, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "dropped" in payload, (
+        "module_callers RPC response must include 'dropped' field"
+    )
+    assert isinstance(payload["dropped"], int)
+    assert payload["dropped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rpc_module_callees_response_has_dropped(_server_with_index) -> None:
+    """module_callees tool response JSON must include 'dropped' key."""
+    lines = [_req("tools/call", {"name": "module_callees", "arguments": {"module": "pkg.other"}}, req_id=1)]
+    responses = await _run_server(_server_with_index, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "dropped" in payload, (
+        "module_callees RPC response must include 'dropped' field"
+    )
+    assert isinstance(payload["dropped"], int)
+    assert payload["dropped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# E. Negative control — verifies the runner can detect a regression
+# Pinned test: version mismatch raises
+# ---------------------------------------------------------------------------
+
+def test_version_mismatch_raises(tmp_path: Path) -> None:
+    """NEGATIVE CONTROL: load() with wrong version must raise ValueError.
+
+    This test pins the version-mismatch rejection path so that any revert of
+    INDEX_VERSION (e.g. back to v4) would cause this test to fail with a clear
+    error message, rather than silently passing with corrupted state.
+    """
+    # Write a v3 index (two versions behind current v5)
+    stale_payload = {
+        "version": 3,
+        "root": str(tmp_path),
+        "raw": _make_minimal_raw(),
+        "skeletons": {},
+        "file_shas": {},
+        # v3 has no missed_callers, git_sha, content_hash
+    }
+    idx_path = tmp_path / "stale.json"
+    idx_path.write_text(json.dumps(stale_payload))
+    with pytest.raises(ValueError, match="v3"):
+        CallGraphIndex.load(idx_path)
+
+
+# ---------------------------------------------------------------------------
+# F. __init__.py boundary: CallGraphIndex importable from pyscope_mcp
+# ---------------------------------------------------------------------------
+
+def test_init_exports_call_graph_index() -> None:
+    """pyscope_mcp.__init__ must re-export CallGraphIndex (src/pyscope_mcp/__init__.py boundary)."""
+    from pyscope_mcp import CallGraphIndex as CGI  # noqa: N811
+    # Verify it's the same class (not a copy/import confusion)
+    assert CGI is CallGraphIndex, (
+        "pyscope_mcp.CallGraphIndex must be the same object as "
+        "pyscope_mcp.graph.CallGraphIndex — __init__.py re-export is broken"
+    )
+
+
+def test_init_exports_version() -> None:
+    """pyscope_mcp.__version__ must be non-empty."""
+    from pyscope_mcp import __version__
+    assert isinstance(__version__, str) and __version__
+
+
+# ---------------------------------------------------------------------------
+# G. hub_suppression_integration boundary:
+#    CallGraphIndex.from_raw() with new git_sha param accepted
+# ---------------------------------------------------------------------------
+
+def test_hub_suppression_index_accepts_git_sha(tmp_path: Path) -> None:
+    """CallGraphIndex.from_raw() must accept git_sha kwarg without error.
+
+    Covers the test_hub_suppression_integration boundary — hub_idx fixture calls
+    from_raw() and the new git_sha parameter must not break it.
+    """
+    raw = {
+        "pkg.utils.shared_helper": [],
+        "pkg.app.entry_point": ["pkg.utils.shared_helper"],
+    }
+    # Must not raise
+    idx = CallGraphIndex.from_raw(
+        str(tmp_path), raw, git_sha="cafebabe01234567"
+    )
+    assert idx.git_sha == "cafebabe01234567"
+    assert idx.content_hash  # populated, non-empty

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -265,13 +265,14 @@ def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
     assert result["truncated"] is False
 
 
-def test_save_version_is_4(tmp_path: Path) -> None:
-    """Saved index must have version=4 (bumped from 3 to carry missed_callers)."""
+def test_save_version_is_current(tmp_path: Path) -> None:
+    """Saved index must have the current INDEX_VERSION."""
+    from pyscope_mcp.graph import INDEX_VERSION
     idx = CallGraphIndex.from_raw("/tmp/test", {})
     out = tmp_path / "index.json"
     idx.save(out)
     payload = _json.loads(out.read_text())
-    assert payload["version"] == 4
+    assert payload["version"] == INDEX_VERSION
 
 
 def test_save_includes_file_shas(tmp_path: Path) -> None:
@@ -296,42 +297,42 @@ def test_save_load_roundtrip_file_shas(tmp_path: Path) -> None:
 
 
 def test_load_version_1_raises(tmp_path: Path) -> None:
-    """Version 1 index raises a clear error naming v4 (no backward compat)."""
+    """Version 1 index raises a clear error (no backward compat)."""
     payload = {"version": 1, "root": "/tmp/test", "raw": {}, "skeletons": {"any.py": []}}
     out = tmp_path / "v1_index.json"
     out.write_text(_json.dumps(payload))
 
-    with pytest.raises(ValueError, match="v4"):
+    with pytest.raises(ValueError, match="v1"):
         CallGraphIndex.load(out)
 
 
 def test_load_version_2_raises(tmp_path: Path) -> None:
-    """Version 2 index raises a clear error naming v4 (no backward compat)."""
+    """Version 2 index raises a clear error (no backward compat)."""
     payload = {"version": 2, "root": "/tmp/test", "raw": {}, "skeletons": {}}
     out = tmp_path / "v2_index.json"
     out.write_text(_json.dumps(payload))
 
-    with pytest.raises(ValueError, match="v4"):
+    with pytest.raises(ValueError, match="v2"):
         CallGraphIndex.load(out)
 
 
 def test_load_version_3_raises(tmp_path: Path) -> None:
-    """Version 3 index raises a clear error naming v4 (no backward compat)."""
+    """Version 3 index raises a clear error (no backward compat)."""
     payload = {"version": 3, "root": "/tmp/test", "raw": {}, "skeletons": {}, "file_shas": {}}
     out = tmp_path / "v3_index.json"
     out.write_text(_json.dumps(payload))
 
-    with pytest.raises(ValueError, match="v4"):
+    with pytest.raises(ValueError, match="v3"):
         CallGraphIndex.load(out)
 
 
 def test_load_version_future_raises(tmp_path: Path) -> None:
-    """Unknown version > 4 raises ValueError."""
-    payload = {"version": 5, "root": "/tmp/test", "raw": {}, "skeletons": {}, "file_shas": {}}
-    out = tmp_path / "v5_index.json"
+    """Unknown future version raises ValueError."""
+    payload = {"version": 99, "root": "/tmp/test", "raw": {}, "skeletons": {}, "file_shas": {}}
+    out = tmp_path / "v99_index.json"
     out.write_text(_json.dumps(payload))
 
-    with pytest.raises(ValueError, match="v4"):
+    with pytest.raises(ValueError, match="v99"):
         CallGraphIndex.load(out)
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -47,20 +47,30 @@ def test_queries() -> None:
 
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    from pyscope_mcp.graph import INDEX_VERSION
     idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
     out = tmp_path / "index.json"
     idx.save(out)
 
+    # Confirm the file carries the current schema version.
+    import json
+    payload = json.loads(out.read_text())
+    assert payload["version"] == INDEX_VERSION
+
     loaded = CallGraphIndex.load(out)
     assert loaded.stats() == idx.stats()
     # Compare only the query results (not staleness — the original idx has file_shas=None
-    # while the saved+loaded v4 index has file_shas={} with no stored hashes and the
+    # while the saved+loaded v5 index has file_shas={} with no stored hashes and the
     # symbol files aren't on disk, so staleness differs by design).
     assert loaded.search("helper")["results"] == idx.search("helper")["results"]
     assert loaded.search("helper")["truncated"] == idx.search("helper")["truncated"]
-    # v4 schema: missed_callers round-trips correctly (default is empty)
+    # v5 schema: missed_callers, git_sha, content_hash round-trip correctly.
     assert loaded.missed_callers == {}
     assert loaded.completeness_for(["sample.a.top"]) == "complete"
+    # git_sha defaults to None when not provided; content_hash is always populated.
+    assert loaded.git_sha is None
+    assert isinstance(loaded.content_hash, str) and len(loaded.content_hash) == 64
+    assert loaded.content_hash == idx.content_hash
 
 
 def _prefix_raw() -> dict[str, list[str]]:

--- a/tests/test_query_logger.py
+++ b/tests/test_query_logger.py
@@ -1,0 +1,531 @@
+"""Tests for the QueryLogger (src/pyscope_mcp/_log.py).
+
+Uses the same FakeReader/FakeWriter in-process harness from test_rpc_server.py
+to exercise the full dispatch path, including the logger intercept in server.py.
+
+Test scenarios per the refined spec:
+  S1 — happy-path tool call
+  S2 — error-path tool call (unknown tool name)
+  S3 — neighborhood with truncation / hub-suppression
+  S4 — opt-out path (PYSCOPE_MCP_LOG=0)
+  S5 — log rotation at 10 MB
+  S6 — reload path (index identity updates after reload)
+  S7 — logger-failure path (internal I/O error does not affect tool response)
+  S8 — index schema v5 round-trip (git_sha + content_hash)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pyscope_mcp._rpc import RpcServer
+from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+
+
+# ---------------------------------------------------------------------------
+# Re-use the pipe harness from test_rpc_server
+# ---------------------------------------------------------------------------
+
+class FakeReader:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+        self._pos = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._pos >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._pos]
+        self._pos += 1
+        return line + b"\n"
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.chunks.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def responses(self) -> list[dict]:
+        result = []
+        for chunk in self.chunks:
+            for line in chunk.split(b"\n"):
+                line = line.strip()
+                if line:
+                    result.append(json.loads(line))
+        return result
+
+
+def _line(obj: Any) -> bytes:
+    return json.dumps(obj).encode()
+
+
+def _req(method: str, params: Any = None, req_id: int = 1) -> bytes:
+    msg: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        msg["params"] = params
+    return _line(msg)
+
+
+async def _run(server: RpcServer, lines: list[bytes]) -> list[dict]:
+    reader = FakeReader(lines)
+    writer = FakeWriter()
+    await server._loop(reader, writer)
+    return writer.responses()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def raw_graph() -> dict[str, list[str]]:
+    return {
+        "pkg.mod.foo": ["pkg.mod.bar"],
+        "pkg.mod.bar": [],
+        "pkg.other.baz": ["pkg.mod.foo"],
+    }
+
+
+@pytest.fixture()
+def tmp_index(tmp_path: Path, raw_graph: dict) -> Path:
+    """Minimal v5 index on disk."""
+    idx = CallGraphIndex.from_raw(tmp_path, raw_graph)
+    idx_path = tmp_path / ".pyscope-mcp" / "index.json"
+    idx.save(idx_path)
+    return idx_path
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state(tmp_index: Path):
+    """Reset server module state + logger between every test."""
+    import pyscope_mcp.server as srv
+    import pyscope_mcp._log as _log
+
+    srv._INDEX_PATH = tmp_index
+    srv._INDEX = None
+    srv._SERVER._shutdown_requested = False
+    _log._LOGGER = None
+    yield
+    srv._INDEX = None
+    _log._LOGGER = None
+
+
+@pytest.fixture()
+def server(tmp_index: Path) -> RpcServer:
+    import pyscope_mcp.server as srv
+    srv._INDEX_PATH = tmp_index
+    srv._INDEX = None
+    return srv._SERVER
+
+
+@pytest.fixture()
+def log_path(tmp_index: Path) -> Path:
+    return tmp_index.parent / "query.jsonl"
+
+
+def _init_logger(log_path: Path) -> None:
+    """Init the logger singleton pointing at log_path."""
+    from pyscope_mcp import _log
+    with patch.dict(os.environ, {"PYSCOPE_MCP_LOG": "1"}):
+        _log.init(log_path)
+
+
+def _read_log(log_path: Path) -> list[dict]:
+    if not log_path.exists():
+        return []
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    return [json.loads(l) for l in lines if l.strip()]
+
+
+# ---------------------------------------------------------------------------
+# S1 — happy-path tool call (callers_of)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_s1_happy_path_callers_of(server: RpcServer, tmp_index: Path, log_path: Path):
+    """S1: callers_of call appends one valid JSONL entry."""
+    import pyscope_mcp.server as srv
+    srv._INDEX = CallGraphIndex.load(tmp_index)
+
+    _init_logger(log_path)
+
+    lines = [
+        _req("tools/call", {"name": "callers_of", "arguments": {"fqn": "pkg.mod.bar"}}, req_id=7),
+    ]
+    responses = await _run(server, lines)
+
+    # Tool must return a non-error result.
+    assert responses[0]["result"]["isError"] is False
+
+    entries = _read_log(log_path)
+    assert len(entries) == 1, f"Expected 1 log entry, got {len(entries)}"
+    e = entries[0]
+
+    # Required fields.
+    assert e["v"] == 1
+    assert e["ts"]  # non-empty ISO string
+    assert e["server_id"]  # non-empty UUID string
+    assert e["rpc_id"] == 7
+    assert e["tool"] == "callers_of"
+    assert "fqn" in e["args"]
+    assert isinstance(e["duration_ms"], int) and e["duration_ms"] >= 0
+    assert e["is_error"] is False
+    assert isinstance(e["truncated"], bool)
+    assert isinstance(e["result_count"], int) and e["result_count"] >= 0
+    assert e["edge_count"] is None
+    assert e["hub_suppressed_count"] is None
+    assert e["depth_full"] is None
+    assert e["token_budget_used"] is None
+    assert e["index_version"] == INDEX_VERSION
+    # No full response payload in the entry.
+    assert "results" not in e
+
+
+# ---------------------------------------------------------------------------
+# S2 — error-path tool call (unknown tool name)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_s2_error_path_unknown_tool(server: RpcServer, tmp_index: Path, log_path: Path):
+    """S2: unknown tool name logs is_error=true entry."""
+    import pyscope_mcp.server as srv
+    srv._INDEX = CallGraphIndex.load(tmp_index)
+
+    _init_logger(log_path)
+
+    lines = [
+        _req("tools/call", {"name": "does_not_exist", "arguments": {}}, req_id=3),
+    ]
+    responses = await _run(server, lines)
+
+    assert responses[0]["result"]["isError"] is True
+
+    entries = _read_log(log_path)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["is_error"] is True
+    assert e["error_msg"]  # non-empty
+    assert e["tool"] == "does_not_exist"
+
+
+# ---------------------------------------------------------------------------
+# S3 — neighborhood with truncation and hub suppression
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def hub_index(tmp_path: Path) -> Path:
+    """Synthetic graph with a hub node (many in-edges) to trigger suppression."""
+    # hub node: "pkg.util.common" called by 20 distinct callers → high in-degree
+    raw: dict[str, list[str]] = {"pkg.util.common": []}
+    for i in range(20):
+        raw[f"pkg.agent.worker_{i}.run"] = ["pkg.util.common"]
+    # Add the target symbol
+    raw["pkg.mod.target"] = ["pkg.util.common", "pkg.agent.worker_0.run"]
+    idx = CallGraphIndex.from_raw(tmp_path, raw)
+    idx_path = tmp_path / ".pyscope-mcp" / "index.json"
+    idx.save(idx_path)
+    return idx_path
+
+
+@pytest.mark.asyncio
+async def test_s3_neighborhood_truncation_hub_suppression(tmp_path: Path, hub_index: Path):
+    """S3: neighborhood with truncation/hub-suppression logs correct stats."""
+    import pyscope_mcp.server as srv
+    import pyscope_mcp._log as _log
+
+    srv._INDEX_PATH = hub_index
+    srv._INDEX = CallGraphIndex.load(hub_index)
+    srv._SERVER._shutdown_requested = False
+
+    log_path = hub_index.parent / "query.jsonl"
+    with patch.dict(os.environ, {"PYSCOPE_MCP_LOG": "1"}):
+        _log.init(log_path)
+
+    lines = [
+        # Very small token_budget to force truncation
+        _req("tools/call", {
+            "name": "neighborhood",
+            "arguments": {"symbol": "pkg.mod.target", "depth": 2, "token_budget": 10},
+        }, req_id=5),
+    ]
+
+    reader = FakeReader(lines)
+    writer = FakeWriter()
+    await srv._SERVER._loop(reader, writer)
+    responses = writer.responses()
+
+    assert responses[0]["result"]["isError"] is False
+    payload = json.loads(responses[0]["result"]["content"][0]["text"])
+
+    entries = _read_log(log_path)
+    assert len(entries) == 1
+    e = entries[0]
+
+    assert e["tool"] == "neighborhood"
+    # edge_count should match actual edges in payload
+    assert e["edge_count"] == len(payload["edges"])
+    # hub_suppressed_count should match
+    assert e["hub_suppressed_count"] == len(payload["hub_suppressed"])
+    # depth_full and token_budget_used present
+    assert e["depth_full"] is not None
+    assert e["token_budget_used"] is not None
+    assert e["result_count"] is None  # neighborhood has no "results" key
+
+
+# ---------------------------------------------------------------------------
+# S4 — opt-out path (PYSCOPE_MCP_LOG=0)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_s4_opt_out_no_file_created(server: RpcServer, tmp_index: Path, log_path: Path):
+    """S4: PYSCOPE_MCP_LOG=0 — no log file written, tool response unchanged."""
+    import pyscope_mcp.server as srv
+    import pyscope_mcp._log as _log
+
+    srv._INDEX = CallGraphIndex.load(tmp_index)
+
+    with patch.dict(os.environ, {"PYSCOPE_MCP_LOG": "0"}):
+        _log.init(log_path)
+
+    assert _log._LOGGER is None
+
+    lines = [
+        _req("tools/call", {"name": "stats", "arguments": {}}, req_id=1),
+    ]
+    responses = await _run(server, lines)
+    assert responses[0]["result"]["isError"] is False
+    assert not log_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# S5 — log rotation at 10 MB
+# ---------------------------------------------------------------------------
+
+def test_s5_log_rotation(tmp_path: Path):
+    """S5: rotation at LOG_MAX_BYTES, max LOG_BACKUP_COUNT historical files."""
+    from pyscope_mcp._log import LOG_BACKUP_COUNT, LOG_MAX_BYTES, QueryLogger
+
+    log_path = tmp_path / "query.jsonl"
+    ql = QueryLogger(log_path)
+
+    # Write a big chunk to simulate a file at the rotation threshold.
+    big_line = "x" * (LOG_MAX_BYTES + 100)
+    log_path.write_text(big_line, encoding="utf-8")
+
+    # One more write triggers rotation.
+    ql._append("new_entry")
+
+    assert log_path.exists()
+    assert (log_path.parent / "query.jsonl.1").exists()
+    content = (log_path.parent / "query.jsonl.1").read_text(encoding="utf-8")
+    assert big_line in content
+    assert log_path.read_text(encoding="utf-8").strip() == "new_entry"
+
+
+def test_s5_rotation_caps_at_backup_count(tmp_path: Path):
+    """S5: oldest backup is deleted when exceeding LOG_BACKUP_COUNT rotations."""
+    from pyscope_mcp._log import LOG_BACKUP_COUNT, LOG_MAX_BYTES, QueryLogger
+
+    log_path = tmp_path / "query.jsonl"
+    ql = QueryLogger(log_path)
+
+    # Pre-create backup files .1 through .LOG_BACKUP_COUNT (already at limit).
+    for i in range(1, LOG_BACKUP_COUNT + 1):
+        backup = log_path.with_suffix(log_path.suffix + f".{i}")
+        backup.write_text(f"backup_{i}", encoding="utf-8")
+
+    # Fill the main log to trigger rotation.
+    log_path.write_text("x" * (LOG_MAX_BYTES + 100), encoding="utf-8")
+    ql._append("latest")
+
+    # .6 should NOT exist
+    too_old = log_path.with_suffix(log_path.suffix + f".{LOG_BACKUP_COUNT + 1}")
+    assert not too_old.exists()
+    # .1 should be the renamed current log
+    assert (log_path.with_suffix(log_path.suffix + ".1")).exists()
+    # Only LOG_BACKUP_COUNT backups remain (no +1)
+    backups = list(tmp_path.glob("query.jsonl.*"))
+    assert len(backups) <= LOG_BACKUP_COUNT
+
+
+# ---------------------------------------------------------------------------
+# S6 — reload path: index identity updates after reload
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_s6_reload_updates_index_identity(tmp_path: Path):
+    """S6: entries after reload carry new index identity; prior entries unchanged."""
+    import pyscope_mcp.server as srv
+    import pyscope_mcp._log as _log
+
+    # Build two different indexes.
+    raw_a = {"pkg.a.foo": ["pkg.a.bar"], "pkg.a.bar": []}
+    raw_b = {"pkg.b.hello": ["pkg.b.world"], "pkg.b.world": []}
+    idx_a = CallGraphIndex.from_raw(tmp_path, raw_a)
+    idx_b = CallGraphIndex.from_raw(tmp_path, raw_b)
+    idx_path = tmp_path / ".pyscope-mcp" / "index.json"
+    idx_a.save(idx_path)
+
+    srv._INDEX_PATH = idx_path
+    srv._INDEX = CallGraphIndex.load(idx_path)
+    hash_a = srv._INDEX.content_hash
+
+    log_path = idx_path.parent / "query.jsonl"
+    with patch.dict(os.environ, {"PYSCOPE_MCP_LOG": "1"}):
+        _log.init(log_path)
+
+    # First call (index A).
+    lines_pre = [
+        _req("tools/call", {"name": "stats", "arguments": {}}, req_id=1),
+    ]
+    reader = FakeReader(lines_pre)
+    writer = FakeWriter()
+    await srv._SERVER._loop(reader, writer)
+
+    # Switch to index B on disk and reload.
+    idx_b.save(idx_path)
+    hash_b = idx_b.content_hash
+
+    lines_reload = [
+        _req("tools/call", {"name": "reload", "arguments": {}}, req_id=2),
+        _req("tools/call", {"name": "stats", "arguments": {}}, req_id=3),
+    ]
+    reader = FakeReader(lines_reload)
+    writer = FakeWriter()
+    await srv._SERVER._loop(reader, writer)
+
+    entries = _read_log(log_path)
+    assert len(entries) == 3
+
+    # First entry uses hash_a.
+    assert entries[0]["index_content_hash"] == hash_a
+    # reload entry uses hash_b (new index already loaded by _dispatch_tool).
+    assert entries[1]["tool"] == "reload"
+    assert entries[1]["index_content_hash"] == hash_b
+    # Third entry also uses hash_b.
+    assert entries[2]["index_content_hash"] == hash_b
+
+
+# ---------------------------------------------------------------------------
+# S7 — logger-failure path (internal error does not affect tool response)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_s7_logger_failure_does_not_affect_tool_response(
+    server: RpcServer, tmp_index: Path, log_path: Path, caplog
+):
+    """S7: when the logger's internal _append raises, tool returns normally and warning emitted."""
+    import pyscope_mcp.server as srv
+    import pyscope_mcp._log as _log
+
+    srv._INDEX = CallGraphIndex.load(tmp_index)
+
+    _init_logger(log_path)
+
+    # Patch _append (the I/O method) to raise, while leaving write()'s exception handler intact.
+    def _boom_append(self, line: str):
+        raise OSError("simulated disk full")
+
+    import logging
+    with patch.object(_log.QueryLogger, "_append", _boom_append):
+        with caplog.at_level(logging.WARNING, logger="pyscope_mcp._log"):
+            lines = [
+                _req("tools/call", {"name": "stats", "arguments": {}}, req_id=1),
+            ]
+            responses = await _run(server, lines)
+
+    # Tool must still return a valid result — logger failure must not propagate.
+    assert responses[0]["result"]["isError"] is False
+    # At least one warning was emitted via the logging infrastructure.
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_records, "Expected at least one warning from QueryLogger"
+
+
+# ---------------------------------------------------------------------------
+# S8 — index schema v5 round-trip
+# ---------------------------------------------------------------------------
+
+def test_s8_v5_roundtrip_git_sha_content_hash(tmp_path: Path):
+    """S8: save/load round-trips git_sha and content_hash; v4 load fails."""
+    raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
+    fake_sha = "a1b2c3d4e5f6789012345678901234567890abcd"
+
+    idx = CallGraphIndex.from_raw(tmp_path, raw, git_sha=fake_sha)
+    assert idx.git_sha == fake_sha
+    assert len(idx.content_hash) == 64  # SHA-256 hex
+
+    idx_path = tmp_path / "index.json"
+    idx.save(idx_path)
+
+    payload = json.loads(idx_path.read_text())
+    assert payload["version"] == INDEX_VERSION
+    assert payload["git_sha"] == fake_sha
+    assert payload["content_hash"] == idx.content_hash
+
+    loaded = CallGraphIndex.load(idx_path)
+    assert loaded.git_sha == fake_sha
+    assert loaded.content_hash == idx.content_hash
+
+
+def test_s8_content_hash_is_deterministic(tmp_path: Path):
+    """S8: two builds against the same raw dict produce the same content_hash."""
+    raw = {"pkg.mod.foo": ["pkg.mod.bar", "pkg.mod.baz"], "pkg.mod.bar": [], "pkg.mod.baz": []}
+    idx1 = CallGraphIndex.from_raw(tmp_path, raw)
+    idx2 = CallGraphIndex.from_raw(tmp_path, raw)
+    assert idx1.content_hash == idx2.content_hash
+    assert len(idx1.content_hash) == 64
+
+
+def test_s8_non_git_build_produces_none_git_sha(tmp_path: Path):
+    """S8: building without a git_sha produces git_sha=None; load/serve still work."""
+    raw = {"pkg.mod.foo": []}
+    idx = CallGraphIndex.from_raw(tmp_path, raw, git_sha=None)
+    assert idx.git_sha is None
+    idx_path = tmp_path / "index.json"
+    idx.save(idx_path)
+
+    loaded = CallGraphIndex.load(idx_path)
+    assert loaded.git_sha is None
+    assert loaded.stats()["functions"] >= 1
+
+
+def test_s8_v4_index_fails_to_load(tmp_path: Path):
+    """S8: loading a v4 index raises ValueError with clear message."""
+    # Write a manually crafted v4 index blob.
+    raw = {"pkg.mod.foo": []}
+    v4_payload = {
+        "version": 4,
+        "root": str(tmp_path),
+        "raw": raw,
+        "skeletons": {},
+        "file_shas": {},
+        "missed_callers": {},
+    }
+    idx_path = tmp_path / "index.json"
+    idx_path.write_text(json.dumps(v4_payload))
+
+    with pytest.raises(ValueError, match="v4"):
+        CallGraphIndex.load(idx_path)
+
+
+def test_s8_different_raw_produces_different_hash(tmp_path: Path):
+    """S8: different raw dicts produce different content hashes."""
+    raw_a = {"pkg.a.foo": ["pkg.a.bar"], "pkg.a.bar": []}
+    raw_b = {"pkg.b.hello": ["pkg.b.world"], "pkg.b.world": []}
+    idx_a = CallGraphIndex.from_raw(tmp_path, raw_a)
+    idx_b = CallGraphIndex.from_raw(tmp_path, raw_b)
+    assert idx_a.content_hash != idx_b.content_hash

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -319,11 +319,12 @@ def test_file_skeleton_build_serve_e2e(tmp_path: Path) -> None:
     )
     assert build_result.returncode == 0, f"build failed: {build_result.stderr.decode()}"
 
-    # 3. Index is version 4 and contains skeletons + file_shas + missed_callers for core.py
+    # 3. Index is current version and contains skeletons + file_shas + missed_callers for core.py
+    from pyscope_mcp.graph import INDEX_VERSION
     payload = json.loads(index_file.read_text())
-    assert payload["version"] == 4
-    assert "file_shas" in payload, "version 4 index must contain file_shas"
-    assert "missed_callers" in payload, "version 4 index must contain missed_callers"
+    assert payload["version"] == INDEX_VERSION
+    assert "file_shas" in payload, "index must contain file_shas"
+    assert "missed_callers" in payload, "index must contain missed_callers"
     rel = "mypkg/core.py"
     assert rel in payload["skeletons"], (
         f"expected '{rel}' in skeletons; got keys: {list(payload['skeletons'])}"
@@ -609,8 +610,9 @@ def test_completeness_field_e2e(tmp_path: Path) -> None:
     )
     assert build_result.returncode == 0, f"build failed: {build_result.stderr.decode()}"
 
+    from pyscope_mcp.graph import INDEX_VERSION
     payload = json.loads(index_file.read_text())
-    assert payload["version"] == 4, f"expected v4 index; got version={payload.get('version')}"
+    assert payload["version"] == INDEX_VERSION, f"expected v{INDEX_VERSION} index; got version={payload.get('version')}"
     assert "missed_callers" in payload, "index must contain missed_callers"
     # bar has an unresolvable getattr call — it must appear in missed_callers
     assert "mypkg.core.bar" in payload["missed_callers"], (


### PR DESCRIPTION
Closes #62

## What changed

Before this PR, every `tools/call` dispatch on the serve path was invisible to the developer: there was no record of which tools fired, how long they took, or when results were truncated. Calibration decisions for depth defaults, token budgets, and hub thresholds had to be made by inspection rather than measurement.

This PR adds a lightweight JSONL query logger on the serve path so real `video_agent_long` sessions can be analyzed offline. Simultaneously, it closes a Law 3 anti-pattern gap by adding `git_sha` and `content_hash` to the index header — enabling log entries to be tied to a specific graph version.

## Implementation walkthrough

### New / modified functions

**`_compute_content_hash(raw)` in `src/pyscope_mcp/graph.py`** — Computes a SHA-256 hex digest of the `raw` call-graph dict, serialized with sorted keys and sorted callee lists. Determinism is required so two builds against the same source always produce the same hash; it is the primary identity key for a graph version.

**`CallGraphIndex.from_raw(..., git_sha=None)` in `src/pyscope_mcp/graph.py`** — Now accepts an optional `git_sha` and auto-computes `content_hash` via `_compute_content_hash`. Both fields are stored on the dataclass and round-tripped through `save`/`load`.

**`CallGraphIndex.save` / `CallGraphIndex.load` in `src/pyscope_mcp/graph.py`** — `save` now writes `version=5`, `git_sha`, and `content_hash` into the JSON payload. `load` requires `version == INDEX_VERSION` (5); any other version raises `ValueError: index schema is vN, server requires v5 — run 'pyscope-mcp build' to regenerate`. No migration shim — old indexes are invalid per CLAUDE.md corollary 1.3/4.3.

**`cmd_build` in `src/pyscope_mcp/cli.py`** — Runs `git rev-parse HEAD` (cwd=repo root, `check=False`). On success, the 40-char hex SHA is passed to `from_raw`. On failure (not a git repo, git binary absent, non-zero exit), `git_sha=None` is passed and the build continues normally. `subprocess` is now imported at the top of the module.

**`QueryLogger` class in `src/pyscope_mcp/_log.py`** — Owns the file handle, rotation logic, and entry construction. Key invariants: (1) `write()` catches all exceptions internally and emits at most one `logger.warning()` per session on I/O failure; (2) `_append()` triggers rotation via `_maybe_rotate()` before every write; (3) rotation renames the current file to `.1`, shifts `.1`–`.4` up by one, and deletes `.6` if it would exist (enforcing a 5-backup cap).

**`log_call(...)` in `src/pyscope_mcp/_log.py`** — Module-level function that checks `_LOGGER is None` (the opt-out fast path) and delegates to `QueryLogger.write`. Wrapped in a `try/except` guard so a bug in the logger can never propagate to the RPC dispatch loop.

**`_tools_call(id, params)` in `src/pyscope_mcp/server.py`** — Intercept added after `await _dispatch_tool(name, arguments)` resolves. `time.perf_counter()` is sampled before and after the dispatch; `_log.log_call(...)` is called with the resolved result, duration, and the current `_INDEX`. The unknown-tool early-exit path also calls `log_call` with `duration_ms=0`. A `RpcError` re-raise skips the logger (RPC-level errors are not tool-level events).

**`run_stdio(index_path)` in `src/pyscope_mcp/server.py`** — Reads `PYSCOPE_MCP_LOG_PATH` (override) or defaults to `<index_dir>/query.jsonl`. Calls `_log.init(log_path)` before starting the RPC loop.

### How components interact

```
tools/call → _tools_call(id, params)
                 │
                 ├─[unknown tool]─► _error_result() ─► log_call(..., duration_ms=0)
                 │
                 ├─► t0 = perf_counter()
                 ├─► await _dispatch_tool(name, args) ─► result
                 ├─► duration_ms = (perf_counter() - t0) * 1000
                 └─► log_call(server_id, rpc_id, tool, args, duration_ms, result, _INDEX)
                          │
                          └─► _LOGGER.write(...)
                                   │
                                   ├─► _build_entry() — extracts shape stats from payload
                                   └─► _append(json_line) ─► _maybe_rotate() ─► file.write+flush
```

### Default execution path

**Before**: `tools/call → _tools_call → _dispatch_tool → result → return to RPC loop`. No record of the dispatch existed outside the RPC stream.

**After**: `tools/call → _tools_call → [t0] → _dispatch_tool → result → [duration_ms] → log_call → _LOGGER.write → _append → file.write+flush → return to RPC loop`. The logger is in-line but synchronous and single-digit-millisecond cost on local disk — well within per-call latency budget. When `PYSCOPE_MCP_LOG=0`, `_LOGGER is None` and the entire path short-circuits at a single `is None` check.

### Edge cases and error handling

- **Logger I/O failure** (disk full, permission denied): caught in `QueryLogger.write` via a broad `except Exception`. One `logger.warning()` is emitted to stderr; `_warned` is set to suppress subsequent warnings. The tool response is unaffected.
- **`log_call` guard**: an additional `try/except` in `log_call` ensures that even if `QueryLogger.write` itself raises unexpectedly (e.g. a bug in `_build_entry`), the exception never propagates to `_tools_call`.
- **Non-git build**: `git rev-parse HEAD` failure → `git_sha=None`. The index saves and loads cleanly; the logger records `index_git_sha: null`.
- **Reload mid-session**: after `reload`, `_INDEX` is replaced. Subsequent `log_call` calls read the new index's `git_sha` and `content_hash`; prior entries are not rewritten.
- **`stats` and `reload` tools**: these return no `results`, `edges`, or `hub_suppressed` fields — the logger records `result_count=null`, `edge_count=null`, `hub_suppressed_count=null` for them.

### What was intentionally not changed

- `_rpc.py` required no changes — `id` is already passed directly to `_tools_call`.
- `.gitignore` required no changes — `.pyscope-mcp/` is already present.
- No async writes — v0 is synchronous per the spec; deferred to a follow-up (noted in `_log.py` docstring).
- No `session_set` MCP tool or `_session_id` param — session correlation is handled offline by joining on `(ts, tool, args)` with claude's own `~/.claude/projects/*.jsonl`.

## Tier / approach

Tier 1 — Planner → Coder (single wave, all files owned by one agent)

## Acceptance criteria

- [x] S1: happy-path callers_of call appends one valid JSONL entry with all required fields
- [x] S2: error-path (unknown tool) logs is_error=true entry with error_msg
- [x] S3: neighborhood with truncation/hub-suppression logs correct truncated, hub_suppressed_count, edge_count
- [x] S4: PYSCOPE_MCP_LOG=0 writes no log file, no .pyscope-mcp/ directory created
- [x] S5: rotation at 10 MB, max 5 historical files retained
- [x] S6: after reload, new entries carry new index identity; prior entries unchanged
- [x] S7: logger internal failure does not affect tool response, emits warning
- [x] S8: v5 round-trip (git_sha + content_hash persisted); v4 load fails with clear error; non-git build produces git_sha=None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Review summary
- Cycles run: 1 (exited early — no tier `fix` findings)
- Findings fixed: 0 (no tier `fix` findings identified)
- Tier `propose` surfaced: 2 minor (F-0-1 redundant inline import, F-0-2 deferred import repeated — not auto-applied)
- Tier `escalate` surfaced: 1 (F-0-3 content_hash not read back on load — design decision deferred to follow-up)
- Intent validation: clean
- Outstanding: None (tier `fix`)

## History
Squash: A — single commit (`fix(#62): lightweight internal query logging on the serve path`)
Branch already up to date with `main` — no rebase required. PR CI: no checks configured.

## Merge instructions
Merge via **squash merge** (not merge commit or rebase merge).