### PR TITLE
fix(#69): clear not-found error_reason for bad path/FQN inputs

### DIFF
--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -432,13 +432,11 @@ class CallGraphIndex:
         if path not in self.skeletons:
             result: dict = {
                 "isError": True,
-                "stale": True,
+                "error_reason": "path_not_in_index",
+                "stale": False,
                 "stale_files": [],
-                "stale_action": self._STALE_ACTION,
                 **commit,
             }
-            if self.file_shas is None:
-                result["index_stale_reason"] = "index_format_incompatible"
             return result
 
         symbols = self.skeletons[path]
@@ -528,7 +526,21 @@ class CallGraphIndex:
         Response includes uniform staleness fields (``stale``, ``stale_files``,
         and optionally ``stale_action`` / ``index_stale_reason``) and a
         ``completeness`` field (``"complete"`` or ``"partial"``).
+
+        If *fqn* is not present in the graph at all, returns an error dict
+        with ``isError: True``, ``error_reason: "fqn_not_in_graph"``, and
+        ``stale: False``.  An FQN that is present but has zero callers returns
+        ``results: []`` (not an error).
         """
+        if fqn not in self.function_graph.nodes:
+            commit = self._commit_staleness()
+            return {  # type: ignore[return-value]
+                "isError": True,
+                "error_reason": "fqn_not_in_graph",
+                "stale": False,
+                "stale_files": [],
+                **commit,
+            }
         rev_fg = self.function_graph.reverse(copy=False)
         bfs_result = _bfs(rev_fg, fqn, depth)
         ranked = self._rank_bfs_results(bfs_result, rev_fg)
@@ -557,7 +569,21 @@ class CallGraphIndex:
         Response includes uniform staleness fields (``stale``, ``stale_files``,
         and optionally ``stale_action`` / ``index_stale_reason``) and a
         ``completeness`` field (``"complete"`` or ``"partial"``).
+
+        If *fqn* is not present in the graph at all, returns an error dict
+        with ``isError: True``, ``error_reason: "fqn_not_in_graph"``, and
+        ``stale: False``.  An FQN that is present but has zero callees returns
+        ``results: []`` (not an error).
         """
+        if fqn not in self.function_graph.nodes:
+            commit = self._commit_staleness()
+            return {  # type: ignore[return-value]
+                "isError": True,
+                "error_reason": "fqn_not_in_graph",
+                "stale": False,
+                "stale_files": [],
+                **commit,
+            }
         fg = self.function_graph
         bfs_result = _bfs(fg, fqn, depth)
         ranked = self._rank_bfs_results(bfs_result, fg)
@@ -617,6 +643,17 @@ class CallGraphIndex:
         """
         fg = self.function_graph
         rev_fg = fg.reverse(copy=False)
+
+        # Guard: FQN not in graph at all → clear not-found error (not ambiguous empty-edges)
+        if symbol not in fg.nodes:
+            commit = self._commit_staleness()
+            return {  # type: ignore[return-value]
+                "isError": True,
+                "error_reason": "fqn_not_in_graph",
+                "stale": False,
+                "stale_files": [],
+                **commit,
+            }
 
         # Resolve effective threshold for this query
         effective_threshold: int = (

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -126,7 +126,10 @@ _TOOL_LIST = [
             "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
             "treating the result as exhaustive. "
             "'complete' means no result FQN (or its class siblings) appears in the miss log. "
-            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...], commit_stale, index_git_sha, head_git_sha}."
+            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...], commit_stale, index_git_sha, head_git_sha}. "
+            "If the FQN is not in the index at all, returns {isError: true, error_reason: 'fqn_not_in_graph', stale: false, stale_files: []} — "
+            "this means the FQN is wrong; rebuilding the index will not help. "
+            "An FQN with zero callers returns results: [] (not an error)."
         ),
         "inputSchema": {
             "type": "object",
@@ -156,7 +159,10 @@ _TOOL_LIST = [
             "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
             "treating the result as exhaustive. "
             "'complete' means no result FQN (or its class siblings) appears in the miss log. "
-            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...], commit_stale, index_git_sha, head_git_sha}."
+            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...], commit_stale, index_git_sha, head_git_sha}. "
+            "If the FQN is not in the index at all, returns {isError: true, error_reason: 'fqn_not_in_graph', stale: false, stale_files: []} — "
+            "this means the FQN is wrong; rebuilding the index will not help. "
+            "An FQN with zero callees returns results: [] (not an error)."
         ),
         "inputSchema": {
             "type": "object",
@@ -275,13 +281,14 @@ _TOOL_LIST = [
             "Response always includes `stale: bool` and `stale_files: list[str]`. "
             "When stale is true, `stale_files` lists the relative paths of changed files "
             "and `stale_action` provides a remediation string. "
-            "If the file was added after the last build, returns isError:true alongside stale fields. "
+            "If the path is not in the index, returns {isError: true, error_reason: 'path_not_in_index', stale: false, stale_files: []} "
+            "with no stale_action — this means the path is wrong; rebuilding the index will not help. "
             "For pre-v3 indexes, `index_stale_reason: 'index_format_incompatible'` is set. "
             "Response includes commit-level staleness: `commit_stale: bool|null`, "
             "`index_git_sha: str|null`, `head_git_sha: str|null`. "
             "Returns {results: [...], truncated: bool, total: int, stale: bool, stale_files: [...], "
             "stale_action?: str, commit_stale, index_git_sha, head_git_sha} or "
-            "{isError: true, stale: true, stale_files: [], stale_action: str, commit_stale, ...}."
+            "{isError: true, error_reason: str, stale: false, stale_files: [], commit_stale, ...}."
         ),
         "inputSchema": {
             "type": "object",
@@ -328,7 +335,11 @@ _TOOL_LIST = [
             "Returns {symbol, depth_full, depth_truncated?, edges: [[caller, callee], ...], "
             "truncated: bool, token_budget_used: int, completeness: str, "
             "hub_suppressed: list[str], hub_threshold: int, stale: bool, stale_files: [...], "
-            "commit_stale, index_git_sha, head_git_sha}."
+            "commit_stale, index_git_sha, head_git_sha}. "
+            "If the symbol FQN is not in the index at all, returns "
+            "{isError: true, error_reason: 'fqn_not_in_graph', stale: false, stale_files: []} — "
+            "this means the FQN is wrong; rebuilding the index will not help. "
+            "A symbol that is present but has no edges returns edges: [] (not an error)."
         ),
         "inputSchema": {
             "type": "object",
@@ -511,13 +522,19 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
         fqn = arguments.get("fqn")
         if not fqn:
             return _error_result("callers_of requires 'fqn'")
-        return _text(idx.callers_of(fqn, int(arguments.get("depth", 1))))
+        result = idx.callers_of(fqn, int(arguments.get("depth", 1)))
+        if result.get("isError"):
+            return {"content": [{"type": "text", "text": _json.dumps(result, indent=2)}], "isError": True}
+        return _text(result)
 
     if name == "callees_of":
         fqn = arguments.get("fqn")
         if not fqn:
             return _error_result("callees_of requires 'fqn'")
-        return _text(idx.callees_of(fqn, int(arguments.get("depth", 1))))
+        result = idx.callees_of(fqn, int(arguments.get("depth", 1)))
+        if result.get("isError"):
+            return {"content": [{"type": "text", "text": _json.dumps(result, indent=2)}], "isError": True}
+        return _text(result)
 
     if name == "module_callers":
         module = arguments.get("module")
@@ -557,7 +574,10 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
         expand_hubs = bool(arguments.get("expand_hubs", False))
         hub_threshold_raw = arguments.get("hub_threshold")
         hub_threshold = int(hub_threshold_raw) if hub_threshold_raw is not None else None
-        return _text(idx.neighborhood(symbol, depth, token_budget, expand_hubs=expand_hubs, hub_threshold=hub_threshold))
+        result = idx.neighborhood(symbol, depth, token_budget, expand_hubs=expand_hubs, hub_threshold=hub_threshold)
+        if result.get("isError"):
+            return {"content": [{"type": "text", "text": _json.dumps(result, indent=2)}], "isError": True}
+        return _text(result)
 
     # Should never reach here — guarded by _TOOL_NAMES check above
     return _error_result(f"unknown tool: {name!r}")

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -251,17 +251,22 @@ class TestNeighborhoodCompleteness:
         assert result["completeness"] == "partial"
 
     def test_isolated_node_completeness_present(self) -> None:
-        """Isolated-node path (symbol not in graph) still returns completeness."""
+        """Symbol not in graph returns isError:true, error_reason:'fqn_not_in_graph'."""
         idx = _make_idx({}, missed_callers={})
         result = idx.neighborhood("nonexistent.symbol")
-        assert "completeness" in result
-        assert result["completeness"] == "complete"
+        # Post-fix: not-in-graph returns an error dict, not a normal neighborhood result
+        assert result["isError"] is True
+        assert result["error_reason"] == "fqn_not_in_graph"
+        assert result["stale"] is False
 
     def test_isolated_node_partial_when_directly_missed(self) -> None:
+        """Symbol not in graph returns error dict even if it appears in missed_callers."""
         missed = {"nonexistent.symbol": {"bare_name_unresolved": 1}}
         idx = _make_idx({}, missed_callers=missed)
         result = idx.neighborhood("nonexistent.symbol")
-        assert result["completeness"] == "partial"
+        # Post-fix: not-in-graph returns an error dict; missed_callers does not override this
+        assert result["isError"] is True
+        assert result["error_reason"] == "fqn_not_in_graph"
 
     def test_completeness_field_always_present(self) -> None:
         idx = _make_idx(self._RAW, missed_callers={})

--- a/tests/test_component_issue69.py
+++ b/tests/test_component_issue69.py
@@ -1,0 +1,861 @@
+"""Component tests for issue #69 — FQN-not-found and path-not-in-index error
+propagation across the graph→server boundary.
+
+Two cross-module boundaries tested:
+
+  B1 (graph.py → server.py): When callers_of, callees_of, or neighborhood
+     receives an FQN absent from the graph, graph.py returns
+     {isError: True, error_reason: 'fqn_not_in_graph', stale: False,
+     stale_files: []} (plus commit staleness fields).
+     server.py must propagate this as an MCP-level isError:true response
+     containing the full dict as JSON text — it must NOT swallow the error
+     via _text(), which would wrap it in isError:false.
+
+  B2 (graph.py → server.py): When file_skeleton receives a path absent from the
+     skeleton index, graph.py returns {isError: True, error_reason:
+     'path_not_in_index', stale: False, stale_files: []} and server.py must
+     propagate it as an MCP-level isError:true response with the full dict as
+     JSON text.  The error_reason discriminator must survive serialisation and
+     be readable by the client.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyscope_mcp.graph import CallGraphIndex
+import pyscope_mcp.server as _srv
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_minimal_raw() -> dict[str, list[str]]:
+    """Minimal synthetic call graph: alpha calls beta; gamma calls alpha."""
+    return {
+        "pkg.mod.alpha": ["pkg.mod.beta"],
+        "pkg.mod.beta": [],
+        "pkg.other.gamma": ["pkg.mod.alpha"],
+    }
+
+
+def _git_fail() -> MagicMock:
+    """Fake subprocess.run result: git unavailable."""
+    m = MagicMock()
+    m.returncode = 128
+    m.stdout = ""
+    return m
+
+
+def _make_index_with_skeleton(tmp_path: Path) -> CallGraphIndex:
+    """Return a CallGraphIndex with one skeleton entry for 'pkg/mod.py'."""
+    raw: dict[str, list[str]] = {
+        "pkg.mod.alpha": ["pkg.mod.beta"],
+        "pkg.mod.beta": [],
+    }
+    skeletons = {
+        "pkg/mod.py": [
+            {"fqn": "pkg.mod.alpha", "kind": "function", "signature": "def alpha():", "lineno": 1},
+            {"fqn": "pkg.mod.beta", "kind": "function", "signature": "def beta():", "lineno": 5},
+        ]
+    }
+    # file_shas must include the path for staleness not to fire; but since the
+    # live file does not actually exist under tmp_path, we need to either
+    # omit file_shas (pre-v3 mode triggers stale=True) or provide matching shas.
+    # Use file_shas=None to get pre-v3 staleness path — that still exercises the
+    # success case skeleton content correctly.
+    return CallGraphIndex.from_raw(
+        str(tmp_path),
+        raw,
+        skeletons=skeletons,
+        file_shas=None,  # pre-v3: stale=True path, but results still returned
+    )
+
+
+# ---------------------------------------------------------------------------
+# RPC harness (mirrors the style used in test_component_issue66.py)
+# ---------------------------------------------------------------------------
+
+class _FakeReader:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+        self._pos = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._pos >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._pos]
+        self._pos += 1
+        return line + b"\n"
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.chunks.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def responses(self) -> list[dict]:
+        result = []
+        for chunk in self.chunks:
+            for line in chunk.split(b"\n"):
+                line = line.strip()
+                if line:
+                    result.append(json.loads(line))
+        return result
+
+
+def _rpc_req(method: str, params: Any = None, req_id: int = 1) -> bytes:
+    msg: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        msg["params"] = params
+    return json.dumps(msg).encode()
+
+
+async def _run_rpc(server, lines: list[bytes]) -> list[dict]:
+    reader = _FakeReader(lines)
+    writer = _FakeWriter()
+    await server._loop(reader, writer)
+    return writer.responses()
+
+
+# ---------------------------------------------------------------------------
+# B1: graph.py → server.py — FQN-not-in-graph error propagation
+#
+# Contract:
+#   1. CallGraphIndex.callers_of/callees_of/neighborhood with an absent FQN
+#      returns {isError: True, error_reason: "fqn_not_in_graph",
+#              stale: False, stale_files: [], ...commit fields}.
+#   2. server.py._dispatch_tool checks result.get("isError") and, when True,
+#      returns {"content": [{"type": "text", "text": <json>}], "isError": True}
+#      — it must NOT route through _text() which would set isError:False.
+#   3. An FQN that is present but has zero callers/callees returns
+#      results: [] (not isError).
+# ---------------------------------------------------------------------------
+
+class TestB1FqnNotFoundErrorPropagation:
+    """graph.py fqn_not_in_graph error → server.py MCP isError:true propagation."""
+
+    @pytest.fixture()
+    def _wired_server(self, tmp_path: Path):
+        """Server fixture with a real in-memory index, wired into the RPC loop."""
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=None)
+        idx_path = tmp_path / "index.json"
+        idx.save(idx_path)
+
+        _srv._INDEX_PATH = idx_path
+        _srv._INDEX = idx
+        _srv._BUILD_LOCK = None
+        _srv._SERVER._shutdown_requested = False
+
+        yield _srv._SERVER, _srv, tmp_path
+
+        # Teardown — reset module-level state
+        _srv._INDEX = None
+        _srv._BUILD_LOCK = None
+
+    # ------------------------------------------------------------------
+    # Graph-layer unit tests (no server involvement)
+    # ------------------------------------------------------------------
+
+    def test_graph_callers_of_bad_fqn_returns_is_error(self, tmp_path: Path) -> None:
+        """[B1-graph] callers_of with absent FQN returns isError:True dict.
+
+        Verifies the graph-layer contract in isolation: the dict must have
+        isError=True and error_reason="fqn_not_in_graph".  Stale must be
+        False and stale_files must be empty — a missing FQN is not a
+        staleness issue.
+        """
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.callers_of("does.not.exist", depth=1)
+
+        # Assert
+        assert result.get("isError") is True, (
+            "callers_of must return isError:True for an absent FQN"
+        )
+        assert result.get("error_reason") == "fqn_not_in_graph", (
+            f"error_reason must be 'fqn_not_in_graph', got {result.get('error_reason')!r}"
+        )
+        assert result.get("stale") is False, "stale must be False for a not-found error"
+        assert result.get("stale_files") == [], "stale_files must be [] for a not-found error"
+
+    def test_graph_callees_of_bad_fqn_returns_is_error(self, tmp_path: Path) -> None:
+        """[B1-graph] callees_of with absent FQN returns isError:True dict."""
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.callees_of("totally.absent.func", depth=1)
+
+        # Assert
+        assert result.get("isError") is True
+        assert result.get("error_reason") == "fqn_not_in_graph"
+        assert result.get("stale") is False
+        assert result.get("stale_files") == []
+
+    def test_graph_neighborhood_bad_fqn_returns_is_error(self, tmp_path: Path) -> None:
+        """[B1-graph] neighborhood with absent FQN returns isError:True dict."""
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.neighborhood("ghost.symbol", depth=2)
+
+        # Assert
+        assert result.get("isError") is True
+        assert result.get("error_reason") == "fqn_not_in_graph"
+        assert result.get("stale") is False
+        assert result.get("stale_files") == []
+
+    def test_graph_callers_of_known_fqn_zero_callers_returns_empty_results(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-graph] callers_of a known FQN with zero callers returns results:[] not isError.
+
+        Negative case: the isError path must NOT trigger when the FQN is present
+        but simply has no callers.
+        """
+        # Arrange — pkg.other.gamma has no callers in the raw graph
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.callers_of("pkg.other.gamma", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True, (
+            "callers_of must NOT set isError for a known FQN with zero callers"
+        )
+        assert "results" in result, "callers_of must include 'results' key"
+        assert result["results"] == [], (
+            "callers_of for a node with zero callers must return results:[]"
+        )
+
+    def test_graph_callees_of_known_fqn_zero_callees_returns_empty_results(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-graph] callees_of a known FQN with zero callees returns results:[] not isError."""
+        # Arrange — pkg.mod.beta has no callees
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.callees_of("pkg.mod.beta", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True
+        assert "results" in result
+        assert result["results"] == []
+
+    def test_graph_neighborhood_known_fqn_isolated_returns_empty_edges(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-graph] neighborhood for an isolated node returns edges:[] not isError."""
+        # Arrange — add a node with no edges
+        raw = _make_minimal_raw()
+        raw["pkg.mod.isolated"] = []
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.neighborhood("pkg.mod.isolated", depth=2)
+
+        # Assert
+        assert result.get("isError") is not True, (
+            "neighborhood must NOT set isError for a known (but isolated) FQN"
+        )
+        assert "edges" in result
+        assert result["edges"] == [], (
+            "neighborhood for an isolated node must return edges:[]"
+        )
+
+    # ------------------------------------------------------------------
+    # Server-layer tests via _dispatch_tool (unit, no RPC loop)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_callers_of_bad_fqn_is_error_true(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-server] _dispatch_tool('callers_of', bad FQN) surfaces isError:true.
+
+        Verifies the server.py isError-check path for callers_of:
+          result.get("isError") → True  ⟹  MCP response isError:True
+        The content text must be valid JSON and must contain error_reason.
+        """
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "callers_of", {"fqn": "no.such.function"}
+            )
+
+        # Assert
+        assert response.get("isError") is True, (
+            "server _dispatch_tool must return isError:True when graph returns "
+            "isError:True for an absent FQN"
+        )
+        assert "content" in response
+        content_text = response["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert payload.get("error_reason") == "fqn_not_in_graph", (
+            f"error_reason must be 'fqn_not_in_graph' in the content JSON, "
+            f"got {payload.get('error_reason')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_callees_of_bad_fqn_is_error_true(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-server] _dispatch_tool('callees_of', bad FQN) surfaces isError:true."""
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "callees_of", {"fqn": "missing.module.func"}
+            )
+
+        # Assert
+        assert response.get("isError") is True
+        content_text = response["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert payload.get("error_reason") == "fqn_not_in_graph"
+        assert payload.get("stale") is False
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_neighborhood_bad_fqn_is_error_true(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-server] _dispatch_tool('neighborhood', bad FQN) surfaces isError:true."""
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "neighborhood", {"symbol": "phantom.func"}
+            )
+
+        # Assert
+        assert response.get("isError") is True
+        content_text = response["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert payload.get("error_reason") == "fqn_not_in_graph"
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_callers_of_known_fqn_is_error_false(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-server] _dispatch_tool('callers_of', known FQN) returns isError:false.
+
+        Negative case: server must NOT set isError:true for a valid FQN that
+        simply has zero callers.  Verifies the _text() path is taken instead.
+        """
+        # Arrange
+        raw = _make_minimal_raw()
+        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "callers_of", {"fqn": "pkg.other.gamma"}
+            )
+
+        # Assert
+        assert response.get("isError") is False, (
+            "server must return isError:False for a known FQN with zero callers"
+        )
+        content_text = response["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert "results" in payload
+        assert payload["results"] == []
+
+    # ------------------------------------------------------------------
+    # Server-layer tests via full RPC loop
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_rpc_callers_of_bad_fqn_is_error_true(
+        self, _wired_server
+    ) -> None:
+        """[B1-rpc] callers_of with absent FQN: full RPC loop propagates isError:true.
+
+        Exercises: JSON-RPC request → _SERVER._loop → _tools_call →
+        _dispatch_tool("callers_of") → isError check → MCP response with
+        isError:true and error_reason in content JSON.
+        """
+        server, srv, _ = _wired_server
+
+        # Arrange
+        lines = [
+            _rpc_req(
+                "tools/call",
+                {"name": "callers_of", "arguments": {"fqn": "absolute.garbage.fqn"}},
+                req_id=1,
+            )
+        ]
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            responses = await _run_rpc(server, lines)
+
+        # Assert
+        assert len(responses) == 1
+        rpc_result = responses[0]["result"]
+        assert rpc_result["isError"] is True, (
+            "MCP result isError must be True when FQN is absent from the graph"
+        )
+        content_text = rpc_result["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert payload.get("error_reason") == "fqn_not_in_graph", (
+            f"error_reason must be 'fqn_not_in_graph' in the MCP content JSON, "
+            f"got {payload.get('error_reason')!r}"
+        )
+        assert payload.get("stale") is False
+        assert payload.get("stale_files") == []
+
+    @pytest.mark.asyncio
+    async def test_rpc_callees_of_bad_fqn_is_error_true(
+        self, _wired_server
+    ) -> None:
+        """[B1-rpc] callees_of with absent FQN: full RPC loop propagates isError:true."""
+        server, srv, _ = _wired_server
+
+        # Arrange
+        lines = [
+            _rpc_req(
+                "tools/call",
+                {"name": "callees_of", "arguments": {"fqn": "not.in.graph.at.all"}},
+                req_id=2,
+            )
+        ]
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            responses = await _run_rpc(server, lines)
+
+        # Assert
+        assert len(responses) == 1
+        rpc_result = responses[0]["result"]
+        assert rpc_result["isError"] is True
+        payload = json.loads(rpc_result["content"][0]["text"])
+        assert payload.get("error_reason") == "fqn_not_in_graph"
+
+    @pytest.mark.asyncio
+    async def test_rpc_neighborhood_bad_fqn_is_error_true(
+        self, _wired_server
+    ) -> None:
+        """[B1-rpc] neighborhood with absent FQN: full RPC loop propagates isError:true."""
+        server, srv, _ = _wired_server
+
+        # Arrange
+        lines = [
+            _rpc_req(
+                "tools/call",
+                {"name": "neighborhood", "arguments": {"symbol": "xyz.unknown.sym"}},
+                req_id=3,
+            )
+        ]
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            responses = await _run_rpc(server, lines)
+
+        # Assert
+        assert len(responses) == 1
+        rpc_result = responses[0]["result"]
+        assert rpc_result["isError"] is True
+        payload = json.loads(rpc_result["content"][0]["text"])
+        assert payload.get("error_reason") == "fqn_not_in_graph"
+
+    @pytest.mark.asyncio
+    async def test_rpc_callers_of_valid_fqn_is_error_false(
+        self, _wired_server
+    ) -> None:
+        """[B1-rpc] callers_of with a valid FQN: full RPC loop does NOT set isError.
+
+        Negative-path test: ensures the isError propagation is gated correctly
+        and a well-formed FQN with zero callers does not accidentally surface as
+        an error.
+        """
+        server, srv, _ = _wired_server
+
+        # Arrange — pkg.other.gamma exists but has no callers in the raw graph
+        lines = [
+            _rpc_req(
+                "tools/call",
+                {"name": "callers_of", "arguments": {"fqn": "pkg.other.gamma"}},
+                req_id=4,
+            )
+        ]
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            responses = await _run_rpc(server, lines)
+
+        # Assert
+        assert len(responses) == 1
+        rpc_result = responses[0]["result"]
+        assert rpc_result["isError"] is False, (
+            "MCP result isError must be False for a valid FQN with zero callers"
+        )
+        payload = json.loads(rpc_result["content"][0]["text"])
+        assert "results" in payload
+        assert payload["results"] == [], "results must be [] for zero-caller FQN"
+
+
+# ---------------------------------------------------------------------------
+# B2: graph.py → server.py
+#
+# Contract: When CallGraphIndex.file_skeleton("bad/path.py") is called and the
+# path is not in the index, it returns
+#   {isError: True, error_reason: "path_not_in_index", stale: False, stale_files: []}
+# (plus commit fields, no stale_action).
+# When server.py's dispatch handler for file_skeleton receives this, it
+# propagates isError: True at the MCP result level and the content text
+# contains the full JSON dict including error_reason.
+# The error_reason discriminator must survive serialisation and be readable
+# by the client.
+# ---------------------------------------------------------------------------
+
+class TestB2PathNotInIndexErrorPropagation:
+    """graph.py.file_skeleton path_not_in_index → server.py MCP isError propagation."""
+
+    # ------------------------------------------------------------------
+    # graph.py unit-side contract
+    # ------------------------------------------------------------------
+
+    def test_graph_returns_error_dict_for_missing_path(self, tmp_path: Path) -> None:
+        """[B2-graph] file_skeleton on absent path returns isError dict with error_reason.
+
+        Verifies Scenario D in graph.py: path not in self.skeletons.
+        The returned dict must have isError=True, error_reason='path_not_in_index',
+        stale=False, stale_files=[] — and no stale_action key.
+        """
+        idx = _make_index_with_skeleton(tmp_path)
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = idx.file_skeleton("does/not/exist.py")
+
+        assert result.get("isError") is True, (
+            f"file_skeleton must return isError:True for absent path, got: {result}"
+        )
+        assert result.get("error_reason") == "path_not_in_index", (
+            f"error_reason must be 'path_not_in_index', got: {result.get('error_reason')!r}"
+        )
+        assert result.get("stale") is False, (
+            f"stale must be False in path_not_in_index error, got: {result.get('stale')!r}"
+        )
+        assert result.get("stale_files") == [], (
+            f"stale_files must be [] in path_not_in_index error, got: {result.get('stale_files')!r}"
+        )
+        # No stale_action — the path is wrong, not stale.
+        assert "stale_action" not in result, (
+            "stale_action must NOT be present in path_not_in_index error (path is wrong, not stale)"
+        )
+
+    def test_graph_returns_commit_fields_in_error_dict(self, tmp_path: Path) -> None:
+        """[B2-graph] path_not_in_index error dict includes commit-level staleness fields.
+
+        The three commit fields (commit_stale, index_git_sha, head_git_sha) must
+        always be present in the error dict so callers can distinguish 'path wrong'
+        from 'index stale' without relying on stale_action absence alone.
+        """
+        idx = _make_index_with_skeleton(tmp_path)
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = idx.file_skeleton("nonexistent/file.py")
+
+        for field in ("commit_stale", "index_git_sha", "head_git_sha"):
+            assert field in result, (
+                f"commit field '{field}' must be present in path_not_in_index error dict"
+            )
+
+    # ------------------------------------------------------------------
+    # server.py dispatch contract (direct _dispatch_tool path, no RPC loop)
+    # ------------------------------------------------------------------
+
+    @pytest.fixture()
+    def _wired_index(self, tmp_path: Path):
+        """Inject a real CallGraphIndex into server._INDEX."""
+        idx = _make_index_with_skeleton(tmp_path)
+
+        import pyscope_mcp.server as srv
+        srv._INDEX = idx
+        srv._INDEX_PATH = tmp_path / "index.json"
+
+        yield srv
+
+        srv._INDEX = None
+        srv._INDEX_PATH = None
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_propagates_iserror_true_for_missing_path(
+        self, _wired_index
+    ) -> None:
+        """[B2-server] _dispatch_tool('file_skeleton', bad path) → MCP isError:true.
+
+        When graph.py returns isError:True, server.py must NOT wrap the result
+        in a success _text() payload — it must propagate isError:True at the
+        MCP result level.
+        """
+        import pyscope_mcp.server as srv
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = await srv._dispatch_tool(
+                "file_skeleton", {"path": "bad/path.py"}
+            )
+
+        assert result.get("isError") is True, (
+            f"MCP result must have isError:True for absent path, got: {result}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_error_content_contains_error_reason(
+        self, _wired_index
+    ) -> None:
+        """[B2-server] error content text contains 'error_reason': 'path_not_in_index'.
+
+        The content[0].text must be JSON that includes error_reason so the MCP
+        client can branch on it programmatically — not just read a human-readable
+        message string.
+        """
+        import pyscope_mcp.server as srv
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = await srv._dispatch_tool(
+                "file_skeleton", {"path": "no/such/file.py"}
+            )
+
+        assert "content" in result, "MCP result must have 'content' key"
+        assert len(result["content"]) >= 1, "MCP result content must be non-empty"
+        text = result["content"][0]["text"]
+
+        # The text must be valid JSON.
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            pytest.fail(
+                f"content[0].text must be valid JSON, got: {text!r}\nError: {exc}"
+            )
+
+        assert payload.get("error_reason") == "path_not_in_index", (
+            f"Deserialised content must have error_reason='path_not_in_index', "
+            f"got: {payload.get('error_reason')!r}"
+        )
+        assert payload.get("isError") is True, (
+            f"Deserialised content must have isError:True, got: {payload.get('isError')!r}"
+        )
+        assert payload.get("stale") is False, (
+            f"Deserialised content stale must be False, got: {payload.get('stale')!r}"
+        )
+        assert payload.get("stale_files") == [], (
+            f"Deserialised content stale_files must be [], got: {payload.get('stale_files')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_error_reason_survives_serialisation(
+        self, _wired_index
+    ) -> None:
+        """[B2-server] error_reason discriminator survives JSON serialisation round-trip.
+
+        This is the core end-to-end contract for this boundary: the string
+        'path_not_in_index' must be identical after json.loads(json.dumps(...)).
+        A regression that loses or transforms the discriminator would silently
+        break all client branching logic.
+        """
+        import pyscope_mcp.server as srv
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = await srv._dispatch_tool(
+                "file_skeleton", {"path": "definitely/not/there.py"}
+            )
+
+        raw_text = result["content"][0]["text"]
+        # Double round-trip: server serialises → client deserialises
+        client_view = json.loads(raw_text)
+        # Re-serialise (client might store/log) → re-deserialise
+        client_view_2 = json.loads(json.dumps(client_view))
+
+        assert client_view_2["error_reason"] == "path_not_in_index", (
+            "error_reason must survive a double JSON round-trip without mutation"
+        )
+
+    # ------------------------------------------------------------------
+    # Positive case: valid path returns skeleton content (not isError)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_valid_path_returns_success(
+        self, _wired_index
+    ) -> None:
+        """[B2-server] file_skeleton with a valid indexed path returns isError:false.
+
+        Verifies the positive / non-error branch so we know the error path is
+        not silently always-on. The response must have isError:False and the
+        content payload must include 'results'.
+        """
+        import pyscope_mcp.server as srv
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = await srv._dispatch_tool(
+                "file_skeleton", {"path": "pkg/mod.py"}
+            )
+
+        assert result.get("isError") is False, (
+            f"file_skeleton on a valid path must return isError:False, got: {result}"
+        )
+        payload = json.loads(result["content"][0]["text"])
+        assert "results" in payload, (
+            f"Success payload must include 'results', got keys: {list(payload.keys())}"
+        )
+        assert isinstance(payload["results"], list), (
+            "results must be a list"
+        )
+        # At least one symbol was indexed for pkg/mod.py.
+        assert len(payload["results"]) >= 1, (
+            f"Expected ≥1 symbol in results for pkg/mod.py, got: {payload['results']}"
+        )
+
+    def test_graph_valid_path_does_not_return_iserror(self, tmp_path: Path) -> None:
+        """[B2-graph] file_skeleton on a known path does NOT return isError.
+
+        Complement to the error test: verifies the positive branch at the graph
+        layer to confirm error_reason is only present on the absent-path path.
+        """
+        idx = _make_index_with_skeleton(tmp_path)
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            result = idx.file_skeleton("pkg/mod.py")
+
+        assert not result.get("isError"), (
+            f"file_skeleton on a known path must NOT return isError, got: {result}"
+        )
+        assert "error_reason" not in result, (
+            "error_reason must not be present in success response"
+        )
+        assert "results" in result, (
+            "success response must include 'results'"
+        )
+
+    # ------------------------------------------------------------------
+    # Full RPC loop path
+    # ------------------------------------------------------------------
+
+    @pytest.fixture()
+    def _wired_server(self, tmp_path: Path):
+        """Server fixture with real index, hooked into the RPC loop."""
+        idx = _make_index_with_skeleton(tmp_path)
+
+        import pyscope_mcp.server as srv
+        srv._INDEX = idx
+        srv._INDEX_PATH = tmp_path / "index.json"
+        srv._SERVER._shutdown_requested = False
+
+        yield srv._SERVER, srv
+
+        srv._INDEX = None
+        srv._INDEX_PATH = None
+
+    @pytest.mark.asyncio
+    async def test_rpc_loop_file_skeleton_missing_path_iserror(
+        self, _wired_server
+    ) -> None:
+        """[B2-rpc] file_skeleton via full RPC loop: absent path yields isError:true.
+
+        Exercises the full JSON-RPC 2.0 wire path: request bytes → _loop →
+        _tools_call → _dispatch_tool → graph.file_skeleton → response bytes.
+        """
+        server, srv = _wired_server
+        lines = [
+            _rpc_req(
+                "tools/call",
+                {"name": "file_skeleton", "arguments": {"path": "ghost/file.py"}},
+                req_id=42,
+            )
+        ]
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            responses = await _run_rpc(server, lines)
+
+        assert len(responses) == 1
+        rpc_result = responses[0]["result"]
+        assert rpc_result.get("isError") is True, (
+            f"RPC result must have isError:True for absent path, got: {rpc_result}"
+        )
+        payload = json.loads(rpc_result["content"][0]["text"])
+        assert payload.get("error_reason") == "path_not_in_index", (
+            f"error_reason must be 'path_not_in_index' in RPC response, "
+            f"got: {payload.get('error_reason')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rpc_loop_file_skeleton_valid_path_success(
+        self, _wired_server
+    ) -> None:
+        """[B2-rpc] file_skeleton via full RPC loop: valid path yields isError:false.
+
+        Positive case through the RPC loop to confirm the loop wiring works for
+        both the error and success branches.
+        """
+        server, srv = _wired_server
+        lines = [
+            _rpc_req(
+                "tools/call",
+                {"name": "file_skeleton", "arguments": {"path": "pkg/mod.py"}},
+                req_id=43,
+            )
+        ]
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+            responses = await _run_rpc(server, lines)
+
+        assert len(responses) == 1
+        rpc_result = responses[0]["result"]
+        assert rpc_result.get("isError") is False, (
+            f"RPC result must have isError:False for valid path, got: {rpc_result}"
+        )
+        payload = json.loads(rpc_result["content"][0]["text"])
+        assert "results" in payload, (
+            f"Success payload must include 'results', got keys: {list(payload.keys())}"
+        )

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -189,14 +189,15 @@ def test_file_skeleton_returns_symbols() -> None:
 
 
 def test_file_skeleton_unknown_path_returns_error() -> None:
-    """Unknown path returns isError:true AND stale:true with stale_files=[]."""
+    """Unknown path returns isError:true, error_reason:'path_not_in_index', stale:false with no stale_action."""
     idx = _make_index_with_skeletons({"mod.py": []}, file_shas={})
     result = idx.file_skeleton("nonexistent/file.py")
 
     assert result["isError"] is True
-    assert result["stale"] is True
+    assert result["error_reason"] == "path_not_in_index"
+    assert result["stale"] is False
     assert result["stale_files"] == []
-    assert "build" in result["stale_action"].lower()
+    assert "stale_action" not in result
     assert "staleness_info" not in result
 
 
@@ -397,13 +398,15 @@ def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
 
 
 def test_file_skeleton_stale_file_not_in_index(tmp_path: Path) -> None:
-    """Scenario D: v3 index, path not in skeletons → isError: true, stale: true, stale_files=[]."""
+    """Scenario D: v3 index, path not in skeletons → isError: true, error_reason: 'path_not_in_index', stale: false."""
     idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
 
     result = idx.file_skeleton("new_mod.py")
     assert result["isError"] is True
-    assert result["stale"] is True
+    assert result["error_reason"] == "path_not_in_index"
+    assert result["stale"] is False
     assert result["stale_files"] == []
+    assert "stale_action" not in result
     assert "staleness_info" not in result
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -493,6 +493,54 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
 
 
 # ---------------------------------------------------------------------------
+# callers_of / callees_of — not-found error shape
+# ---------------------------------------------------------------------------
+
+def test_callers_of_fqn_not_in_graph() -> None:
+    """callers_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    result = idx.callers_of("no.such.fqn")
+    assert result["isError"] is True
+    assert result["error_reason"] == "fqn_not_in_graph"
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+    assert "stale_action" not in result
+
+
+def test_callees_of_fqn_not_in_graph() -> None:
+    """callees_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    result = idx.callees_of("no.such.fqn")
+    assert result["isError"] is True
+    assert result["error_reason"] == "fqn_not_in_graph"
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+    assert "stale_action" not in result
+
+
+def test_callers_of_known_zero_callers() -> None:
+    """callers_of on an FQN with no callers returns results:[], not an error."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    # sample.a.top has no callers
+    result = idx.callers_of("sample.a.top")
+    assert result.get("isError") is not True
+    assert result["results"] == []
+    # Not a not-found error; staleness value depends on test fixture setup
+    assert "error_reason" not in result
+
+
+def test_callees_of_known_zero_callees() -> None:
+    """callees_of on an FQN with no callees returns results:[], not an error."""
+    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    # sample.b.inner has no callees
+    result = idx.callees_of("sample.b.inner")
+    assert result.get("isError") is not True
+    assert result["results"] == []
+    # Not a not-found error; staleness value depends on test fixture setup
+    assert "error_reason" not in result
+
+
+# ---------------------------------------------------------------------------
 # neighborhood
 # ---------------------------------------------------------------------------
 
@@ -550,12 +598,14 @@ def test_neighborhood_token_budget_enforced() -> None:
 
 
 def test_neighborhood_unknown_symbol() -> None:
-    """neighborhood on a symbol not in the graph returns empty edges, truncated=False."""
+    """neighborhood on a symbol not in the graph returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
     idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
     result = idx.neighborhood("nonexistent.symbol", depth=2, token_budget=1000)
-    assert result["symbol"] == "nonexistent.symbol"
-    assert result["edges"] == []
-    assert result["truncated"] is False
+    assert result["isError"] is True
+    assert result["error_reason"] == "fqn_not_in_graph"
+    assert result["stale"] is False
+    assert result["stale_files"] == []
+    assert "stale_action" not in result
 
 
 def test_neighborhood_depth_full_reflects_graph() -> None:
@@ -766,9 +816,17 @@ def test_hub_threshold_attribute_reflects_distribution() -> None:
 
 
 def test_neighborhood_hub_fields_always_present_isolated() -> None:
-    """hub_suppressed and hub_threshold are present even for isolated/unknown symbols."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
-    result = idx.neighborhood("nonexistent.symbol", depth=2, token_budget=10000)
+    """hub_suppressed and hub_threshold are present even for isolated symbols (present in graph, no edges)."""
+    # Use a symbol that IS in the graph but has no edges — isolated but present.
+    # We add "b.isolated" as a standalone caller with an empty callees list.
+    raw = _neighborhood_raw()
+    raw["b.isolated"] = []
+    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    result = idx.neighborhood("b.isolated", depth=2, token_budget=10000)
+    # An isolated-but-present node returns empty edges, not an error
+    assert result.get("isError") is not True
+    assert result["edges"] == []
+    assert result["truncated"] is False
     assert "hub_suppressed" in result
     assert "hub_threshold" in result
     assert result["hub_suppressed"] == []

--- a/tests/test_integration_issue69.py
+++ b/tests/test_integration_issue69.py
@@ -1,0 +1,751 @@
+"""Integration tests for issue #69 — not-found error_reason on all four query tools.
+
+Two tiers:
+
+  slice-not-found-error-reason-all-tools-e2e (wiring):
+    Verifies that file_skeleton, callers_of, callees_of, and neighborhood all
+    return isError:true at the MCP result level when given nonexistent paths/FQNs,
+    that the error_reason key is present with the expected slug, and that stale is
+    False with no stale_action key — over the real stdio-RPC wire.
+
+    Also verifies the AC5 regression guard: callers_of with a present-but-zero-callers
+    FQN returns isError NOT true with results=[].
+
+  slice-not-found-error-reason-all-tools-e2e (artifact):
+    Verifies the exact values of error_reason slugs, stale=False (not None, not 0),
+    stale_files=[], no stale_action key, and the AC5 empty-results path.
+
+Pattern: real subprocess, real OS pipes, stdio JSON-RPC 2.0.
+Mirrors test_integration_issue66.py conventions exactly (same _send/_recv helpers,
+same index fixture shape, same env dict).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_integration_issue66.py)
+# ---------------------------------------------------------------------------
+
+
+def _send(proc: subprocess.Popen, msg: dict) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write((json.dumps(msg) + "\n").encode())
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen, timeout: float = 10.0) -> dict:
+    assert proc.stdout is not None
+    line = proc.stdout.readline()
+    if not line:
+        err = proc.stderr.read().decode() if proc.stderr else ""
+        raise AssertionError(f"server produced no stdout; stderr={err!r}")
+    return json.loads(line.decode())
+
+
+def _handshake(proc: subprocess.Popen, client_name: str = "it-test") -> None:
+    """Send MCP initialize + initialized notification; assert initialize OK."""
+    _send(proc, {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": "0"},
+        },
+    })
+    r = _recv(proc)
+    assert r["id"] == 1
+    assert r["result"]["protocolVersion"] == "2024-11-05"
+    _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+
+def _shutdown(proc: subprocess.Popen, req_id: int = 99) -> None:
+    """Send shutdown + close stdin; assert server exits 0."""
+    _send(proc, {"jsonrpc": "2.0", "id": req_id, "method": "shutdown"})
+    r = _recv(proc)
+    assert r == {"jsonrpc": "2.0", "id": req_id, "result": {}}
+    assert proc.stdin is not None
+    proc.stdin.close()
+    assert proc.wait(timeout=5) == 0
+
+
+def _spawn_server(index_path: Path, root: Path | None = None) -> subprocess.Popen:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+    args = [
+        sys.executable, "-m", "pyscope_mcp.cli", "serve",
+        "--root", str(root or repo_root),
+        "--index", str(index_path),
+    ]
+    return subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def built_index(tmp_path_factory: pytest.TempPathFactory):
+    """Build a real index for a synthetic 3-function package.
+
+    Package structure:
+        mypkg/
+            __init__.py
+            core.py   # alpha, beta (calls alpha), gamma (calls beta)
+
+    Real FQNs in index:
+        mypkg.core.alpha   — called by beta; zero callers (AC5 target)
+        mypkg.core.beta    — calls alpha, called by gamma
+        mypkg.core.gamma   — calls beta; zero callers from graph perspective
+
+    Wait — gamma has zero callers (nothing calls gamma), so callers_of(gamma)=[]
+    and alpha is called by beta so callers_of(alpha)=[beta]. For AC5 we need a
+    present-but-zero-callers FQN: use mypkg.core.gamma (nothing calls it).
+
+    Bad inputs for error testing:
+        bad path:  mypkg/does_not_exist.py
+        bad FQN:   mypkg.does_not_exist.whatever
+
+    Returns (index_file, pkg_root, repo_root, env).
+    """
+    tmp = tmp_path_factory.mktemp("it69")
+    pkg = tmp / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "core.py").write_text(
+        "def alpha(): pass\n\n"
+        "def beta(): return alpha()\n\n"
+        "def gamma(): return beta()\n"
+    )
+
+    index_file = tmp / ".pyscope-mcp" / "index.json"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "build",
+            "--root", str(tmp),
+            "--package", "mypkg",
+            "--output", str(index_file),
+        ],
+        capture_output=True, env=env,
+    )
+    assert result.returncode == 0, (
+        f"pyscope-mcp build failed in fixture:\n{result.stderr.decode()}"
+    )
+    return index_file, tmp, repo_root, env
+
+
+# ===========================================================================
+# SCENARIO: slice-not-found-error-reason-all-tools-e2e
+# layers_involved: src/pyscope_mcp/graph.py, src/pyscope_mcp/server.py
+# ===========================================================================
+
+
+class TestSliceNotFoundErrorReasonWiring:
+    """Wiring tier — slice-not-found-error-reason-all-tools-e2e.
+
+    Verifies the structural contract for not-found error responses:
+    - isError:true at the MCP result level
+    - content is present and parseable as JSON
+    - error_reason key exists with the correct slug type (str)
+    - stale is False, stale_action key is absent
+    - AC5 regression guard: present-but-zero-callers FQN returns isError=False
+    """
+
+    @pytest.mark.integration_wiring
+    def test_file_skeleton_bad_path_is_error_with_error_reason(
+        self, built_index
+    ) -> None:
+        """[wiring] file_skeleton(bad_path) → isError:true, error_reason present, stale=false, no stale_action.
+
+        AC1: file_skeleton with a path not in the index must return the not-found
+        error shape, not a server crash or a JSON-RPC error.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-wiring-skeleton")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "file_skeleton",
+                    "arguments": {"path": "mypkg/does_not_exist.py"},
+                },
+            })
+            r = _recv(proc)
+
+            # [Assert] JSON-RPC level: no transport error
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] MCP tool level: isError:true
+            assert result.get("isError") is True, (
+                f"file_skeleton with bad path must return isError:true; got {result}"
+            )
+
+            # [Assert] content is parseable JSON
+            content = result["content"]
+            assert len(content) >= 1, "result must have at least one content item"
+            assert content[0]["type"] == "text"
+            body = json.loads(content[0]["text"])
+
+            # [Assert] error_reason key is present and is a string
+            assert "error_reason" in body, (
+                "not-found response must include 'error_reason' key"
+            )
+            assert isinstance(body["error_reason"], str), (
+                f"error_reason must be a string, got {type(body['error_reason'])}"
+            )
+
+            # [Assert] stale is False (not missing, not truthy)
+            assert "stale" in body, "not-found response must include 'stale' key"
+            assert body["stale"] is False, (
+                f"stale must be False on not-found error, got {body['stale']!r}"
+            )
+
+            # [Assert] stale_action key must NOT be present
+            assert "stale_action" not in body, (
+                "not-found response must NOT include 'stale_action' — "
+                "stale_action is only for stale=true results, not missing-path errors"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_callers_of_bad_fqn_is_error_with_error_reason(
+        self, built_index
+    ) -> None:
+        """[wiring] callers_of(bad_fqn) → isError:true, error_reason present, stale=false, no stale_action.
+
+        AC2: callers_of with an FQN not in the graph must return the not-found
+        error shape — not an empty results list and not a server crash.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-wiring-callers")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "callers_of",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever"},
+                },
+            })
+            r = _recv(proc)
+
+            # [Assert] JSON-RPC level: no transport error
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] MCP tool level: isError:true
+            assert result.get("isError") is True, (
+                f"callers_of with bad FQN must return isError:true; got {result}"
+            )
+
+            # [Assert] content is parseable JSON with error_reason
+            body = json.loads(result["content"][0]["text"])
+            assert "error_reason" in body, (
+                "not-found response must include 'error_reason' key"
+            )
+            assert isinstance(body["error_reason"], str)
+
+            # [Assert] stale=False, no stale_action
+            assert body.get("stale") is False, (
+                f"stale must be False on not-found error, got {body.get('stale')!r}"
+            )
+            assert "stale_action" not in body, (
+                "not-found response must NOT include 'stale_action'"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_callees_of_bad_fqn_is_error_with_error_reason(
+        self, built_index
+    ) -> None:
+        """[wiring] callees_of(bad_fqn) → isError:true, error_reason present, stale=false, no stale_action.
+
+        AC3: callees_of with an FQN not in the graph must return the same
+        not-found error shape as callers_of.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-wiring-callees")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "callees_of",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever"},
+                },
+            })
+            r = _recv(proc)
+
+            # [Assert] JSON-RPC level: no transport error
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] MCP tool level: isError:true
+            assert result.get("isError") is True, (
+                f"callees_of with bad FQN must return isError:true; got {result}"
+            )
+
+            # [Assert] content is parseable JSON with error_reason
+            body = json.loads(result["content"][0]["text"])
+            assert "error_reason" in body, (
+                "not-found response must include 'error_reason' key"
+            )
+            assert isinstance(body["error_reason"], str)
+
+            # [Assert] stale=False, no stale_action
+            assert body.get("stale") is False, (
+                f"stale must be False on not-found error, got {body.get('stale')!r}"
+            )
+            assert "stale_action" not in body, (
+                "not-found response must NOT include 'stale_action'"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_neighborhood_bad_fqn_is_error_with_error_reason(
+        self, built_index
+    ) -> None:
+        """[wiring] neighborhood(bad_symbol) → isError:true, error_reason present, stale=false, no stale_action.
+
+        AC4: neighborhood with an FQN not in the graph must return the not-found
+        error shape — not empty edges and not a server crash.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-wiring-neighborhood")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "neighborhood",
+                    "arguments": {"symbol": "mypkg.does_not_exist.whatever"},
+                },
+            })
+            r = _recv(proc)
+
+            # [Assert] JSON-RPC level: no transport error
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] MCP tool level: isError:true
+            assert result.get("isError") is True, (
+                f"neighborhood with bad FQN must return isError:true; got {result}"
+            )
+
+            # [Assert] content is parseable JSON with error_reason
+            body = json.loads(result["content"][0]["text"])
+            assert "error_reason" in body, (
+                "not-found response must include 'error_reason' key"
+            )
+            assert isinstance(body["error_reason"], str)
+
+            # [Assert] stale=False, no stale_action
+            assert body.get("stale") is False, (
+                f"stale must be False on not-found error, got {body.get('stale')!r}"
+            )
+            assert "stale_action" not in body, (
+                "not-found response must NOT include 'stale_action'"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_callers_of_present_fqn_with_zero_callers_is_not_error(
+        self, built_index
+    ) -> None:
+        """[wiring] AC5 regression guard: callers_of(present-but-no-callers FQN) → isError NOT true, results list present.
+
+        mypkg.core.gamma is in the index (so isError must NOT be true) but
+        nothing calls gamma, so results must be a list (possibly empty).
+        This guards against the not-found path being incorrectly triggered for
+        FQNs that are present but have zero incoming edges.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-wiring-ac5")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "callers_of",
+                    "arguments": {"fqn": "mypkg.core.gamma"},
+                },
+            })
+            r = _recv(proc)
+
+            # [Assert] JSON-RPC level: no transport error
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] isError must NOT be true for a present FQN
+            assert result.get("isError") is not True, (
+                "callers_of with a present FQN (gamma) must NOT return isError:true — "
+                "zero callers is not an error; got isError=True"
+            )
+
+            # [Assert] content is parseable JSON and includes 'results' key
+            body = json.loads(result["content"][0]["text"])
+            assert "results" in body, (
+                "callers_of(gamma) must include 'results' key in response body"
+            )
+            assert isinstance(body["results"], list), (
+                f"results must be a list, got {type(body['results'])}"
+            )
+
+            # [Assert] stale is present (and False for fresh index)
+            assert "stale" in body, (
+                "callers_of response must include 'stale' key"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+
+# ===========================================================================
+# Artifact tier — slice-not-found-error-reason-all-tools-e2e
+# ===========================================================================
+
+
+class TestSliceNotFoundErrorReasonArtifact:
+    """Artifact tier — slice-not-found-error-reason-all-tools-e2e.
+
+    Verifies exact output values against hard-coded golden expectations:
+    - exact error_reason slug matches the spec ('path_not_in_index' or 'fqn_not_in_graph')
+    - stale is exactly False (not None, not 0, not "false")
+    - stale_files is exactly []
+    - stale_action key is completely absent from the response body
+    - AC5: callers_of(gamma) returns results==[] AND stale==False
+    """
+
+    @pytest.mark.integration_artifact
+    def test_file_skeleton_bad_path_exact_error_reason(self, built_index) -> None:
+        """[artifact] file_skeleton(bad_path) → error_reason=='path_not_in_index', stale==False, stale_files==[], no stale_action.
+
+        Golden: error_reason='path_not_in_index' (defined in graph.py file_skeleton).
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-artifact-skeleton")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "file_skeleton",
+                    "arguments": {"path": "mypkg/does_not_exist.py"},
+                },
+            })
+            r = _recv(proc)
+            result = r["result"]
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact error_reason slug — golden: 'path_not_in_index'
+            assert body["error_reason"] == "path_not_in_index", (
+                f"expected error_reason='path_not_in_index', got {body['error_reason']!r}"
+            )
+
+            # [Assert] stale is exactly False (not None, not 0)
+            assert body["stale"] is False, (
+                f"stale must be exactly False (bool), got {body['stale']!r} "
+                f"(type: {type(body['stale']).__name__})"
+            )
+
+            # [Assert] stale_files is exactly []
+            assert body["stale_files"] == [], (
+                f"stale_files must be exactly [], got {body['stale_files']!r}"
+            )
+
+            # [Assert] stale_action key is completely absent
+            assert "stale_action" not in body, (
+                f"stale_action must be absent from not-found response; "
+                f"found stale_action={body['stale_action']!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_callers_of_bad_fqn_exact_error_reason(self, built_index) -> None:
+        """[artifact] callers_of(bad_fqn) → error_reason=='fqn_not_in_graph', stale==False, stale_files==[], no stale_action.
+
+        Golden: error_reason='fqn_not_in_graph' (defined in graph.py callers_of).
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-artifact-callers")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "callers_of",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever"},
+                },
+            })
+            r = _recv(proc)
+            result = r["result"]
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact error_reason slug — golden: 'fqn_not_in_graph'
+            assert body["error_reason"] == "fqn_not_in_graph", (
+                f"expected error_reason='fqn_not_in_graph', got {body['error_reason']!r}"
+            )
+
+            # [Assert] stale is exactly False (bool)
+            assert body["stale"] is False, (
+                f"stale must be exactly False (bool), got {body['stale']!r} "
+                f"(type: {type(body['stale']).__name__})"
+            )
+
+            # [Assert] stale_files is exactly []
+            assert body["stale_files"] == [], (
+                f"stale_files must be exactly [], got {body['stale_files']!r}"
+            )
+
+            # [Assert] stale_action key is completely absent
+            assert "stale_action" not in body, (
+                f"stale_action must be absent from not-found response; "
+                f"found stale_action={body['stale_action']!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_callees_of_bad_fqn_exact_error_reason(self, built_index) -> None:
+        """[artifact] callees_of(bad_fqn) → error_reason=='fqn_not_in_graph', stale==False, stale_files==[], no stale_action.
+
+        Golden: error_reason='fqn_not_in_graph' (defined in graph.py callees_of).
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-artifact-callees")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "callees_of",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever"},
+                },
+            })
+            r = _recv(proc)
+            result = r["result"]
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact error_reason slug — golden: 'fqn_not_in_graph'
+            assert body["error_reason"] == "fqn_not_in_graph", (
+                f"expected error_reason='fqn_not_in_graph', got {body['error_reason']!r}"
+            )
+
+            # [Assert] stale is exactly False (bool)
+            assert body["stale"] is False, (
+                f"stale must be exactly False (bool), got {body['stale']!r} "
+                f"(type: {type(body['stale']).__name__})"
+            )
+
+            # [Assert] stale_files is exactly []
+            assert body["stale_files"] == [], (
+                f"stale_files must be exactly [], got {body['stale_files']!r}"
+            )
+
+            # [Assert] stale_action key is completely absent
+            assert "stale_action" not in body, (
+                f"stale_action must be absent from not-found response; "
+                f"found stale_action={body['stale_action']!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_neighborhood_bad_fqn_exact_error_reason(self, built_index) -> None:
+        """[artifact] neighborhood(bad_symbol) → error_reason=='fqn_not_in_graph', stale==False, stale_files==[], no stale_action.
+
+        Golden: error_reason='fqn_not_in_graph' (defined in graph.py neighborhood).
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-artifact-neighborhood")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "neighborhood",
+                    "arguments": {"symbol": "mypkg.does_not_exist.whatever"},
+                },
+            })
+            r = _recv(proc)
+            result = r["result"]
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact error_reason slug — golden: 'fqn_not_in_graph'
+            assert body["error_reason"] == "fqn_not_in_graph", (
+                f"expected error_reason='fqn_not_in_graph', got {body['error_reason']!r}"
+            )
+
+            # [Assert] stale is exactly False (bool)
+            assert body["stale"] is False, (
+                f"stale must be exactly False (bool), got {body['stale']!r} "
+                f"(type: {type(body['stale']).__name__})"
+            )
+
+            # [Assert] stale_files is exactly []
+            assert body["stale_files"] == [], (
+                f"stale_files must be exactly [], got {body['stale_files']!r}"
+            )
+
+            # [Assert] stale_action key is completely absent
+            assert "stale_action" not in body, (
+                f"stale_action must be absent from not-found response; "
+                f"found stale_action={body['stale_action']!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_callers_of_present_fqn_with_zero_callers_exact_values(
+        self, built_index
+    ) -> None:
+        """[artifact] AC5: callers_of(gamma) → results==[], stale==False exactly.
+
+        mypkg.core.gamma is present in the index (it calls beta) but nothing
+        calls gamma itself.  The response must be a success (isError NOT true)
+        with results exactly equal to [] and stale exactly equal to False.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            # [Arrange]
+            _handshake(proc, "it69-artifact-ac5")
+
+            # [Act]
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "callers_of",
+                    "arguments": {"fqn": "mypkg.core.gamma"},
+                },
+            })
+            r = _recv(proc)
+            result = r["result"]
+
+            # [Assert] isError must NOT be true
+            assert result.get("isError") is not True, (
+                "callers_of(gamma) must NOT be isError:true — "
+                "gamma is present in the index; zero callers is not an error"
+            )
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] results is exactly [] (golden: gamma has no callers)
+            assert body["results"] == [], (
+                f"callers_of(gamma) must return results=[] since nothing calls gamma; "
+                f"got {body['results']!r}"
+            )
+
+            # [Assert] stale is exactly False (bool, not None, not 0)
+            assert body["stale"] is False, (
+                f"stale must be exactly False (bool), got {body['stale']!r} "
+                f"(type: {type(body['stale']).__name__})"
+            )
+
+            # [Assert] stale_files is exactly []
+            assert body["stale_files"] == [], (
+                f"stale_files must be exactly [], got {body['stale_files']!r}"
+            )
+
+            # [Assert] No stale_action on a fresh (non-stale) result
+            assert "stale_action" not in body, (
+                "stale_action must be absent when stale=False"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -1021,9 +1021,9 @@ async def test_notification_handler_raises_silent(server: RpcServer):
     "name,arguments,expect_error",
     [
         # Wrong-type fqn: truthy values that aren't in the graph.
-        # _bfs handles unknown starts gracefully → empty list, isError:false.
-        ("callers_of",     {"fqn": 123},                             False),
-        ("callees_of",     {"fqn": 123},                             False),
+        # The not-in-graph check fires before _bfs → isError:true.
+        ("callers_of",     {"fqn": 123},                             True),
+        ("callees_of",     {"fqn": 123},                             True),
         # Non-string module: str.startswith raises TypeError → isError:true.
         ("module_callers", {"module": True},                         True),
         # List-typed module: unhashable → TypeError on dict lookup → isError:true.
@@ -1171,14 +1171,15 @@ async def test_tool_neighborhood_missing_symbol(server: RpcServer):
 
 @pytest.mark.asyncio
 async def test_tool_neighborhood_unknown_symbol(server: RpcServer):
-    """neighborhood on a symbol not in the graph returns empty edges, not an error."""
+    """neighborhood on a symbol not in the graph returns isError:true, error_reason:'fqn_not_in_graph'."""
     lines = [_req("tools/call", {"name": "neighborhood", "arguments": {"symbol": "not.in.graph"}}, req_id=1)]
     responses = await _run(server, lines)
     r = responses[0]["result"]
-    assert r["isError"] is False
+    assert r["isError"] is True
     payload = json.loads(r["content"][0]["text"])
-    assert payload["edges"] == []
-    assert payload["truncated"] is False
+    assert payload["isError"] is True
+    assert payload["error_reason"] == "fqn_not_in_graph"
+    assert payload["stale"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -549,6 +549,60 @@ def test_callers_of_stale_e2e_wire(tmp_path: Path) -> None:
             proc.wait(timeout=2)
 
 
+def test_callers_of_fqn_not_in_graph_e2e(index_path: Path) -> None:
+    """E2E: callers_of with a nonexistent FQN returns isError:true + error_reason over real stdio pipes."""
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "serve",
+            "--root", str(repo_root),
+            "--index", str(index_path),
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-not-found", "version": "0"},
+            },
+        })
+        r = _recv(proc)
+        assert r["id"] == 1
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        # Call callers_of with a FQN that cannot be in the index
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "callers_of", "arguments": {"fqn": "no.such.fqn.at.all"}},
+        })
+        r = _recv(proc)
+        assert r["id"] == 2
+        assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+        # The MCP result must carry isError:true at the top level
+        assert r["result"]["isError"] is True
+        # The body text must contain error_reason
+        body = json.loads(r["result"]["content"][0]["text"])
+        assert body["isError"] is True
+        assert body["error_reason"] == "fqn_not_in_graph"
+        assert body["stale"] is False
+        assert "stale_action" not in body
+
+        _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
+        r = _recv(proc)
+        assert r == {"jsonrpc": "2.0", "id": 99, "result": {}}
+        proc.stdin.close()
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
 def test_shutdown_then_eof_exits_zero(index_path: Path) -> None:
     """Full lifecycle: shutdown → stdin EOF → exit 0."""
     repo_root = Path(__file__).resolve().parents[1]
@@ -649,17 +703,19 @@ def test_completeness_field_e2e(tmp_path: Path) -> None:
             f"full body: {body2}"
         )
 
-        # baz has no callers and no missed_callers entry → complete
+        # bar has no callers and no missed_callers entry for bar-as-callee → complete
+        # (bar IS in the graph as a caller of foo, so callers_of(bar) returns results:[])
         _send(proc, {
             "jsonrpc": "2.0", "id": 3, "method": "tools/call",
-            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.baz"}},
+            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.bar"}},
         })
         r3 = _recv(proc)
         assert r3["id"] == 3
         assert "error" not in r3, f"unexpected JSON-RPC error: {r3}"
         body3 = json.loads(r3["result"]["content"][0]["text"])
+        assert body3.get("isError") is not True, f"bar is in graph and should not be an error: {body3}"
         assert body3["completeness"] == "complete", (
-            f"expected complete for baz; got completeness={body3.get('completeness')!r}\n"
+            f"expected complete for bar; got completeness={body3.get('completeness')!r}\n"
             f"full body: {body3}"
         )
 


### PR DESCRIPTION
Closes #69

## What changed

When pyscope-mcp tools received a path or FQN not present in the index, they returned an ambiguous response shape identical to a genuine staleness response (`stale: true`, `stale_files: []`, `stale_action: "Call build"`). An agent receiving this had no actionable signal: the remediation hint ("rebuild") was actively wrong for bad-input cases. This PR adds a machine-readable `error_reason` discriminator and sets `stale: false` on all not-found errors, so callers can branch correctly — fix the path, not rebuild.

## Implementation walkthrough

### `file_skeleton` — Scenario D fix (`src/pyscope_mcp/graph.py`, lines 431–442)

The \"Scenario D\" branch (path not in `self.skeletons`) previously returned `stale: True, stale_action: "Call build"`. It now returns `{"isError": True, "error_reason": "path_not_in_index", "stale": False, "stale_files": [], ...commit_fields}` with no `stale_action`. The `index_stale_reason` field (previously set for pre-v3 indexes) is also omitted — it was a staleness signal and doesn't apply to not-found errors.

### `callers_of` / `callees_of` — pre-graph-check (`src/pyscope_mcp/graph.py`, ~line 520 and ~540)

Both methods now check `fqn not in self.function_graph.nodes` before the BFS call. Previously, `_bfs(graph, fqn, depth)` silently returned `{}` when `fqn` was absent (line 1023: `if depth <= 0 or start not in g: return {}`), which propagated as `results: [], completeness: "complete"` — indistinguishable from a genuine zero-callers result. The guard now returns `{"isError": True, "error_reason": "fqn_not_in_graph", "stale": False, "stale_files": []}` before BFS runs. An FQN that IS in the graph but has zero callers still returns `results: []` (not an error).

### `neighborhood` — symbol-presence check (`src/pyscope_mcp/graph.py`, ~line 644)

Added `if symbol not in fg.nodes` guard at method entry, before the BFS loop. Previously, a nonexistent symbol caused an empty `edge_depths` dict, which fell into the `if not edge_depths:` branch and returned `edges: []` with `truncated: False` — identical to an isolated-but-present node. The new guard fires only for symbols absent from the graph; isolated-but-present nodes (present in graph with no edges) still fall through to the `if not edge_depths:` path and correctly return `edges: []`.

### MCP dispatch propagation (`src/pyscope_mcp/server.py`)

`callers_of`, `callees_of`, and `neighborhood` dispatch handlers now mirror the pattern used by `file_skeleton`: after calling the graph method, they check `result.get("isError")` and return the full error dict with `isError: True` at the MCP result level. Previously, these handlers used `_text()` unconditionally, which would have wrapped the error dict as a regular success response.

Tool descriptions for all four affected tools are updated to document the `error_reason` field and clarify that `isError: true` with `error_reason` means bad input, not a stale index.

### Default execution path

**Before** (`callers_of("bad.fqn")`):
`server.callers_of → idx.callers_of → _bfs(rev_fg, "bad.fqn", 1) → {} → results:[], completeness:"complete", stale:false`

The consumer sees a normal empty result. There is no signal that the FQN was invalid.

**After** (`callers_of("bad.fqn")`):
`server.callers_of → idx.callers_of → "bad.fqn" not in fg.nodes → {isError:True, error_reason:"fqn_not_in_graph", stale:False} → server checks isError → {content:[...], isError:True}`

The consumer receives `isError: true` at the MCP result level and `error_reason: "fqn_not_in_graph"` in the body text. The remediation is unambiguous: fix the FQN.

### Edge cases and error handling

- **Isolated-but-present node** (in graph, zero edges): `callers_of` returns `results: []` (not an error). `neighborhood` falls through to the `if not edge_depths:` branch and returns `edges: []`. These are valid empty results, not bad inputs.
- **Wrong-type FQN** (e.g., integer 123 passed where a string is expected): the `fqn not in fg.nodes` check fires (integer is not in string-keyed graph), returning `isError: true`. This is a behavior change from the previous silent degradation (integer fell through BFS as unknown start → `results: []`).
- **module_callers / module_callees**: unchanged. These use prefix-match semantics; a prefix that matches nothing returns `results: []` by design — this is documented and semantically distinct from FQN not-found.

### What was intentionally not changed

- Staleness responses (`stale: true` in Scenarios B, C, E) are unchanged.
- `search` tool is out of scope (substring search; zero matches is a valid result).
- `module_callers` / `module_callees` are out of scope (prefix-match contract).
- Auto-correction of bad paths is out of scope per the refined spec.

## Tier / approach

Tier 2 — Planner → Coder A (single-wave, all files in scope) → binary checks + commit

## Acceptance criteria

- [x] `file_skeleton("bad/path")` → `isError: true, error_reason: "path_not_in_index", stale: false`, no `stale_action`
- [x] `callers_of("bad.fqn")` → `isError: true, error_reason: "fqn_not_in_graph", stale: false`
- [x] `callers_of("real.fqn.with.no.callers")` → `results: [], stale: false` (not an error)
- [x] `neighborhood("bad.fqn")` → `isError: true, error_reason: "fqn_not_in_graph", stale: false`
- [x] `neighborhood("isolated.but.present")` → `edges: [], stale: false` (not an error)
- [x] `module_callers("nonexistent.pkg")` → `results: [], stale: false` (unchanged, no error)
- [x] MCP wire: `callers_of` with bad FQN propagates `isError: true` + `error_reason` in content text (new e2e test)
- [x] All existing tests pass (updated to reflect new error shapes)
- [x] Every `isError: true` dict in graph.py includes `error_reason`

🤖 Generated with [Claude Code](https://claude.com/claude-code)