### PR TITLE
feat: task-type triggers in MCP server instructions (#70)

### DIFF
--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -64,14 +64,30 @@ _SERVER = RpcServer(
     name="pyscope-mcp",
     version=__version__,
     instructions=(
-        "Query the prebuilt Python call-graph index. "
-        "Use stats to check graph size, callers_of/callees_of for function-level "
-        "traversal, module_callers/module_callees for module-level traversal, "
-        "search for symbol lookup, file_skeleton for a file's symbol list, "
-        "neighborhood for a bounded bidirectional subgraph around a symbol, "
-        "build to rebuild the index from source (triggers pyscope-mcp build as a "
-        "subprocess and reloads the in-process index), and reload to re-read an "
-        "already-built index from disk."
+        "Python call-graph index for the target repo. Reach for these tools BEFORE "
+        "grep when the question involves a named Python symbol.\n\n"
+        "Trigger on task intake (not after deciding to grep):\n"
+        "- Refactoring or renaming a symbol → `search` + `callers_of` to scope blast "
+        "radius before reading any file.\n"
+        "- Deleting code → `callers_of` to confirm it is actually dead.\n"
+        "- Implementing something new → `search` first to check it does not already "
+        "exist (avoid reimplementing).\n"
+        "- Reading unfamiliar code → `file_skeleton` for the symbol list, then "
+        "`neighborhood` to orient in the local subgraph before diving in.\n"
+        "- Moving or splitting a module → `module_callers` to find all importers "
+        "upfront.\n\n"
+        "Grep stays correct for: literal strings, comments, config values, `import` "
+        "lines, and `except FooError:` clauses — things the call graph does not "
+        "capture.\n\n"
+        "Tool inventory: `stats` (graph size), `search` (symbol lookup), "
+        "`callers_of` / `callees_of` (function-level traversal), `module_callers` / "
+        "`module_callees` (module-level), `file_skeleton` (file's symbol list), "
+        "`neighborhood` (bounded bidirectional subgraph), `build` (rebuild + reload "
+        "in one step), `reload` (re-read an existing index from disk).\n\n"
+        "Known limit: dynamic dispatch, decorator chains, and string-keyed registries "
+        "can produce missing edges. Absence of an edge is weak evidence. Responses "
+        "flagged with `completeness: \"partial\"` should be cross-checked with grep "
+        "for imports/catches."
     ),
 )
 

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -1,0 +1,148 @@
+"""Regression guard for server.py instructions= string (issue #70).
+
+Asserts that the MCP server instructions contain the task-type-triggered
+guidance phrases required by the issue spec. Tests both the in-process
+object (_SERVER._instructions) and the wire-level initialize response.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import pyscope_mcp.server as srv
+from pyscope_mcp._rpc import RpcServer
+
+
+# ---------------------------------------------------------------------------
+# Anchor phrases required in the instructions string.
+# Each tuple is (label, phrase) where phrase is checked case-insensitively.
+# ---------------------------------------------------------------------------
+REQUIRED_ANCHORS = [
+    ("trigger-framing keyword", "before"),
+    ("refactor trigger keyword", "refactor"),
+    ("callers_of anchor (refactor + delete triggers)", "callers_of"),
+    ("delete-dead-code trigger", "delet"),     # matches "Deleting" and "delete"
+    ("file_skeleton anchor (read-unfamiliar trigger)", "file_skeleton"),
+    ("neighborhood anchor (read-unfamiliar trigger)", "neighborhood"),
+    ("module_callers anchor (module-move trigger)", "module_callers"),
+    ("completeness reference (limits paragraph)", "completeness"),
+    ("partial reference (limits paragraph)", "partial"),
+    ("import carve-out (grep-stays-correct)", "import"),
+    ("except carve-out (grep-stays-correct)", "except"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Unit test: in-process object
+# ---------------------------------------------------------------------------
+
+class TestServerInstructionsObject:
+    """Read _SERVER._instructions directly — fastest possible regression guard."""
+
+    def _instructions(self) -> str:
+        return srv._SERVER._instructions  # type: ignore[attr-defined]
+
+    def test_instructions_is_non_empty_string(self):
+        inst = self._instructions()
+        assert isinstance(inst, str)
+        assert inst.strip(), "_SERVER._instructions must be non-empty"
+
+    @pytest.mark.parametrize("label,phrase", REQUIRED_ANCHORS)
+    def test_anchor_present(self, label: str, phrase: str):
+        inst = self._instructions().lower()
+        assert phrase.lower() in inst, (
+            f"Missing anchor [{label}]: expected '{phrase}' to appear in "
+            f"_SERVER._instructions. "
+            f"This guard ensures the task-type-triggered guidance (issue #70) "
+            f"has not been reverted to the old descriptive blurb."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wire-level test harness (mirrors test_rpc_server.py pattern)
+# ---------------------------------------------------------------------------
+
+class _FakeReader:
+    """Feeds pre-encoded lines to the RPC loop as if they came from stdin."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+        self._pos = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._pos >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._pos]
+        self._pos += 1
+        return line + b"\n"
+
+
+class _FakeWriter:
+    """Captures bytes written by the RPC loop (synchronous write, async drain)."""
+
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.chunks.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def responses(self) -> list[dict]:
+        result = []
+        for chunk in self.chunks:
+            for line in chunk.split(b"\n"):
+                line = line.strip()
+                if line:
+                    result.append(json.loads(line))
+        return result
+
+
+def _req(method: str, params: Any = None, req_id: int = 1) -> bytes:
+    msg: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        msg["params"] = params
+    return json.dumps(msg).encode()
+
+
+async def _run(server: RpcServer, lines: list[bytes]) -> list[dict]:
+    reader = _FakeReader(lines)
+    writer = _FakeWriter()
+    await server._loop(reader, writer)
+    return writer.responses()
+
+
+@pytest.fixture()
+def wire_server() -> RpcServer:
+    """Return the live server instance used by the MCP server module."""
+    return srv._SERVER  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_initialize_wire_instructions_anchors(wire_server: RpcServer):
+    """Wire-level: initialize response instructions field contains all anchor phrases."""
+    lines = [_req("initialize", {"protocolVersion": "2025-06-18"}, req_id=1)]
+    responses = await _run(wire_server, lines)
+    assert responses, "No responses from initialize"
+    result = responses[0].get("result", {})
+    assert "instructions" in result, "instructions key missing from initialize response"
+    inst: str = result["instructions"]
+    assert inst.strip(), "instructions must be non-empty in wire response"
+
+    inst_lower = inst.lower()
+    missing = [
+        f"'{phrase}' (label: {label})"
+        for label, phrase in REQUIRED_ANCHORS
+        if phrase.lower() not in inst_lower
+    ]
+    assert not missing, (
+        "Wire-level initialize response is missing required instruction anchors:\n"
+        + "\n".join(f"  - {m}" for m in missing)
+    )


### PR DESCRIPTION
## Summary

- Replaces the descriptive ~70-word `instructions=` string in `RpcServer` (server.py:66-75) with ~210-word prescriptive, task-type-triggered guidance
- Adds five task-type triggers that fire at task intake: refactor/rename, delete dead code, implement new, read unfamiliar code, move/split module
- Retains grep-stays-correct carve-out (import lines, except clauses, strings/comments), full tool inventory, and `completeness: "partial"` limits paragraph
- Adds `tests/test_server_instructions.py` with 12 parametrized unit tests against `_SERVER._instructions` and one wire-level test against the `initialize` response

Closes #70

## Test plan

- [x] 13 new tests in `tests/test_server_instructions.py` all pass (12 unit anchor checks + 1 wire-level initialize check)
- [x] Full test suite (716 tests) passes with no regressions
- [ ] Manual smoke test: register pyscope-mcp in a consumer repo's Claude config, start a fresh session, verify the new text appears in the `## pyscope-mcp` block under `MCP Server Instructions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Acceptance criteria
- [x] `instructions=` string at server.py:66 replaced with task-type-triggered prescriptive guidance
- [x] BEFORE/task-intake framing present ("Reach for these tools BEFORE grep when the question involves a named Python symbol.")
- [x] All five task-type triggers covered: refactor/rename, delete, implement, read unfamiliar, move/split
- [x] Grep-stays-correct carve-out present (import lines, except clauses, strings, comments, config values)
- [x] Tool inventory paragraph retained (all 10 tools)
- [x] `completeness: "partial"` reference present in known-limits paragraph
- [x] 13 regression-guard tests covering all anchor phrases (unit + wire-level)
- [x] No existing tests broken (716/716 pass)

## Review summary
- Cycles run: 0 of 2 (exited early — no critical/major findings)
- Findings fixed: 0
- Intent validation: clean — no intent risks detected
- Outstanding: None

## History
Squash: A (single implementation commit)
Rebased onto `main` — branch already up to date, no rebase needed.

## Merge instructions
Merge via **squash merge** (not merge commit or rebase merge).