### PR TITLE
epic(#76): migrate to site-keyed graph index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,11 @@ Everything downstream (`CallGraphIndex.from_raw`, save/load, the MCP tools) alre
 
 Fully-qualified dotted paths are the primary ID. Matches LSP and what downstream code expects. Don't invent alternative schemes (`{kind}:{relpath}:{name}` etc.) — they collide on overloads and break interop.
 
-### Unresolved edges (forthcoming)
+### Unresolved edges
 
-Dynamic patterns (string-keyed registries, `getattr`, duck typing, decorators returning callable-class instances, LLM tool-use) cannot be resolved statically. The current shape silently drops them. **Preferred direction:** keep these call sites in the graph but tag them with a confidence score (axon pattern) — either `{caller: [(callee, confidence), ...]}` or a parallel `low_confidence` dict. This is a schema change; bump the version when landing.
+Dynamic patterns (string-keyed registries, `getattr`, duck typing, decorators returning callable-class instances, LLM tool-use) cannot be resolved statically. The current shape drops them from the graph by design — Law 1 forbids uncertain edges, and the constitution's Rejected Alternatives explicitly rules out axon-style confidence scoring. Unresolved call sites belong in `misses.json` for telemetry, not in the graph.
 
-Until that lands, absence of an edge is **weak** evidence — treat the graph as "definite edges, silent false negatives."
+Absence of an edge is **weak** evidence — treat the graph as "definite edges, silent false negatives." The compensating signal is `misses.json`, not a low-confidence edge surface.
 
 ## Core convention: precomputed-and-saved index
 

--- a/src/pyscope_mcp/analyzer/__init__.py
+++ b/src/pyscope_mcp/analyzer/__init__.py
@@ -22,12 +22,13 @@ from .discovery import (
 )
 from .imports import build_import_table as _build_import_table
 from .misses import MissLog, classify_miss as _classify_miss
-from .pipeline import build_raw, build_with_report
+from .pipeline import build_nodes_with_report, build_raw, build_with_report
 from .visitor import EdgeVisitor as _EdgeVisitor
 
 __all__ = [
     "build_raw",
     "build_with_report",
+    "build_nodes_with_report",
     "MissLog",
     # Private names re-exported for existing tests / callers:
     "_collect_defs",

--- a/src/pyscope_mcp/analyzer/discovery.py
+++ b/src/pyscope_mcp/analyzer/discovery.py
@@ -374,13 +374,18 @@ def collect_self_attr_types(
     return result
 
 
-def _resolve_annotation(
+def resolve_annotation(
     annotation: ast.expr,
     module_fqn: str,
     import_table: dict[str, str],
     known_fqns: set[str],
 ) -> str | None:
-    """Resolve a type annotation expression to an in-package FQN, or None."""
+    """Resolve a type annotation expression to an in-package FQN, or None.
+
+    Public helper exposed for use by ``EdgeVisitor`` (epic #76 child #2 — emits
+    annotation kind edges).  The discovery-internal call sites continue to use
+    the ``_resolve_annotation`` alias below for stylistic continuity.
+    """
     if isinstance(annotation, ast.Name):
         name = annotation.id
         if name in import_table:
@@ -407,6 +412,11 @@ def _resolve_annotation(
     if dotted in known_fqns:
         return dotted
     return None
+
+
+# Backwards-compatible internal alias.  Prefer ``resolve_annotation`` in new
+# code; this alias keeps the existing private call sites in this module stable.
+_resolve_annotation = resolve_annotation
 
 
 def _infer_type(

--- a/src/pyscope_mcp/analyzer/discovery.py
+++ b/src/pyscope_mcp/analyzer/discovery.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from .imports import build_import_table
 from .resolution import attr_chain
 
 # Sentinel FQN strings for builtin/pathlib types that are NOT in known_fqns but

--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -245,6 +245,13 @@ class MissLog:
         self.accepted_counts: dict[str, int] = {}
         self.builtin_method_modules: Counter[str] = Counter()
 
+        # v5 (epic #76 child #1): dead_keys are callers with no incoming
+        # call edges.  We accumulate the caller / callee universes here so
+        # to_dict() can derive dead_keys without taking the legacy ``raw``
+        # dict as a parameter.
+        self._call_callers: set[str] = set()
+        self._call_callees: set[str] = set()
+
     def record_miss(
         self,
         pattern: str,
@@ -285,7 +292,19 @@ class MissLog:
         if pattern == "builtin_method_call":
             self.builtin_method_modules[file_path] += 1
 
-    def to_dict(self, raw: dict[str, list[str]], known_fqns: set[str]) -> dict:
+    def record_call_edge(self, caller: str, callee: str) -> None:
+        """Track a resolved call edge for dead_keys computation.
+
+        Pipeline calls this for every (caller, callee) pair that lands in the
+        final edge dict.  ``to_dict()`` derives ``dead_keys`` as
+        ``sorted(callers - callees)`` from the accumulated sets — the same
+        semantics the pre-migration ``to_dict(raw, known_fqns)`` produced
+        from the ``raw`` dict.
+        """
+        self._call_callers.add(caller)
+        self._call_callees.add(callee)
+
+    def to_dict(self) -> dict:
         """Assemble the full misses.json structure."""
         total = self.calls_total
         in_pkg = self.calls_resolved_in_package
@@ -302,10 +321,10 @@ class MissLog:
         for pattern in sorted(self.unresolved_calls):
             flat_unresolved.extend(self.unresolved_calls[pattern])
 
-        all_callees: set[str] = set()
-        for callees in raw.values():
-            all_callees.update(callees)
-        dead_keys = sorted(k for k in raw if k not in all_callees)
+        # dead_keys: callers that no edge points to — derived from per-edge
+        # tracking in record_call_edge (pre-migration this was computed
+        # from the ``raw`` dict argument).
+        dead_keys = sorted(self._call_callers - self._call_callees)
 
         # unreferenced_modules: requires module_fqns keyset not threaded here.
         unreferenced_modules: list[str] = []

--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 import builtins
-import collections
 from collections import Counter
 
 from .resolution import attr_chain

--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -124,6 +124,13 @@ def build_with_report(
 ) -> tuple[dict[str, list[str]], dict, dict[str, list[dict]], dict[str, str]]:
     """Pass 1 + pass 2 with MissLog. Returns (raw_edges, miss_report_dict, skeletons, file_shas).
 
+    Returns the legacy caller-keyed ``{caller: [callees]}`` raw shape — the
+    site-keyed v5 inversion happens at the index boundary
+    (``CallGraphIndex.from_nodes`` / ``CallGraphIndex.save``) so this slice
+    (epic #76 child #1) can land without disturbing the analyzer test corpus.
+    Build-pipeline inversion (Child #2/#3) will move the inversion phase here
+    in a follow-up.
+
     ``skeletons`` maps relative file paths to pre-computed symbol lists suitable
     for storage in the index under the ``skeletons`` key (version 3 schema).
 
@@ -217,7 +224,13 @@ def build_with_report(
             _warn(f"error processing {fqn} in pass 2: {type(exc).__name__}: {exc}")
 
     raw = {caller: sorted(callees) for caller, callees in sorted(all_edges.items())}
-    report = miss_log.to_dict(raw, known_fqns)
+    # Track every (caller, callee) pair so MissLog.to_dict() can derive
+    # dead_keys without taking the legacy raw dict as a parameter (epic #76
+    # child #1 — the to_dict signature change).
+    for caller, callees in raw.items():
+        for callee in callees:
+            miss_log.record_call_edge(caller, callee)
+    report = miss_log.to_dict()
     skeletons = _extract_skeletons(root, parsed)
     return raw, report, skeletons, file_shas
 

--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -200,8 +200,12 @@ def build_with_report(
 
     miss_log.files_parsed = len(parsed)
 
-    # Pass 2: extract edges.
+    # Pass 2: extract edges.  We collect both the legacy call-only adjacency
+    # (used by the back-compat ``raw`` return value) AND the kind-tagged map
+    # produced by the new visitors so the same pass feeds both
+    # ``build_with_report`` (legacy) and ``build_nodes_with_report`` (new).
     all_edges: dict[str, set[str]] = {}
+    all_kind_edges: dict[str, dict[str, set[str]]] = {}
     for fqn, tree, path, import_table in parsed:
         try:
             visitor = EdgeVisitor(
@@ -220,6 +224,10 @@ def build_with_report(
             visitor.visit(tree)
             for caller, callees in visitor.edges.items():
                 all_edges.setdefault(caller, set()).update(callees)
+            for caller, kind_buckets in visitor.kind_edges.items():
+                merged = all_kind_edges.setdefault(caller, {})
+                for kind, callees in kind_buckets.items():
+                    merged.setdefault(kind, set()).update(callees)
         except Exception as exc:  # noqa: BLE001
             _warn(f"error processing {fqn} in pass 2: {type(exc).__name__}: {exc}")
 
@@ -232,7 +240,90 @@ def build_with_report(
             miss_log.record_call_edge(caller, callee)
     report = miss_log.to_dict()
     skeletons = _extract_skeletons(root, parsed)
+    # Stash the kind-tagged edges on a thread-local stash keyed by the report
+    # id — keeps the misses-sidecar JSON shape stable while letting
+    # ``build_nodes_with_report`` recover the kind-tagged data without
+    # re-running pass 2.
+    _last_kind_edges[id(report)] = all_kind_edges
     return raw, report, skeletons, file_shas
+
+
+# Internal stash so ``build_nodes_with_report`` can recover the kind-tagged
+# edges from the most recent ``build_with_report`` call without polluting the
+# misses-sidecar JSON contract.  Keyed by ``id(report)`` so concurrent calls
+# don't collide.  Entries are short-lived — drained immediately by the
+# wrapper in ``build_nodes_with_report``.
+_last_kind_edges: dict[int, dict[str, dict[str, set[str]]]] = {}
+
+
+def _invert_to_nodes(
+    kind_edges: dict[str, dict[str, set[str]]],
+) -> dict[str, dict[str, dict[str, list[str]]]]:
+    """Build-time inversion: assemble per-symbol site-keyed records.
+
+    Input is the forward kind-tagged adjacency emitted by the analyzer:
+    ``{caller: {kind: {callee, ...}}}``.  Output is the site-keyed shape the
+    index serialises:
+    ``{symbol: {"calls": {kind: [callees]}, "called_by": {kind: [callers]}}}``.
+
+    Determinism (Corollary 3.2): node keys are inserted in sorted order, kind
+    keys per bucket are inserted in sorted order, and per-kind callee/caller
+    lists are sorted before insertion — so the same forward map produces the
+    same JSON bytes regardless of analyzer iteration order.
+    """
+    forward: dict[str, dict[str, set[str]]] = {}
+    reverse: dict[str, dict[str, set[str]]] = {}
+    all_symbols: set[str] = set()
+
+    for caller, buckets in kind_edges.items():
+        all_symbols.add(caller)
+        for kind, callees in buckets.items():
+            for callee in callees:
+                all_symbols.add(callee)
+                forward.setdefault(caller, {}).setdefault(kind, set()).add(callee)
+                reverse.setdefault(callee, {}).setdefault(kind, set()).add(caller)
+
+    nodes: dict[str, dict[str, dict[str, list[str]]]] = {}
+    for sym in sorted(all_symbols):
+        record: dict[str, dict[str, list[str]]] = {"calls": {}, "called_by": {}}
+        f_buckets = forward.get(sym, {})
+        for kind in sorted(f_buckets):
+            record["calls"][kind] = sorted(f_buckets[kind])
+        r_buckets = reverse.get(sym, {})
+        for kind in sorted(r_buckets):
+            record["called_by"][kind] = sorted(r_buckets[kind])
+        nodes[sym] = record
+    return nodes
+
+
+def build_nodes_with_report(
+    root: str | Path,
+    package: str,
+) -> tuple[dict[str, dict], dict, dict[str, list[dict]], dict[str, str]]:
+    """Pass 1 + pass 2 + build-time inversion.  Returns ``(nodes, report,
+    skeletons, file_shas)`` where *nodes* is the site-keyed shape Child #1
+    landed (``CallGraphIndex.from_nodes``).
+
+    This is the new analyzer entry point introduced by epic #76 child #2
+    (issue #85).  ``build_with_report`` continues to return the legacy
+    call-only ``raw`` shape so the existing test corpus and downstream
+    callers keep working until Child #3 migrates the fixtures.
+
+    The build-time inversion phase here populates ``called_by`` per-symbol
+    deterministically (sorted callee/caller lists, sorted kind keys), so the
+    on-disk index is byte-identical for the same source tree.
+    """
+    raw, report, skeletons, file_shas = build_with_report(root, package)
+    kind_edges = _last_kind_edges.pop(id(report), None)
+    if kind_edges is None:
+        # No kind-tagged stash available (defensive fallback); derive
+        # call-only kind_edges from raw so we still produce a valid nodes
+        # shape — non-call kinds will be empty.
+        kind_edges = {}
+        for caller, callees in raw.items():
+            kind_edges[caller] = {"call": set(callees)}
+    nodes = _invert_to_nodes(kind_edges)
+    return nodes, report, skeletons, file_shas
 
 
 def build_raw(root: str | Path, package: str) -> dict[str, list[str]]:

--- a/src/pyscope_mcp/analyzer/visitor.py
+++ b/src/pyscope_mcp/analyzer/visitor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 
-from .discovery import SENTINEL_BUILTIN_TYPES
+from .discovery import SENTINEL_BUILTIN_TYPES, resolve_annotation
 from .misses import (
     ACCEPTED_PATTERNS,
     BUILTIN_COLLECTION_METHODS,
@@ -42,6 +42,24 @@ _SENTINEL_ACCEPTED: dict[str, tuple[str, frozenset[str]]] = {
 assert set(_SENTINEL_ACCEPTED) == SENTINEL_BUILTIN_TYPES, (
     "visitor._SENTINEL_ACCEPTED keys diverged from discovery.SENTINEL_BUILTIN_TYPES"
 )
+
+
+def _warn_kind_failure(kind: str, file_path: str, exc: BaseException) -> None:
+    """Emit a per-kind visitor failure warning to stderr.
+
+    Used by the new edge-kind visitors (import / except / annotation /
+    isinstance) under their per-method ``try/except`` so a failure in one kind
+    does not poison other kinds' edges from the same file (Corollary 1.2/4.2
+    extended per-kind, per epic #76).
+    """
+    import sys
+
+    where = file_path or "<unknown>"
+    print(
+        f"[pyscope-mcp] {kind}-edge visitor failed in {where}: "
+        f"{type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
 
 
 class EdgeVisitor(ast.NodeVisitor):
@@ -82,7 +100,12 @@ class EdgeVisitor(ast.NodeVisitor):
         self._miss_log = miss_log
         self._scope_stack: list[str] = []
         self._func_node_stack: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
-        self.edges: dict[str, set[str]] = {}
+        # Kind-tagged edges: caller_fqn -> kind -> set[callee_fqn].
+        # Edge kinds: "call", "import", "except", "annotation", "isinstance".
+        # The legacy ``self.edges`` view (call edges only) remains available via
+        # the property below so call-edge consumers (pipeline aggregation,
+        # legacy tests) continue to work unmodified.
+        self.kind_edges: dict[str, dict[str, set[str]]] = {}
 
     # ------------------------------------------------------------------
     # Scope helpers
@@ -317,9 +340,39 @@ class EdgeVisitor(ast.NodeVisitor):
     # Edge emission
     # ------------------------------------------------------------------
 
-    def _emit(self, callee_fqn: str) -> None:
-        caller = self._current_caller()
-        self.edges.setdefault(caller, set()).add(callee_fqn)
+    def _emit(self, callee_fqn: str, kind: str = "call", caller: str | None = None) -> None:
+        """Record an edge from *caller* (or the current caller) to *callee_fqn*
+        under the given *kind* bucket.
+
+        ``kind`` is one of the supported edge-kind strings — ``call``, ``import``,
+        ``except``, ``annotation``, ``isinstance``.  Adding a new kind is a
+        single-line additive change to the call site that emits it; the
+        visitor stores all kinds in the same per-caller dict.
+
+        ``caller`` overrides the current scope-derived caller when supplied,
+        which lets module-level emitters (imports) attribute edges to the
+        module FQN regardless of how the AST walk's scope stack happens to
+        be configured at the visit site.
+        """
+        if caller is None:
+            caller = self._current_caller()
+        bucket = self.kind_edges.setdefault(caller, {})
+        bucket.setdefault(kind, set()).add(callee_fqn)
+
+    @property
+    def edges(self) -> dict[str, set[str]]:
+        """Backward-compatible view: caller -> set[callee] for ``call`` edges only.
+
+        The legacy ``self.edges`` shape (flat call-only) is preserved as a
+        derived view over ``self.kind_edges``.  Pipeline aggregation and the
+        existing test corpus consume this view; non-call edge kinds are
+        accessible directly via ``self.kind_edges``.
+        """
+        return {
+            caller: set(buckets["call"])
+            for caller, buckets in self.kind_edges.items()
+            if "call" in buckets and buckets["call"]
+        }
 
     def _try_accept_self_attr_sentinel(self, node: ast.Call) -> str | None:
         """For ``self.<attr>.<method>(...)`` calls where ``<attr>`` is typed as a
@@ -509,6 +562,9 @@ class EdgeVisitor(ast.NodeVisitor):
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._scope_stack.append(node.name)
         self._func_node_stack.append(node)
+        # Annotation edges from this function's signature are emitted with the
+        # function's own FQN as the caller — push the scope first.
+        self._scan_function_annotations(node)
         self.generic_visit(node)
         self._func_node_stack.pop()
         self._scope_stack.pop()
@@ -516,6 +572,7 @@ class EdgeVisitor(ast.NodeVisitor):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._scope_stack.append(node.name)
         self._func_node_stack.append(node)
+        self._scan_function_annotations(node)
         self.generic_visit(node)
         self._func_node_stack.pop()
         self._scope_stack.pop()
@@ -525,7 +582,225 @@ class EdgeVisitor(ast.NodeVisitor):
         self.generic_visit(node)
         self._scope_stack.pop()
 
+    # ------------------------------------------------------------------
+    # New edge-kind visitors (epic #76 child #2 / issue #85)
+    #
+    # Per-kind error isolation: each new visitor wraps its body in
+    # try/except so a failure in (say) annotation resolution does not drop
+    # call/import/except edges from the same file.  The outer per-file guard
+    # in pipeline.py remains as the safety net for ``visit_Call`` itself
+    # (which is hot and has its own intricate resolution path).
+    # ------------------------------------------------------------------
+
+    def visit_Import(self, node: ast.Import) -> None:
+        try:
+            module_caller = self._ctx.module_fqn
+            for alias in node.names:
+                # ``import foo.bar`` → emit an import edge to ``foo.bar``.
+                # ``import foo.bar as fb`` → still emit ``foo.bar`` (the imported
+                # symbol's canonical FQN, not the local rebinding).
+                target = alias.name
+                if target:
+                    self._emit(target, kind="import", caller=module_caller)
+        except Exception as exc:  # noqa: BLE001
+            _warn_kind_failure("import", self._file_path, exc)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        try:
+            module_caller = self._ctx.module_fqn
+            level = node.level or 0
+            if level > 0:
+                # Relative import — resolve via import_table: each alias.local
+                # was registered there by build_import_table.
+                for alias in node.names:
+                    local = alias.asname if alias.asname else alias.name
+                    target = self._ctx.import_table.get(local)
+                    if target:
+                        self._emit(target, kind="import", caller=module_caller)
+            else:
+                base = node.module
+                if base:
+                    for alias in node.names:
+                        # ``from foo.bar import *`` — alias.name == "*".  Skip:
+                        # we don't have visibility into the wildcard expansion
+                        # at the visitor layer.  (Wildcard imports are #74.)
+                        if alias.name == "*":
+                            continue
+                        target = f"{base}.{alias.name}"
+                        self._emit(target, kind="import", caller=module_caller)
+        except Exception as exc:  # noqa: BLE001
+            _warn_kind_failure("import", self._file_path, exc)
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        try:
+            exc_type = node.type
+            if exc_type is not None:
+                # ``except (A, B):`` — tuple of exception types.
+                if isinstance(exc_type, ast.Tuple):
+                    for elt in exc_type.elts:
+                        self._emit_except_target(elt)
+                else:
+                    self._emit_except_target(exc_type)
+        except Exception as exc:  # noqa: BLE001
+            _warn_kind_failure("except", self._file_path, exc)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        try:
+            self._scan_annotation(node.annotation)
+        except Exception as exc:  # noqa: BLE001
+            _warn_kind_failure("annotation", self._file_path, exc)
+        self.generic_visit(node)
+
+    # ---- annotation helpers ----
+
+    def _scan_function_annotations(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        """Emit ``annotation`` edges from this function/method to every type
+        named in its argument and return annotations.
+
+        Wrapped in its own try/except for per-kind isolation.
+        """
+        try:
+            args = node.args
+            for arg in (
+                *args.args,
+                *args.kwonlyargs,
+                *args.posonlyargs,
+            ):
+                if arg.annotation is not None:
+                    self._scan_annotation(arg.annotation)
+            if args.vararg is not None and args.vararg.annotation is not None:
+                self._scan_annotation(args.vararg.annotation)
+            if args.kwarg is not None and args.kwarg.annotation is not None:
+                self._scan_annotation(args.kwarg.annotation)
+            if node.returns is not None:
+                self._scan_annotation(node.returns)
+        except Exception as exc:  # noqa: BLE001
+            _warn_kind_failure("annotation", self._file_path, exc)
+
+    def _scan_annotation(self, annotation: ast.expr) -> None:
+        """Resolve *annotation* to in-package type FQNs and emit annotation
+        edges.  Recurses into ``Subscript`` (``Optional[X]``, ``list[X]``,
+        ``Union[A, B]``) and ``BinOp`` (``A | B`` PEP 604 unions).  Bare
+        ``ast.Name`` / ``ast.Attribute`` chains are resolved via
+        ``resolve_annotation`` (the discovery helper, exposed for reuse).
+        """
+        # Subscript: peel off the subscript and recurse into both value and slice.
+        if isinstance(annotation, ast.Subscript):
+            self._scan_annotation(annotation.value)
+            slice_node = annotation.slice
+            # Tuple slice: ``Union[A, B]`` -> Tuple(A, B); ``Dict[K, V]`` similar.
+            if isinstance(slice_node, ast.Tuple):
+                for elt in slice_node.elts:
+                    self._scan_annotation(elt)
+            else:
+                self._scan_annotation(slice_node)
+            return
+        # PEP 604 unions: ``A | B`` is BinOp(BitOr).  Recurse on both sides.
+        if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+            self._scan_annotation(annotation.left)
+            self._scan_annotation(annotation.right)
+            return
+        # Bare names and attribute chains: resolve via the shared helper.
+        if isinstance(annotation, (ast.Name, ast.Attribute)):
+            resolved = resolve_annotation(
+                annotation,
+                self._ctx.module_fqn,
+                self._ctx.import_table,
+                self._ctx.known_fqns,
+            )
+            if resolved is not None:
+                # Emit from the innermost enclosing function; module scope falls
+                # back to the module FQN via _current_caller().
+                func_fqn = self._current_func_fqn()
+                caller = func_fqn if func_fqn is not None else self._current_caller()
+                self._emit(resolved, kind="annotation", caller=caller)
+
+    def _emit_except_target(self, type_node: ast.expr) -> None:
+        """Resolve an ``except T:`` clause's type expression to an in-package
+        FQN and emit an ``except`` edge.  Falls back to ``import_table`` lookup
+        for bare names so ``except SomeError:`` resolves correctly even when
+        ``SomeError`` is brought in via ``from x import SomeError``.
+        """
+        target: str | None = None
+        if isinstance(type_node, ast.Name):
+            name = type_node.id
+            candidate = self._ctx.import_table.get(name)
+            if candidate is not None:
+                target = candidate
+            else:
+                local_candidate = f"{self._ctx.module_fqn}.{name}"
+                if local_candidate in self._ctx.known_fqns:
+                    target = local_candidate
+        elif isinstance(type_node, ast.Attribute):
+            # Reuse the annotation resolver — it handles dotted chains via
+            # the import table the same way exception names work.
+            target = resolve_annotation(
+                type_node,
+                self._ctx.module_fqn,
+                self._ctx.import_table,
+                self._ctx.known_fqns,
+            )
+        if target is not None:
+            func_fqn = self._current_func_fqn()
+            caller = func_fqn if func_fqn is not None else self._current_caller()
+            self._emit(target, kind="except", caller=caller)
+
+    def _try_emit_isinstance_edge(self, node: ast.Call) -> bool:
+        """If *node* is an ``isinstance(obj, T)`` call, emit ``isinstance``
+        edges to T's resolved FQN(s) and return True.  Otherwise return False.
+
+        T may be a tuple ``isinstance(obj, (A, B))`` — one edge per element.
+        Edges are attributed to the innermost enclosing function (consistent
+        with the call-edge convention), falling back to module scope.
+
+        Resolution failures inside this method (e.g. unresolved name) are
+        non-fatal — return True regardless so the caller skips the normal
+        miss-classification path for the ``isinstance`` builtin itself.
+        """
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "isinstance"):
+            return False
+        if len(node.args) < 2:
+            return True  # malformed isinstance — still skip miss recording
+        try:
+            second = node.args[1]
+            type_exprs: list[ast.expr]
+            if isinstance(second, ast.Tuple):
+                type_exprs = list(second.elts)
+            else:
+                type_exprs = [second]
+            func_fqn = self._current_func_fqn()
+            caller = func_fqn if func_fqn is not None else self._current_caller()
+            for expr in type_exprs:
+                if isinstance(expr, (ast.Name, ast.Attribute)):
+                    resolved = resolve_annotation(
+                        expr,
+                        self._ctx.module_fqn,
+                        self._ctx.import_table,
+                        self._ctx.known_fqns,
+                    )
+                    if resolved is not None:
+                        self._emit(resolved, kind="isinstance", caller=caller)
+        except Exception as exc:  # noqa: BLE001
+            _warn_kind_failure("isinstance", self._file_path, exc)
+        return True
+
     def visit_Call(self, node: ast.Call) -> None:
+        # isinstance carve-out: emit isinstance kind edges to the checked
+        # type(s) and skip both the normal call-resolution path and the miss
+        # classification (isinstance is a builtin — emitting a "call" edge
+        # would be a false positive, and recording it as an unresolved miss
+        # would pollute the miss log).  Still recurse into children for
+        # nested calls inside the isinstance arguments.
+        if self._try_emit_isinstance_edge(node):
+            self.generic_visit(node)
+            return
         callee = self._resolve_expr(node.func, call_lineno=node.lineno)
         if callee is not None:
             self._emit(callee)

--- a/src/pyscope_mcp/cli.py
+++ b/src/pyscope_mcp/cli.py
@@ -59,9 +59,11 @@ def cmd_build(args: argparse.Namespace) -> int:
         out = (root / out).resolve()
 
     print(f"[pyscope-mcp] building index: root={root} package={package or root.name}", file=sys.stderr)
-    from pyscope_mcp.analyzer import build_with_report
+    from pyscope_mcp.analyzer import build_nodes_with_report
 
-    raw, miss_report, skeletons, file_shas = build_with_report(root, package=package or root.name)
+    nodes, miss_report, skeletons, file_shas = build_nodes_with_report(
+        root, package=package or root.name
+    )
 
     # Inline missed_callers into index.json at build time (Law 3: single artifact).
     # Aggregate per-caller pattern counts from the flat unresolved_calls list.
@@ -91,8 +93,8 @@ def cmd_build(args: argparse.Namespace) -> int:
     except FileNotFoundError:
         pass  # git binary not installed
 
-    idx = CallGraphIndex.from_raw(
-        root, raw, skeletons=skeletons, file_shas=file_shas, missed_callers=missed_callers,
+    idx = CallGraphIndex.from_nodes(
+        root, nodes, skeletons=skeletons, file_shas=file_shas, missed_callers=missed_callers,
         git_sha=git_sha,
     )
     idx.save(out)

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict
 
-INDEX_VERSION = 5
-
 from pyscope_mcp.types import (
     CalleesResult,
     CallersResult,
@@ -19,6 +17,8 @@ from pyscope_mcp.types import (
     SearchResult,
     StatsResult,
 )
+
+INDEX_VERSION = 5
 
 
 class SymbolSummary(TypedDict):

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -124,27 +124,87 @@ class _DiGraphReverseView:
         )
 
 
-def _compute_content_hash(raw: dict[str, list[str]]) -> str:
-    """Return SHA-256 hex digest of the deterministically serialised *raw* dict.
+def _compute_content_hash(nodes: dict[str, dict]) -> str:
+    """Return SHA-256 hex digest of the deterministically serialised *nodes* dict.
+
+    Hashes the canonical (sorted) projection of the call edges in the
+    site-keyed shape: ``nodes[caller]["calls"]["call"]``.  Only ``call`` edges
+    contribute today (matching pre-migration semantics so freshness checks
+    survive the schema bump for repos that have not added other kinds yet).
 
     Sorted keys and sorted callee lists ensure the same graph always yields
     the same hash, regardless of insertion order.
     """
-    canonical = json.dumps(
-        {k: sorted(v) for k, v in sorted(raw.items())},
-        separators=(",", ":"),
-    ).encode()
+    projection: dict[str, list[str]] = {}
+    for caller in sorted(nodes):
+        record = nodes[caller]
+        callees = list(record.get("calls", {}).get("call", ()))
+        if callees:
+            projection[caller] = sorted(callees)
+    canonical = json.dumps(projection, separators=(",", ":")).encode()
     return hashlib.sha256(canonical).hexdigest()
+
+
+def _raw_to_nodes(raw: dict[str, list[str]]) -> dict[str, dict]:
+    """Convert legacy ``raw`` (caller → [callees]) to site-keyed ``nodes`` shape.
+
+    Build-time inversion: every ``(caller, callee)`` pair in *raw* yields
+    ``nodes[caller]["calls"]["call"]`` (forward) and
+    ``nodes[callee]["called_by"]["call"]`` (reverse).  Both endpoints get a
+    ``NodeRecord`` skeleton with sorted, deduplicated lists per kind so the
+    serialisation determinism invariant (Corollary 3.2) holds regardless of
+    insertion order.
+    """
+    forward: dict[str, set[str]] = {}
+    reverse: dict[str, set[str]] = {}
+    for caller, callees in raw.items():
+        forward.setdefault(caller, set()).update(callees)
+        for callee in callees:
+            reverse.setdefault(callee, set()).add(caller)
+            forward.setdefault(callee, set())  # ensure callee node exists
+        # Keep callers with empty callee list as nodes too.
+        forward.setdefault(caller, set())
+
+    all_symbols = set(forward) | set(reverse)
+    nodes: dict[str, dict] = {}
+    for sym in sorted(all_symbols):
+        record: dict[str, dict[str, list[str]]] = {"calls": {}, "called_by": {}}
+        callees = forward.get(sym, set())
+        if callees:
+            record["calls"]["call"] = sorted(callees)
+        callers = reverse.get(sym, set())
+        if callers:
+            record["called_by"]["call"] = sorted(callers)
+        nodes[sym] = record
+    return nodes
+
+
+def _nodes_to_raw(nodes: dict[str, dict]) -> dict[str, list[str]]:
+    """Project the site-keyed ``nodes`` shape back to the legacy ``raw`` form.
+
+    Used to support the deprecated ``raw`` property and ``from_raw`` constructor
+    while Child #3 of epic #76 migrates the test corpus.  Only ``call`` edges
+    appear in the projection — non-call kinds are not part of the legacy
+    contract and are silently omitted (they remain available via
+    ``CallGraphIndex.nodes``).
+    """
+    out: dict[str, list[str]] = {}
+    for caller in sorted(nodes):
+        callees = nodes[caller].get("calls", {}).get("call")
+        if callees:
+            out[caller] = sorted(callees)
+    return out
 
 
 @dataclass
 class CallGraphIndex:
     """Function- and module-level call graph over a Python repo.
 
-    The source of truth is `raw`: a mapping {caller_fqn: [callee_fqn, ...]}.
-    Graphs are derived from `raw` on construction and on `load`. The backend
-    that populates `raw` from source code lives in pyscope_mcp.analyzer
-    (AST-based; fully implemented — see CLAUDE.md for the contract).
+    The source of truth is ``nodes``: a site-keyed mapping
+    ``{symbol_fqn: {"calls": {kind: [callees]}, "called_by": {kind: [callers]}}}``.
+    Graphs are derived from ``nodes[s]["calls"]["call"]`` on construction and
+    on ``load``.  The legacy ``raw`` property projects the same call edges in
+    the pre-migration shape for transitional callers.
 
     ``skeletons`` maps relative file paths → pre-computed lists of SymbolSummary
     dicts, populated during ``pyscope-mcp build`` (index version 2+).
@@ -153,7 +213,9 @@ class CallGraphIndex:
     root: Path
     function_graph: _DiGraph = field(default_factory=_DiGraph)
     module_graph: _DiGraph = field(default_factory=_DiGraph)
-    raw: dict[str, list[str]] = field(default_factory=dict)
+    # v5+: site-keyed nodes — replaces the legacy ``raw`` field.  The ``raw``
+    # property below derives a call-only projection for transitional callers.
+    nodes: dict[str, dict] = field(default_factory=dict)
     skeletons: dict[str, list[SymbolSummary]] = field(default_factory=dict)
     # None = pre-v3 index (no hashes stored); dict = v3/v5 index with per-file SHA256 digests.
     file_shas: dict[str, str] | None = field(default=None)
@@ -169,27 +231,49 @@ class CallGraphIndex:
     # Derived at load/from_raw time: maps FQN → relative file path (inverted from skeletons).
     # Not serialised — rebuilt on every load.
     _fqn_to_file: dict[str, str] = field(default_factory=dict, repr=False)
-    # Computed at from_raw time: p99 of in-degree distribution, floor of 10.
+    # Computed at from_nodes time: p99 of in-degree distribution, floor of 10.
     # Used by neighborhood() for hub suppression. Not serialised — recomputed on load.
     _in_degree_threshold: int = field(default=10, repr=False)
 
+    @property
+    def raw(self) -> dict[str, list[str]]:
+        """Legacy projection of ``nodes`` to ``{caller: [callees]}`` (call edges only).
+
+        Provided as a transitional read-only view for callers that have not
+        migrated to the ``nodes`` shape yet (Child #3 of epic #76 migrates
+        the remaining test fixtures).  New code should consume ``nodes``
+        directly to keep access to non-call edge kinds.
+        """
+        return _nodes_to_raw(self.nodes)
+
     @classmethod
-    def from_raw(
+    def from_nodes(
         cls,
         root: str | Path,
-        raw: dict[str, list[str]],
+        nodes: dict[str, dict],
         skeletons: dict[str, list[SymbolSummary]] | None = None,
         file_shas: dict[str, str] | None = None,
         missed_callers: dict[str, dict[str, int]] | None = None,
         git_sha: str | None = None,
     ) -> "CallGraphIndex":
+        """Construct a CallGraphIndex from the site-keyed ``nodes`` shape.
+
+        Populates ``function_graph`` and ``module_graph`` from
+        ``nodes[s]["calls"]["call"]`` only — non-call kinds are stored in
+        ``nodes`` but are not used by the existing graph traversal layer
+        (see Decision Prior "Keep _DiGraph" in epic #76's intent doc).
+        """
         root = Path(root).resolve()
         fg = _DiGraph()
         mg = _DiGraph()
-        for caller, callees in raw.items():
+        # Ensure every site key is a graph node, even when its calls bucket
+        # is empty (so callers_of returns empty results, not fqn_not_in_graph).
+        for caller in nodes:
             fg.add_node(caller)
+            mg.add_node(_module_of(caller))
+        for caller, record in nodes.items():
+            callees = record.get("calls", {}).get("call", ())
             cm = _module_of(caller)
-            mg.add_node(cm)
             for callee in callees:
                 fg.add_edge(caller, callee)
                 tm = _module_of(callee)
@@ -202,16 +286,14 @@ class CallGraphIndex:
             for sym in symbols:
                 fqn_to_file[sym["fqn"]] = rel_path
         # Compute in-degree threshold: p99 of in-degree distribution, floor of 10.
-        # One-time O(N) cost at index load; cached for O(1) lookup during BFS.
         in_degree_threshold = _compute_in_degree_threshold(fg)
-        # Compute content_hash: SHA-256 of the deterministically serialised raw dict.
-        # Sorted keys + sorted callee lists ensure same raw → same hash.
-        content_hash = _compute_content_hash(raw)
+        # Compute content_hash from the canonical projection of call edges.
+        content_hash = _compute_content_hash(nodes)
         return cls(
             root=root,
             function_graph=fg,
             module_graph=mg,
-            raw=raw,
+            nodes=nodes,
             skeletons=skeletons,
             file_shas=file_shas,
             missed_callers=missed_callers if missed_callers is not None else {},
@@ -221,20 +303,64 @@ class CallGraphIndex:
             _in_degree_threshold=in_degree_threshold,
         )
 
+    @classmethod
+    def from_raw(
+        cls,
+        root: str | Path,
+        raw: dict[str, list[str]],
+        skeletons: dict[str, list[SymbolSummary]] | None = None,
+        file_shas: dict[str, str] | None = None,
+        missed_callers: dict[str, dict[str, int]] | None = None,
+        git_sha: str | None = None,
+    ) -> "CallGraphIndex":
+        """Deprecated — convert legacy ``raw`` shape to ``nodes`` and delegate.
+
+        Retained for transitional callers (notably the test corpus that Child #3
+        of epic #76 will migrate).  New code should call :meth:`from_nodes`
+        directly so non-call edge kinds can be expressed.
+        """
+        nodes = _raw_to_nodes(raw)
+        return cls.from_nodes(
+            root,
+            nodes,
+            skeletons=skeletons,
+            file_shas=file_shas,
+            missed_callers=missed_callers,
+            git_sha=git_sha,
+        )
+
     def save(self, path: str | Path) -> Path:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Deterministic serialisation: sort node keys, sort kind keys within
+        # each calls/called_by bucket, sort each kind's list.  json.dumps with
+        # sort_keys=True handles the dict layers; we pre-sort the lists.
+        canonical_nodes: dict[str, dict] = {}
+        for sym in sorted(self.nodes):
+            record = self.nodes[sym]
+            calls_buckets = record.get("calls", {}) or {}
+            called_by_buckets = record.get("called_by", {}) or {}
+            canonical_nodes[sym] = {
+                "calls": {
+                    kind: sorted(calls_buckets[kind])
+                    for kind in sorted(calls_buckets)
+                },
+                "called_by": {
+                    kind: sorted(called_by_buckets[kind])
+                    for kind in sorted(called_by_buckets)
+                },
+            }
         payload: dict = {
             "version": INDEX_VERSION,
             "root": str(self.root),
-            "raw": self.raw,
+            "nodes": canonical_nodes,
             "skeletons": self.skeletons,
             "file_shas": self.file_shas if self.file_shas is not None else {},
             "missed_callers": self.missed_callers,
             "git_sha": self.git_sha,
             "content_hash": self.content_hash,
         }
-        path.write_text(json.dumps(payload))
+        path.write_text(json.dumps(payload, sort_keys=True))
         return path
 
     @classmethod
@@ -247,13 +373,22 @@ class CallGraphIndex:
                 f"index schema is v{version}, server requires v{INDEX_VERSION} — "
                 "run 'pyscope-mcp build' to regenerate"
             )
+        # Pre-migration v5 indexes wrote ``raw`` instead of ``nodes``.  Reject
+        # them with the same clear-error contract used for older versions —
+        # there is no migration shim (Corollary 1.3/4.3).
+        if "nodes" not in payload:
+            raise ValueError(
+                f"index schema is v{version} but uses the legacy 'raw' field; "
+                f"server requires v{INDEX_VERSION} with site-keyed 'nodes' — "
+                "run 'pyscope-mcp build' to regenerate"
+            )
         skeletons: dict[str, list[SymbolSummary]] = payload.get("skeletons", {})
         file_shas: dict[str, str] = payload.get("file_shas", {})
         missed_callers: dict[str, dict[str, int]] = payload.get("missed_callers", {})
         git_sha: str | None = payload.get("git_sha")
-        return cls.from_raw(
+        return cls.from_nodes(
             Path(payload["root"]),
-            payload["raw"],
+            payload["nodes"],
             skeletons=skeletons,
             file_shas=file_shas,
             missed_callers=missed_callers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Shared pytest fixtures for the pyscope-mcp test suite.
+
+The single helper exported here, :func:`make_nodes`, converts a compact
+``{caller: [callees]}`` dict (the legacy ``raw`` shape) into the site-keyed
+``nodes`` shape introduced by epic #76 child #1.
+
+Centralising the conversion keeps every fixture site in the test corpus
+compact: each test still expresses its graph as ``{caller: [callees]}`` —
+the most natural representation for call-only tests — and lets the helper
+expand to the site-keyed record shape ``CallGraphIndex.from_nodes``
+expects.
+
+The helper also supports building call edges of an arbitrary kind via the
+``kind`` keyword and unioning multiple kind buckets through repeated calls
+in the same test (``make_nodes(raw1, kind="call")`` then merged with
+``make_nodes(raw2, kind="import")``).  This keeps the next-edge-kind PR
+cost bounded to one helper call per kind, not one fixture migration per
+site (Success Metric 3 of epic #76).
+"""
+
+from __future__ import annotations
+
+
+def make_nodes(
+    raw: dict[str, list[str]],
+    *,
+    kind: str = "call",
+) -> dict[str, dict]:
+    """Convert a ``{caller: [callees]}`` dict to the site-keyed nodes shape.
+
+    Each key in *raw* becomes (or extends) a node with
+    ``calls[kind] = sorted(callees)``.  Each callee gets a corresponding
+    ``called_by[kind]`` entry naming its caller.  Empty callee lists are
+    preserved as nodes with no edges so callers like ``CallGraphIndex
+    .callers_of`` see the FQN as present-but-isolated rather than missing.
+
+    Determinism: callee/caller lists are sorted within each kind bucket so
+    ``make_nodes(raw)`` and ``make_nodes(reversed_raw)`` for the same
+    logical edges produce dict equal output (and, when fed through
+    ``CallGraphIndex.save``, byte-identical JSON).
+
+    Parameters
+    ----------
+    raw:
+        Compact ``{caller_fqn: [callee_fqn, ...]}`` mapping.  Same shape as
+        the pre-migration ``raw`` field; preserved here as the ergonomic
+        author-facing form.
+    kind:
+        Edge kind to file the callees under.  Defaults to ``"call"`` so
+        existing tests get call edges for free; pass ``"import"``,
+        ``"except"``, ``"annotation"``, or ``"isinstance"`` to build
+        fixtures for the other kinds defined by epic #76.
+
+    Returns
+    -------
+    dict[str, dict]
+        Site-keyed nodes mapping suitable for ``CallGraphIndex.from_nodes``.
+        Every symbol that appears as a caller or callee is present as a key,
+        even when its edge buckets are empty for the requested kind.
+    """
+    forward: dict[str, set[str]] = {}
+    reverse: dict[str, set[str]] = {}
+    for caller, callees in raw.items():
+        forward.setdefault(caller, set()).update(callees)
+        for callee in callees:
+            reverse.setdefault(callee, set()).add(caller)
+            forward.setdefault(callee, set())  # ensure node exists
+
+    all_symbols = set(forward) | set(reverse)
+    nodes: dict[str, dict] = {}
+    for sym in sorted(all_symbols):
+        record: dict[str, dict[str, list[str]]] = {"calls": {}, "called_by": {}}
+        callees = forward.get(sym, set())
+        if callees:
+            record["calls"][kind] = sorted(callees)
+        callers = reverse.get(sym, set())
+        if callers:
+            record["called_by"][kind] = sorted(callers)
+        nodes[sym] = record
+    return nodes

--- a/tests/test_analyzer_builtin_methods.py
+++ b/tests/test_analyzer_builtin_methods.py
@@ -137,7 +137,7 @@ def test_to_dict_rollup_top5() -> None:
     for _ in range(6):
         log.record_accepted("builtin_method_call", "f.py")
 
-    report = log.to_dict({}, set())
+    report = log.to_dict()
     summary = report["summary"]
 
     assert summary["calls_accepted"] == 21

--- a/tests/test_analyzer_kind_edges.py
+++ b/tests/test_analyzer_kind_edges.py
@@ -1,0 +1,502 @@
+"""Tests for the new edge kinds added in epic #76 child #2 (issue #85).
+
+Covers the four new edge kinds — ``import``, ``except``, ``annotation``,
+``isinstance`` — and the build-time inversion phase that produces
+``called_by`` per symbol.
+
+Per-kind error isolation has its own test below: a deliberately-broken
+visitor method for one kind must not drop edges of other kinds from the
+same file (Corollary 1.2/4.2 extended per-kind, per epic #76).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from pyscope_mcp.analyzer import build_nodes_with_report
+
+
+def _write(root: Path, rel: str, src: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(src).lstrip("\n"))
+
+
+# ----------------------------------------------------------------------
+# Scenario 1 — import edge emission
+# ----------------------------------------------------------------------
+
+def test_import_from_emits_import_edge(tmp_path: Path) -> None:
+    """``from pkg.lib import MyFunc`` produces an ``import`` edge to the
+    fully-qualified imported symbol."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/lib.py", "def MyFunc():\n    pass\n")
+    _write(
+        tmp_path,
+        "pkg/consumer.py",
+        """
+        from pkg.lib import MyFunc
+
+        def use_it():
+            MyFunc()
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    consumer = nodes["pkg.consumer"]
+    assert "pkg.lib.MyFunc" in consumer["calls"].get("import", [])
+
+
+def test_plain_import_emits_module_edge(tmp_path: Path) -> None:
+    """``import pkg.lib`` emits an ``import`` edge to the module FQN."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/lib.py", "X = 1\n")
+    _write(
+        tmp_path,
+        "pkg/consumer.py",
+        """
+        import pkg.lib
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    consumer = nodes["pkg.consumer"]
+    assert "pkg.lib" in consumer["calls"].get("import", [])
+
+
+def test_import_star_is_skipped(tmp_path: Path) -> None:
+    """Wildcard imports are dropped at the visitor layer (issue #74's scope)."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/lib.py", "X = 1\n")
+    _write(
+        tmp_path,
+        "pkg/consumer.py",
+        """
+        from pkg.lib import *
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    # If pkg.consumer is in nodes at all, it must not list a ``*`` import.
+    consumer = nodes.get("pkg.consumer", {"calls": {}, "called_by": {}})
+    imports = consumer.get("calls", {}).get("import", [])
+    assert not any(name.endswith(".*") for name in imports)
+
+
+# ----------------------------------------------------------------------
+# Scenario 2 — except edge emission
+# ----------------------------------------------------------------------
+
+def test_except_handler_emits_except_edge(tmp_path: Path) -> None:
+    """``except SomeError:`` emits an ``except`` edge from the enclosing
+    function to the exception class FQN (resolved via import_table)."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/errors.py",
+        """
+        class BadThing(Exception):
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/handler.py",
+        """
+        from pkg.errors import BadThing
+
+        def process():
+            try:
+                ...
+            except BadThing:
+                ...
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    excepts = nodes["pkg.handler.process"]["calls"].get("except", [])
+    assert "pkg.errors.BadThing" in excepts
+
+
+def test_except_tuple_emits_one_edge_per_member(tmp_path: Path) -> None:
+    """``except (A, B):`` emits one edge per element."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/errors.py",
+        """
+        class A(Exception):
+            pass
+
+        class B(Exception):
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/handler.py",
+        """
+        from pkg.errors import A, B
+
+        def process():
+            try:
+                ...
+            except (A, B):
+                ...
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    excepts = set(nodes["pkg.handler.process"]["calls"].get("except", []))
+    assert "pkg.errors.A" in excepts
+    assert "pkg.errors.B" in excepts
+
+
+def test_bare_except_emits_no_edge(tmp_path: Path) -> None:
+    """``except:`` (no type) must not emit any edge."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/handler.py",
+        """
+        def process():
+            try:
+                ...
+            except:
+                ...
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    proc = nodes.get("pkg.handler.process", {"calls": {}, "called_by": {}})
+    # The function may not have a node at all if no edges of any kind were
+    # emitted — accept either "no node" or "node with no except bucket".
+    assert not proc.get("calls", {}).get("except")
+
+
+# ----------------------------------------------------------------------
+# Scenario 3 — annotation edge emission
+# ----------------------------------------------------------------------
+
+def test_function_param_and_return_annotations_emit_edges(tmp_path: Path) -> None:
+    """Argument annotations and the return annotation both produce
+    ``annotation`` edges from the function FQN to the annotated types."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/models.py",
+        """
+        class MyClass:
+            pass
+
+        class OtherClass:
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/typed.py",
+        """
+        from pkg.models import MyClass, OtherClass
+
+        def f(x: MyClass) -> OtherClass:
+            ...
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    annotations = set(nodes["pkg.typed.f"]["calls"].get("annotation", []))
+    assert "pkg.models.MyClass" in annotations
+    assert "pkg.models.OtherClass" in annotations
+
+
+def test_ann_assign_emits_annotation_edge(tmp_path: Path) -> None:
+    """``y: MyClass = ...`` inside a function emits an ``annotation`` edge."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/models.py", "class MyClass:\n    pass\n")
+    _write(
+        tmp_path,
+        "pkg/typed.py",
+        """
+        from pkg.models import MyClass
+
+        def f():
+            y: MyClass = MyClass()
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    annotations = nodes["pkg.typed.f"]["calls"].get("annotation", [])
+    assert "pkg.models.MyClass" in annotations
+
+
+def test_subscripted_annotation_unwraps_to_inner_type(tmp_path: Path) -> None:
+    """``x: Optional[MyClass]`` — the inner type is captured."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/models.py", "class MyClass:\n    pass\n")
+    _write(
+        tmp_path,
+        "pkg/typed.py",
+        """
+        from typing import Optional
+        from pkg.models import MyClass
+
+        def f(x: Optional[MyClass]) -> None:
+            ...
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    annotations = nodes["pkg.typed.f"]["calls"].get("annotation", [])
+    assert "pkg.models.MyClass" in annotations
+
+
+def test_pep604_union_unwraps_both_sides(tmp_path: Path) -> None:
+    """``x: A | B`` — both A and B captured as annotation edges."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/models.py",
+        """
+        class A:
+            pass
+
+        class B:
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/typed.py",
+        """
+        from pkg.models import A, B
+
+        def f(x: A | B) -> None:
+            ...
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    annotations = set(nodes["pkg.typed.f"]["calls"].get("annotation", []))
+    assert "pkg.models.A" in annotations
+    assert "pkg.models.B" in annotations
+
+
+# ----------------------------------------------------------------------
+# Scenario 4 — isinstance edge emission
+# ----------------------------------------------------------------------
+
+def test_isinstance_emits_isinstance_edge(tmp_path: Path) -> None:
+    """``isinstance(obj, Widget)`` emits an ``isinstance`` edge from the
+    enclosing function to ``Widget``'s FQN (NOT a ``call`` edge for the
+    isinstance builtin itself)."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/models.py", "class Widget:\n    pass\n")
+    _write(
+        tmp_path,
+        "pkg/checks.py",
+        """
+        from pkg.models import Widget
+
+        def validate(obj):
+            return isinstance(obj, Widget)
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    rec = nodes["pkg.checks.validate"]
+    assert "pkg.models.Widget" in rec["calls"].get("isinstance", [])
+    # Critically: no spurious ``call`` edge for the isinstance builtin.
+    assert "isinstance" not in rec["calls"].get("call", [])
+
+
+def test_isinstance_with_tuple_emits_per_element(tmp_path: Path) -> None:
+    """``isinstance(x, (A, B))`` — one edge per type."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/models.py",
+        """
+        class A:
+            pass
+
+        class B:
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/checks.py",
+        """
+        from pkg.models import A, B
+
+        def validate(obj):
+            return isinstance(obj, (A, B))
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    isinstances = set(nodes["pkg.checks.validate"]["calls"].get("isinstance", []))
+    assert "pkg.models.A" in isinstances
+    assert "pkg.models.B" in isinstances
+
+
+# ----------------------------------------------------------------------
+# Scenario 5 — build-time inversion produces called_by entries
+# ----------------------------------------------------------------------
+
+def test_build_time_inversion_populates_called_by(tmp_path: Path) -> None:
+    """Build-time inversion: forward edges produce matching ``called_by``
+    entries on the callee, sorted and per-kind."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/b.py",
+        """
+        def g():
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/a.py",
+        """
+        from pkg.b import g
+
+        def f():
+            g()
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/c.py",
+        """
+        import pkg.b
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    # Forward call edge
+    assert "pkg.b.g" in nodes["pkg.a.f"]["calls"].get("call", [])
+    # Reverse call edge — this is the inversion's responsibility
+    assert "pkg.a.f" in nodes["pkg.b.g"]["called_by"].get("call", [])
+    # Reverse import edge from pkg.c → pkg.b appears under pkg.b.called_by.import
+    assert "pkg.c" in nodes["pkg.b"]["called_by"].get("import", [])
+
+
+def test_inversion_lists_are_sorted(tmp_path: Path) -> None:
+    """Determinism (Corollary 3.2): callee/caller lists per kind are sorted."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/target.py",
+        """
+        def t():
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/zeta.py",
+        """
+        from pkg.target import t
+
+        def use():
+            t()
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/alpha.py",
+        """
+        from pkg.target import t
+
+        def use():
+            t()
+        """,
+    )
+    nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    callers = nodes["pkg.target.t"]["called_by"].get("call", [])
+    assert callers == sorted(callers)
+
+
+# ----------------------------------------------------------------------
+# Scenario 6 — per-kind error isolation
+# ----------------------------------------------------------------------
+
+def test_per_kind_isolation_failure_in_annotation_does_not_drop_call_edges(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the annotation visitor raises while processing one file, other
+    kinds' edges from the same file (call, import, except) must still be
+    emitted.  This verifies the per-method try/except guard rather than a
+    single coarse per-file guard.
+    """
+    from pyscope_mcp.analyzer import visitor as visitor_mod
+
+    original = visitor_mod.EdgeVisitor._scan_annotation
+
+    def boom(self, annotation):  # noqa: ANN001 — patched method
+        raise RuntimeError("induced annotation failure")
+
+    monkeypatch.setattr(visitor_mod.EdgeVisitor, "_scan_annotation", boom)
+
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/lib.py",
+        """
+        class Boom(Exception):
+            pass
+
+        def helper():
+            pass
+        """,
+    )
+    _write(
+        tmp_path,
+        "pkg/handler.py",
+        """
+        from pkg.lib import helper, Boom
+
+        def process(x: int) -> None:
+            try:
+                helper()
+            except Boom:
+                ...
+        """,
+    )
+    try:
+        nodes, _report, _skel, _shas = build_nodes_with_report(tmp_path, "pkg")
+    finally:
+        # The monkeypatch fixture restores automatically, but be explicit.
+        monkeypatch.setattr(visitor_mod.EdgeVisitor, "_scan_annotation", original)
+
+    proc = nodes.get("pkg.handler.process", {})
+    calls = proc.get("calls", {})
+    # Call edge survived
+    assert "pkg.lib.helper" in calls.get("call", [])
+    # Except edge survived
+    assert "pkg.lib.Boom" in calls.get("except", [])
+    # Annotation edges suppressed (broken visitor) — bucket is absent or empty.
+    assert not calls.get("annotation")
+    # Sanity: the import edge from the module FQN survives too.
+    assert "pkg.lib.helper" in nodes["pkg.handler"]["calls"].get("import", [])
+
+
+# ----------------------------------------------------------------------
+# Determinism — same source → byte-identical inversion output
+# ----------------------------------------------------------------------
+
+def test_inversion_is_deterministic(tmp_path: Path) -> None:
+    """Running the build twice on the same tree yields identical nodes."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/m1.py",
+        """
+        from pkg.m2 import g
+        from pkg.m3 import h
+
+        def f():
+            g()
+            h()
+        """,
+    )
+    _write(tmp_path, "pkg/m2.py", "def g():\n    pass\n")
+    _write(tmp_path, "pkg/m3.py", "def h():\n    pass\n")
+    a, _, _, _ = build_nodes_with_report(tmp_path, "pkg")
+    b, _, _, _ = build_nodes_with_report(tmp_path, "pkg")
+    import json
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)

--- a/tests/test_bfs_ranking_integration.py
+++ b/tests/test_bfs_ranking_integration.py
@@ -123,7 +123,9 @@ def test_analyzer_resolves_all_depth1_callers(callers_idx: CallGraphIndex) -> No
     """
     target = "ranking_callers_fixture.target.target_fn"
     direct_callers = {
-        fqn for fqn, callees in callers_idx.raw.items() if target in callees
+        fqn
+        for fqn, node in callers_idx.nodes.items()
+        if target in node.get("calls", {}).get("call", [])
     }
     expected = {f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}"
                 for i in range(1, _N_DEPTH1 + 1)}

--- a/tests/test_commit_staleness.py
+++ b/tests/test_commit_staleness.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -40,11 +41,7 @@ def _make_idx(
     raw: dict[str, list[str]] | None = None,
     git_sha: str | None = None,
 ) -> CallGraphIndex:
-    return CallGraphIndex.from_raw(
-        str(tmp_path),
-        raw or {},
-        git_sha=git_sha,
-    )
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw or {}), git_sha=git_sha)
 
 
 _MOCK_HEAD = "abcdef1234567890abcdef1234567890abcdef12"
@@ -130,12 +127,7 @@ def _make_idx_with_raw(tmp_path: Path, git_sha: str = _MOCK_INDEX_SHA) -> CallGr
         "pkg.mod.fn_a": ["pkg.mod.fn_b"],
         "pkg.mod.fn_b": [],
     }
-    return CallGraphIndex.from_raw(
-        str(tmp_path),
-        raw,
-        file_shas={},
-        git_sha=git_sha,
-    )
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), file_shas={}, git_sha=git_sha)
 
 
 def test_callers_of_includes_commit_staleness(tmp_path: Path) -> None:
@@ -211,13 +203,7 @@ def test_file_skeleton_includes_commit_staleness(tmp_path: Path) -> None:
     (tmp_path / "mod.py").write_text("def fn_a(): pass\n")
     import hashlib
     shas = {"mod.py": hashlib.sha256(b"def fn_a(): pass\n").hexdigest()}
-    idx = CallGraphIndex.from_raw(
-        str(tmp_path),
-        {},
-        skeletons=skeletons,
-        file_shas=shas,
-        git_sha=_MOCK_INDEX_SHA,
-    )
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons=skeletons, file_shas=shas, git_sha=_MOCK_INDEX_SHA)
     with patch("subprocess.run", return_value=_mock_git_success(_MOCK_HEAD)):
         result = idx.file_skeleton("mod.py")
     assert "commit_stale" in result
@@ -234,7 +220,7 @@ def server_with_index(tmp_path: Path):
     from pyscope_mcp import server as srv
 
     raw = {"pkg.mod.fn_a": ["pkg.mod.fn_b"], "pkg.mod.fn_b": []}
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
     index_path = tmp_path / "index.json"
     idx.save(index_path)
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -49,9 +50,9 @@ def _make_idx(
     file_shas: dict[str, str] | None = None,
     git_sha: str | None = None,
 ) -> CallGraphIndex:
-    return CallGraphIndex.from_raw(
+    return CallGraphIndex.from_nodes(
         "/tmp/test",
-        raw,
+        make_nodes(raw),
         skeletons=skeletons or {},
         file_shas=file_shas or {},
         missed_callers=missed_callers or {},

--- a/tests/test_component_issue62.py
+++ b/tests/test_component_issue62.py
@@ -27,6 +27,7 @@ from typing import Any
 import pytest
 
 from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -44,7 +45,7 @@ def _make_minimal_raw() -> dict[str, list[str]]:
 def _make_index(tmp_path: Path, raw: dict[str, list[str]] | None = None) -> CallGraphIndex:
     if raw is None:
         raw = _make_minimal_raw()
-    return CallGraphIndex.from_raw(str(tmp_path), raw)
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ def test_load_accepts_v5_index(tmp_path: Path) -> None:
 def test_from_raw_populates_content_hash(tmp_path: Path) -> None:
     """content_hash is computed and non-empty after from_raw()."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     assert isinstance(idx.content_hash, str)
     assert len(idx.content_hash) == 64, "SHA-256 hex digest must be 64 chars"
 
@@ -108,8 +109,8 @@ def test_from_raw_populates_content_hash(tmp_path: Path) -> None:
 def test_content_hash_is_deterministic(tmp_path: Path) -> None:
     """Same raw dict always produces the same content_hash."""
     raw = _make_minimal_raw()
-    idx1 = CallGraphIndex.from_raw(str(tmp_path), raw)
-    idx2 = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx1 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
+    idx2 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     assert idx1.content_hash == idx2.content_hash
 
 
@@ -117,8 +118,8 @@ def test_content_hash_changes_with_raw(tmp_path: Path) -> None:
     """Different raw dicts produce different content_hashes."""
     raw_a = {"pkg.a": ["pkg.b"], "pkg.b": []}
     raw_b = {"pkg.a": ["pkg.c"], "pkg.c": []}
-    idx_a = CallGraphIndex.from_raw(str(tmp_path), raw_a)
-    idx_b = CallGraphIndex.from_raw(str(tmp_path), raw_b)
+    idx_a = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw_a))
+    idx_b = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw_b))
     assert idx_a.content_hash != idx_b.content_hash
 
 
@@ -131,7 +132,7 @@ def test_git_sha_defaults_to_none(tmp_path: Path) -> None:
 def test_git_sha_roundtrips_through_save_load(tmp_path: Path) -> None:
     """git_sha is persisted on save and restored on load."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha="abc123def456")
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha="abc123def456")
     saved = idx.save(tmp_path / "index.json")
     loaded = CallGraphIndex.load(saved)
     assert loaded.git_sha == "abc123def456"
@@ -140,7 +141,7 @@ def test_git_sha_roundtrips_through_save_load(tmp_path: Path) -> None:
 def test_git_sha_none_roundtrips_through_save_load(tmp_path: Path) -> None:
     """git_sha=None round-trips correctly (persisted as null, restored as None)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=None)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=None)
     saved = idx.save(tmp_path / "index.json")
     loaded = CallGraphIndex.load(saved)
     assert loaded.git_sha is None
@@ -149,7 +150,7 @@ def test_git_sha_none_roundtrips_through_save_load(tmp_path: Path) -> None:
 def test_content_hash_roundtrips_through_save_load(tmp_path: Path) -> None:
     """content_hash is persisted on save and identical after load."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     saved = idx.save(tmp_path / "index.json")
     loaded = CallGraphIndex.load(saved)
     assert loaded.content_hash == idx.content_hash
@@ -159,7 +160,7 @@ def test_content_hash_roundtrips_through_save_load(tmp_path: Path) -> None:
 def test_saved_payload_has_git_sha_and_content_hash_keys(tmp_path: Path) -> None:
     """Serialised index JSON must contain git_sha and content_hash keys."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha="deadbeef")
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha="deadbeef")
     saved = idx.save(tmp_path / "index.json")
     payload = json.loads(saved.read_text())
     assert "git_sha" in payload, "git_sha must be present in saved index"
@@ -175,7 +176,7 @@ def test_saved_payload_has_git_sha_and_content_hash_keys(tmp_path: Path) -> None
 def test_callers_of_has_dropped_field(tmp_path: Path) -> None:
     """callers_of result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.callers_of("pkg.mod.bar", depth=1)
     assert "dropped" in result, "callers_of must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -185,7 +186,7 @@ def test_callers_of_has_dropped_field(tmp_path: Path) -> None:
 def test_callees_of_has_dropped_field(tmp_path: Path) -> None:
     """callees_of result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.callees_of("pkg.mod.foo", depth=1)
     assert "dropped" in result, "callees_of must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -195,7 +196,7 @@ def test_callees_of_has_dropped_field(tmp_path: Path) -> None:
 def test_module_callers_has_dropped_field(tmp_path: Path) -> None:
     """module_callers result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.module_callers("pkg.mod", depth=1)
     assert "dropped" in result, "module_callers must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -205,7 +206,7 @@ def test_module_callers_has_dropped_field(tmp_path: Path) -> None:
 def test_module_callees_has_dropped_field(tmp_path: Path) -> None:
     """module_callees result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.module_callees("pkg.other", depth=1)
     assert "dropped" in result, "module_callees must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -271,7 +272,7 @@ async def _run_server(server, lines: list[bytes]) -> list[dict]:
 def _server_with_index(tmp_path: Path):
     """A server fixture wired to a fresh minimal index."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     idx_path = tmp_path / "index.json"
     idx.save(idx_path)
 
@@ -407,8 +408,6 @@ def test_hub_suppression_index_accepts_git_sha(tmp_path: Path) -> None:
         "pkg.app.entry_point": ["pkg.utils.shared_helper"],
     }
     # Must not raise
-    idx = CallGraphIndex.from_raw(
-        str(tmp_path), raw, git_sha="cafebabe01234567"
-    )
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha="cafebabe01234567")
     assert idx.git_sha == "cafebabe01234567"
     assert idx.content_hash  # populated, non-empty

--- a/tests/test_component_issue66.py
+++ b/tests/test_component_issue66.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -136,7 +137,7 @@ class TestB1GraphToTypes:
         merge from **commit to a manual copy could omit or coerce fields.
         """
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", return_value=_git_ok(_MOCK_HEAD_SHA)):
             result = idx.callers_of("pkg.mod.beta", depth=1)
@@ -165,7 +166,7 @@ class TestB1GraphToTypes:
         would be absent from the dict entirely rather than present with None.
         """
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
             result = idx.stats()
@@ -187,7 +188,7 @@ class TestB1GraphToTypes:
         to SearchResult; a merge that drops the value would silently be False/None.
         """
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", return_value=_git_ok(_MOCK_HEAD_SHA)):
             result = idx.search("alpha")
@@ -215,7 +216,7 @@ class TestB2ServerGraphBuildRpcLoop:
     def _wired_server(self, tmp_path: Path):
         """Server fixture with a real saved index, hooked into the RPC loop."""
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
         idx_path = tmp_path / "index.json"
         idx.save(idx_path)
 

--- a/tests/test_component_issue69.py
+++ b/tests/test_component_issue69.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 import pyscope_mcp.server as _srv
 
 
@@ -70,9 +71,9 @@ def _make_index_with_skeleton(tmp_path: Path) -> CallGraphIndex:
     # omit file_shas (pre-v3 mode triggers stale=True) or provide matching shas.
     # Use file_shas=None to get pre-v3 staleness path — that still exercises the
     # success case skeleton content correctly.
-    return CallGraphIndex.from_raw(
+    return CallGraphIndex.from_nodes(
         str(tmp_path),
-        raw,
+        make_nodes(raw),
         skeletons=skeletons,
         file_shas=None,  # pre-v3: stale=True path, but results still returned
     )
@@ -153,7 +154,7 @@ class TestB1FqnNotFoundErrorPropagation:
     def _wired_server(self, tmp_path: Path):
         """Server fixture with a real in-memory index, wired into the RPC loop."""
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=None)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=None)
         idx_path = tmp_path / "index.json"
         idx.save(idx_path)
 
@@ -182,7 +183,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -202,7 +203,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-graph] callees_of with absent FQN returns isError:True dict."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -218,7 +219,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-graph] neighborhood with absent FQN returns isError:True dict."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -240,7 +241,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange — pkg.other.gamma has no callers in the raw graph
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -261,7 +262,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-graph] callees_of a known FQN with zero callees returns results:[] not isError."""
         # Arrange — pkg.mod.beta has no callees
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -279,7 +280,7 @@ class TestB1FqnNotFoundErrorPropagation:
         # Arrange — add a node with no edges
         raw = _make_minimal_raw()
         raw["pkg.mod.isolated"] = []
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -310,7 +311,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 
@@ -340,7 +341,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-server] _dispatch_tool('callees_of', bad FQN) surfaces isError:true."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 
@@ -364,7 +365,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-server] _dispatch_tool('neighborhood', bad FQN) surfaces isError:true."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 
@@ -391,7 +392,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 from pyscope_mcp.analyzer.pipeline import _extract_skeletons, _first_def_line
 
 
@@ -34,7 +35,7 @@ def _make_index_with_skeletons(skeletons: dict, file_shas: dict | None = None) -
     Pass ``file_shas=None`` (the default) to simulate a pre-v3 index.
     Pass ``file_shas={}`` (or a populated dict) to simulate a v3 index.
     """
-    return CallGraphIndex.from_raw("/tmp/test", {}, skeletons=skeletons, file_shas=file_shas)
+    return CallGraphIndex.from_nodes("/tmp/test", make_nodes({}), skeletons=skeletons, file_shas=file_shas)
 
 
 def _parse(source: str) -> ast.Module:
@@ -254,7 +255,7 @@ def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
         _make_symbol("pkg.mod.MyClass", "class", 1),
         _make_symbol("pkg.mod.MyClass.run", "method", 5),
     ]
-    idx = CallGraphIndex.from_raw("/tmp/test", {"pkg.mod.MyClass.run": []}, skeletons={"mod.py": symbols})
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({"pkg.mod.MyClass.run": []}), skeletons={"mod.py": symbols})
     out = tmp_path / "index.json"
     idx.save(out)
 
@@ -269,7 +270,7 @@ def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
 def test_save_version_is_current(tmp_path: Path) -> None:
     """Saved index must have the current INDEX_VERSION."""
     from pyscope_mcp.graph import INDEX_VERSION
-    idx = CallGraphIndex.from_raw("/tmp/test", {})
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({}))
     out = tmp_path / "index.json"
     idx.save(out)
     payload = _json.loads(out.read_text())
@@ -279,7 +280,7 @@ def test_save_version_is_current(tmp_path: Path) -> None:
 def test_save_includes_file_shas(tmp_path: Path) -> None:
     """Saved index includes file_shas key."""
     shas = {"mod.py": "abc123"}
-    idx = CallGraphIndex.from_raw("/tmp/test", {}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({}), file_shas=shas)
     out = tmp_path / "index.json"
     idx.save(out)
     payload = _json.loads(out.read_text())
@@ -290,7 +291,7 @@ def test_save_includes_file_shas(tmp_path: Path) -> None:
 def test_save_load_roundtrip_file_shas(tmp_path: Path) -> None:
     """file_shas survive save() → load() intact."""
     shas = {"a.py": "deadbeef", "b.py": "cafebabe"}
-    idx = CallGraphIndex.from_raw("/tmp/test", {}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({}), file_shas=shas)
     out = tmp_path / "index.json"
     idx.save(out)
     loaded = CallGraphIndex.load(out)
@@ -353,7 +354,7 @@ def test_file_skeleton_stale_sha_match(tmp_path: Path) -> None:
 
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": _sha256(content)}
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=shas)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is False
@@ -371,7 +372,7 @@ def test_file_skeleton_stale_sha_mismatch(tmp_path: Path) -> None:
 
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": _sha256(original)}  # stored hash is of original content
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=shas)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
@@ -387,7 +388,7 @@ def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": "somehex"}
     # Don't create the file on disk
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=shas)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
@@ -399,7 +400,7 @@ def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
 
 def test_file_skeleton_stale_file_not_in_index(tmp_path: Path) -> None:
     """Scenario D: v3 index, path not in skeletons → isError: true, error_reason: 'path_not_in_index', stale: false."""
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={}, file_shas={})
 
     result = idx.file_skeleton("new_mod.py")
     assert result["isError"] is True
@@ -414,7 +415,7 @@ def test_file_skeleton_stale_pre_v3_index(tmp_path: Path) -> None:
     """Scenario E: pre-v3 index (file_shas=None) → stale: true, index_format_incompatible."""
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     # file_shas=None simulates loading a v1 or v2 index
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=None)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=None)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -831,3 +831,151 @@ def test_neighborhood_hub_fields_always_present_isolated() -> None:
     assert "hub_threshold" in result
     assert result["hub_suppressed"] == []
     assert isinstance(result["hub_threshold"], int)
+
+
+# ---------------------------------------------------------------------------
+# Issue #84 — Schema + index model migration (epic #76 child #1)
+#
+# These tests pin the four acceptance scenarios from issue #84:
+#   1. Save/load round-trip with the new ``nodes`` shape
+#   2. Old-shape (v5 with ``raw``, or any v<5) indexes are rejected
+#   3. ``MissLog.to_dict()`` takes no arguments
+#   4. Deterministic JSON serialisation across insertion orders
+# ---------------------------------------------------------------------------
+
+import pytest
+
+from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+
+
+def _sample_nodes() -> dict[str, dict]:
+    return {
+        "pkg.mod.foo": {
+            "calls": {"call": ["pkg.mod.bar"]},
+            "called_by": {},
+        },
+        "pkg.mod.bar": {
+            "calls": {},
+            "called_by": {"call": ["pkg.mod.foo"]},
+        },
+    }
+
+
+def test_load_version_5_roundtrip(tmp_path: Path) -> None:
+    """Scenario 1: save() then load() with the new ``nodes`` shape preserves edges and stats."""
+    idx = CallGraphIndex.from_nodes(str(tmp_path), _sample_nodes())
+    out = tmp_path / "index.json"
+    idx.save(out)
+
+    raw_payload = json.loads(out.read_text())
+    assert raw_payload["version"] == INDEX_VERSION == 5
+    assert "nodes" in raw_payload
+    assert "raw" not in raw_payload
+
+    loaded = CallGraphIndex.load(out)
+    assert loaded.stats() == idx.stats()
+    # Forward edge available via callees_of
+    callees = loaded.callees_of("pkg.mod.foo", depth=1)
+    assert callees["results"] == ["pkg.mod.bar"]
+    # Reverse edge available via callers_of (rebuilt _DiGraph._pred)
+    callers = loaded.callers_of("pkg.mod.bar", depth=1)
+    assert callers["results"] == ["pkg.mod.foo"]
+
+
+def test_load_legacy_v5_raw_payload_raises(tmp_path: Path) -> None:
+    """Scenario 2: a v5 payload that still uses the legacy ``raw`` field is rejected.
+
+    Pre-migration v5 indexes (epic #76 in-flight) wrote ``raw`` instead of
+    ``nodes``.  The clear-error contract says: rebuild required, no migration
+    shim (Corollary 1.3/4.3).  The error message must mention both
+    ``version`` (so the user knows it's a schema issue) and ``build`` (so they
+    know how to fix it).
+    """
+    legacy_v5 = {
+        "version": 5,
+        "root": str(tmp_path),
+        "raw": {"pkg.mod.foo": ["pkg.mod.bar"]},
+        "skeletons": {},
+        "file_shas": {},
+        "missed_callers": {},
+    }
+    idx_path = tmp_path / "legacy_v5.json"
+    idx_path.write_text(json.dumps(legacy_v5))
+    with pytest.raises(ValueError, match="build"):
+        CallGraphIndex.load(idx_path)
+
+
+def test_misslog_to_dict_takes_no_arguments() -> None:
+    """Scenario 3: ``MissLog.to_dict()`` is callable with no positional args."""
+    from pyscope_mcp.analyzer.misses import MissLog
+
+    log = MissLog()
+    log.record_call_edge("pkg.mod.foo", "pkg.mod.bar")
+    log.record_call_edge("pkg.mod.foo", "pkg.mod.baz")
+    # No arguments — no raw, no known_fqns
+    report = log.to_dict()
+    assert "summary" in report
+    # dead_keys: callers with no in-edges (foo is the only caller; it has no in-edges)
+    assert report["summary"]["rollups"]["dead_keys"] == ["pkg.mod.foo"]
+
+
+def test_deterministic_serialization(tmp_path: Path) -> None:
+    """Scenario 4: same edges in different insertion orders → byte-identical JSON."""
+    nodes_a: dict[str, dict] = {
+        "pkg.a": {"calls": {"call": ["pkg.b", "pkg.c"]}, "called_by": {}},
+        "pkg.b": {"calls": {}, "called_by": {"call": ["pkg.a"]}},
+        "pkg.c": {"calls": {}, "called_by": {"call": ["pkg.a"]}},
+    }
+    # Reverse insertion order; reverse list orders too.
+    nodes_b: dict[str, dict] = {}
+    nodes_b["pkg.c"] = {"calls": {}, "called_by": {"call": ["pkg.a"]}}
+    nodes_b["pkg.b"] = {"calls": {}, "called_by": {"call": ["pkg.a"]}}
+    nodes_b["pkg.a"] = {"calls": {"call": ["pkg.c", "pkg.a"][::-1]}, "called_by": {}}
+    # Note: nodes_b["pkg.a"]["calls"]["call"] is now ["pkg.a","pkg.c"] reversed → ["pkg.c","pkg.a"]
+    # We want the same edge set as nodes_a, just supplied in a different list order.
+    nodes_b["pkg.a"]["calls"]["call"] = ["pkg.c", "pkg.b"]
+
+    idx_a = CallGraphIndex.from_nodes(str(tmp_path), nodes_a)
+    idx_b = CallGraphIndex.from_nodes(str(tmp_path), nodes_b)
+    path_a = tmp_path / "a.json"
+    path_b = tmp_path / "b.json"
+    idx_a.save(path_a)
+    idx_b.save(path_b)
+
+    assert path_a.read_bytes() == path_b.read_bytes(), (
+        "Same edges in different insertion / list orders must produce "
+        "byte-identical JSON output (Corollary 3.2 — determinism)."
+    )
+
+
+def test_from_raw_delegates_to_from_nodes(tmp_path: Path) -> None:
+    """Backwards-compat: ``from_raw`` still works and yields the same graph as ``from_nodes``."""
+    raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    # Forward edges visible
+    callees = idx.callees_of("pkg.mod.foo", depth=1)
+    assert callees["results"] == ["pkg.mod.bar"]
+    # Reverse edges visible (build-time inversion happened in _raw_to_nodes)
+    callers = idx.callers_of("pkg.mod.bar", depth=1)
+    assert callers["results"] == ["pkg.mod.foo"]
+    # ``raw`` property projects nodes → raw shape
+    assert idx.raw == {"pkg.mod.foo": ["pkg.mod.bar"]}
+
+
+def test_save_uses_sort_keys_true(tmp_path: Path) -> None:
+    """The on-disk JSON must have sorted top-level keys (sort_keys=True).
+
+    This is a structural prerequisite for Scenario 4 (determinism); also a
+    practical aid for human inspection of the index.  We assert the literal
+    output contains keys in sorted order at the top level.
+    """
+    idx = CallGraphIndex.from_nodes(str(tmp_path), _sample_nodes())
+    out = tmp_path / "index.json"
+    idx.save(out)
+    text = out.read_text()
+    # The first key emitted should be alphabetically first among the
+    # top-level payload keys: content_hash < file_shas < git_sha < missed_callers
+    # < nodes < root < skeletons < version.  ``content_hash`` wins.
+    assert text.startswith('{"content_hash":'), (
+        f"save() must use sort_keys=True; first 60 chars: {text[:60]!r}"
+    )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 
 
 def _sample_raw() -> dict[str, list[str]]:
@@ -15,7 +16,7 @@ def _sample_raw() -> dict[str, list[str]]:
 
 
 def test_from_raw_builds_graphs() -> None:
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     stats = idx.stats()
     assert stats["functions"] >= 3
     assert stats["function_edges"] == 2
@@ -23,7 +24,7 @@ def test_from_raw_builds_graphs() -> None:
 
 
 def test_queries() -> None:
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # callers_of / callees_of now return dict shapes
     callees = idx.callees_of("sample.a.top", depth=1)
     assert isinstance(callees, dict)
@@ -48,7 +49,7 @@ def test_queries() -> None:
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     from pyscope_mcp.graph import INDEX_VERSION
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     out = tmp_path / "index.json"
     idx.save(out)
 
@@ -92,7 +93,7 @@ def _prefix_raw() -> dict[str, list[str]]:
 
 def test_module_callers_prefix_match() -> None:
     """module_callers with a prefix returns callers of all matched modules."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("pkg.agents")
     assert result["truncated"] is False
     # pkg.core calls into pkg.agents.writer and pkg.agents.reader
@@ -104,7 +105,7 @@ def test_module_callers_prefix_match() -> None:
 
 def test_module_callees_prefix_match() -> None:
     """module_callees with a prefix returns callees of all matched modules."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("pkg.agents")
     assert result["truncated"] is False
     # pkg.agents.writer calls pkg.io.disk; pkg.agents.reader calls pkg.io.network
@@ -114,7 +115,7 @@ def test_module_callees_prefix_match() -> None:
 
 def test_module_callers_exact_match_backward_compat() -> None:
     """An exact FQN returns the same callers as before, now in structured form."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("pkg.agents.writer")
     assert isinstance(result, dict)
     assert "results" in result
@@ -125,7 +126,7 @@ def test_module_callers_exact_match_backward_compat() -> None:
 
 def test_module_callers_no_match() -> None:
     """A prefix matching no module nodes returns empty results, no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("nonexistent.pkg")
     assert result["results"] == []
     assert result["truncated"] is False
@@ -134,7 +135,7 @@ def test_module_callers_no_match() -> None:
 
 def test_module_callees_no_match() -> None:
     """A prefix matching no module nodes returns empty results, no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("nonexistent.pkg")
     assert result["results"] == []
     assert result["truncated"] is False
@@ -143,7 +144,7 @@ def test_module_callees_no_match() -> None:
 
 def test_module_callers_empty_prefix() -> None:
     """Empty-string prefix matches all modules; returns structured dict with no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("")
     # All modules are seeds — callers within the same set are excluded.
     # The important invariants are shape and no error.
@@ -156,7 +157,7 @@ def test_module_callers_empty_prefix() -> None:
 
 def test_module_callees_empty_prefix() -> None:
     """Empty-string prefix matches all modules; returns structured dict with no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("")
     assert isinstance(result, dict)
     assert "results" in result
@@ -172,7 +173,7 @@ def test_module_callers_truncation() -> None:
     for i in range(60):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callers("target")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -185,7 +186,7 @@ def test_module_callees_truncation() -> None:
     }
     for i in range(60):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callees("source")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -195,7 +196,7 @@ def test_search_truncation() -> None:
     """When matches exceed the cap, truncated=True and total_matched reflects the full count."""
     # Build a raw graph with 5 symbols all containing "fn"
     raw = {f"pkg.mod.fn{i}": [] for i in range(5)}
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
 
     # Cap at 3 — should truncate
     result = idx.search("fn", limit=3)
@@ -222,7 +223,7 @@ def test_search_truncation() -> None:
 
 def test_callers_of_returns_dict() -> None:
     """callers_of returns {results: list[str], truncated: bool}, not a bare list."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callers_of("sample.b.helper", depth=1)
     assert isinstance(result, dict)
     assert "results" in result
@@ -234,7 +235,7 @@ def test_callers_of_returns_dict() -> None:
 
 def test_callees_of_returns_dict() -> None:
     """callees_of returns {results: list[str], truncated: bool}, not a bare list."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callees_of("sample.a.top", depth=1)
     assert isinstance(result, dict)
     assert "results" in result
@@ -251,7 +252,7 @@ def test_callers_of_truncation() -> None:
     for i in range(60):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callers_of("target.core.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -264,7 +265,7 @@ def test_callees_of_truncation() -> None:
     }
     for i in range(60):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callees_of("source.mod.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -276,7 +277,7 @@ def test_callees_of_truncation() -> None:
 
 def test_callers_of_dropped_zero_when_not_truncated() -> None:
     """dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callers_of("sample.b.helper", depth=1)
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -285,7 +286,7 @@ def test_callers_of_dropped_zero_when_not_truncated() -> None:
 
 def test_callees_of_dropped_zero_when_not_truncated() -> None:
     """dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callees_of("sample.a.top", depth=1)
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -298,7 +299,7 @@ def test_callers_of_dropped_correct_when_truncated() -> None:
     for i in range(57):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callers_of("target.core.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -312,7 +313,7 @@ def test_callees_of_dropped_correct_when_truncated() -> None:
     }
     for i in range(57):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callees_of("source.mod.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -347,7 +348,7 @@ def _ranking_raw_callers() -> dict[str, list[str]]:
 
 def test_callers_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
     """Depth-1 callers appear before depth-2 callers in results, even when alphabetically later."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _ranking_raw_callers())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_ranking_raw_callers()))
     result = idx.callers_of("target.fn", depth=2)
 
     # depth-1 callers must be present despite sorting alphabetically after a_depth2 nodes
@@ -391,7 +392,7 @@ def _ranking_raw_callees() -> dict[str, list[str]]:
 
 def test_callees_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
     """Depth-1 callees appear before depth-2 callees, even when alphabetically later."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _ranking_raw_callees())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_ranking_raw_callees()))
     result = idx.callees_of("source.fn", depth=2)
 
     # depth-1 callees: bridge.mod.fn, z_depth1.mod.fn, y_depth1.mod.fn
@@ -424,7 +425,7 @@ def test_callees_of_depth1_precede_depth2_when_alphabetical_would_invert() -> No
 
 def test_module_callers_dropped_zero_when_not_truncated() -> None:
     """module_callers: dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("pkg.agents")
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -433,7 +434,7 @@ def test_module_callers_dropped_zero_when_not_truncated() -> None:
 
 def test_module_callees_dropped_zero_when_not_truncated() -> None:
     """module_callees: dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("pkg.agents")
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -446,7 +447,7 @@ def test_module_callers_dropped_correct_when_truncated() -> None:
     for i in range(57):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callers("target")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -460,7 +461,7 @@ def test_module_callees_dropped_correct_when_truncated() -> None:
     }
     for i in range(57):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callees("source")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -478,7 +479,7 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
     raw["z_depth1.mod.fn"] = ["target.fn"]
     raw["y_depth1.mod.fn"] = ["target.fn"]
     raw["target.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callers("target", depth=2)
 
     assert "z_depth1.mod" in result["results"], (
@@ -498,7 +499,7 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
 
 def test_callers_of_fqn_not_in_graph() -> None:
     """callers_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callers_of("no.such.fqn")
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
@@ -509,7 +510,7 @@ def test_callers_of_fqn_not_in_graph() -> None:
 
 def test_callees_of_fqn_not_in_graph() -> None:
     """callees_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callees_of("no.such.fqn")
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
@@ -520,7 +521,7 @@ def test_callees_of_fqn_not_in_graph() -> None:
 
 def test_callers_of_known_zero_callers() -> None:
     """callers_of on an FQN with no callers returns results:[], not an error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # sample.a.top has no callers
     result = idx.callers_of("sample.a.top")
     assert result.get("isError") is not True
@@ -531,7 +532,7 @@ def test_callers_of_known_zero_callers() -> None:
 
 def test_callees_of_known_zero_callees() -> None:
     """callees_of on an FQN with no callees returns results:[], not an error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # sample.b.inner has no callees
     result = idx.callees_of("sample.b.inner")
     assert result.get("isError") is not True
@@ -559,7 +560,7 @@ def _neighborhood_raw() -> dict[str, list[str]]:
 
 def test_neighborhood_non_truncated() -> None:
     """neighborhood with generous budget returns all edges, truncated=False."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     result = idx.neighborhood("b.middle", depth=2, token_budget=10000)
     assert result["symbol"] == "b.middle"
     assert result["truncated"] is False
@@ -575,7 +576,7 @@ def test_neighborhood_non_truncated() -> None:
 
 def test_neighborhood_truncated() -> None:
     """neighborhood with tiny budget truncates and sets depth_truncated."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     # Budget of 1 token = 4 chars, which cannot fit any edge
     result = idx.neighborhood("b.middle", depth=2, token_budget=1)
     assert result["truncated"] is True
@@ -588,7 +589,7 @@ def test_neighborhood_truncated() -> None:
 
 def test_neighborhood_token_budget_enforced() -> None:
     """neighborhood response content fits within token_budget * 4 chars."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     token_budget = 5  # very tight
     result = idx.neighborhood("b.middle", depth=2, token_budget=token_budget)
     # The edges JSON representation must fit strictly within the budget.
@@ -599,7 +600,7 @@ def test_neighborhood_token_budget_enforced() -> None:
 
 def test_neighborhood_unknown_symbol() -> None:
     """neighborhood on a symbol not in the graph returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     result = idx.neighborhood("nonexistent.symbol", depth=2, token_budget=1000)
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
@@ -610,7 +611,7 @@ def test_neighborhood_unknown_symbol() -> None:
 
 def test_neighborhood_depth_full_reflects_graph() -> None:
     """depth_full reflects actual graph depth, not declared depth parameter."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     # Graph has max depth 2 from b.middle; requesting depth=5 should give depth_full <= 2
     result = idx.neighborhood("b.middle", depth=5, token_budget=10000)
     assert result["depth_full"] <= 2
@@ -618,7 +619,7 @@ def test_neighborhood_depth_full_reflects_graph() -> None:
 
 def test_neighborhood_edges_deduplicated() -> None:
     """Each edge appears at most once in the result."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     result = idx.neighborhood("b.middle", depth=3, token_budget=10000)
     edge_tuples = [tuple(e) for e in result["edges"]]
     assert len(edge_tuples) == len(set(edge_tuples)), "Edges must be deduplicated"
@@ -626,7 +627,7 @@ def test_neighborhood_edges_deduplicated() -> None:
 
 def test_neighborhood_deterministic() -> None:
     """Same input always produces the same output (Law 3)."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     r1 = idx.neighborhood("b.middle", depth=2, token_budget=10000)
     r2 = idx.neighborhood("b.middle", depth=2, token_budget=10000)
     assert r1["edges"] == r2["edges"]
@@ -661,7 +662,7 @@ def _hub_raw() -> dict[str, list[str]]:
 
 def test_hub_suppression_default_on() -> None:
     """Hub suppression: default call suppresses high-in-degree H; expand_hubs=True does not."""
-    idx = CallGraphIndex.from_raw("/tmp/hub", _hub_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/hub", make_nodes(_hub_raw()))
 
     # Default: suppression on — H's other callers must NOT appear
     result = idx.neighborhood("queried.symbol", depth=2, token_budget=100000)
@@ -712,7 +713,7 @@ def test_hub_suppression_non_hub_unchanged() -> None:
         "c.leaf": [],
         "d.caller": ["a.top"],
     }
-    idx = CallGraphIndex.from_raw("/tmp/nonhub", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/nonhub", make_nodes(raw))
     result = idx.neighborhood("a.top", depth=2, token_budget=100000)
     assert result["hub_suppressed"] == [], (
         f"Expected empty hub_suppressed, got {result['hub_suppressed']}"
@@ -734,7 +735,7 @@ def test_hub_suppression_symbol_is_hub_exemption() -> None:
     for i in range(20):
         raw[f"caller_{i}"] = ["H"]
 
-    idx = CallGraphIndex.from_raw("/tmp/hubself", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/hubself", make_nodes(raw))
     # Calling neighborhood directly on H — H is exempt
     result = idx.neighborhood("H", depth=2, token_budget=100000)
     # H's callers must appear (queried symbol exempt from suppression)
@@ -755,7 +756,7 @@ def test_hub_suppression_out_degree_not_suppressed() -> None:
     for i in range(30):
         raw[f"callee_{i}"] = []
 
-    idx = CallGraphIndex.from_raw("/tmp/outdeg", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/outdeg", make_nodes(raw))
     result = idx.neighborhood("queried.symbol", depth=2, token_budget=100000)
 
     # M should NOT be in hub_suppressed (only in-degree triggers suppression)
@@ -772,7 +773,7 @@ def test_hub_suppression_out_degree_not_suppressed() -> None:
 
 def test_hub_suppression_per_call_threshold_override() -> None:
     """Per-call hub_threshold override: response echoes the override value."""
-    idx = CallGraphIndex.from_raw("/tmp/hub", _hub_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/hub", make_nodes(_hub_raw()))
 
     # H has 20 callers. Override threshold to 100 → H is NOT a hub at that threshold.
     result_high = idx.neighborhood("queried.symbol", depth=2, token_budget=100000, hub_threshold=100)
@@ -792,7 +793,7 @@ def test_hub_suppression_per_call_threshold_override() -> None:
 def test_hub_threshold_attribute_after_construction() -> None:
     """_in_degree_threshold is computed at from_raw time with floor of 10."""
     # Tiny graph — all nodes have in-degree 0 or 1; p99 will be below floor
-    idx = CallGraphIndex.from_raw("/tmp/small", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/small", make_nodes(_neighborhood_raw()))
     assert hasattr(idx, "_in_degree_threshold"), "_in_degree_threshold must exist on index"
     assert idx._in_degree_threshold >= 10, (
         f"Threshold must be >= 10 (floor), got {idx._in_degree_threshold}"
@@ -806,7 +807,7 @@ def test_hub_threshold_attribute_reflects_distribution() -> None:
     raw: dict[str, list[str]] = {"hub.node": []}
     for i in range(100):
         raw[f"caller_{i}"] = ["hub.node"]
-    idx = CallGraphIndex.from_raw("/tmp/p99test", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/p99test", make_nodes(raw))
     # p99 of in-degree distribution: 99 nodes have in-degree 0, hub.node has 100
     # p99_idx = int(0.99 * 101) = 99; sorted list: [0]*100 + [100] at index 100 → 100
     # but p99_idx=99 → value=0; floor=10 → threshold=10.
@@ -821,7 +822,7 @@ def test_neighborhood_hub_fields_always_present_isolated() -> None:
     # We add "b.isolated" as a standalone caller with an empty callees list.
     raw = _neighborhood_raw()
     raw["b.isolated"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.neighborhood("b.isolated", depth=2, token_budget=10000)
     # An isolated-but-present node returns empty edges, not an error
     assert result.get("isError") is not True
@@ -951,7 +952,7 @@ def test_deterministic_serialization(tmp_path: Path) -> None:
 def test_from_raw_delegates_to_from_nodes(tmp_path: Path) -> None:
     """Backwards-compat: ``from_raw`` still works and yields the same graph as ``from_nodes``."""
     raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     # Forward edges visible
     callees = idx.callees_of("pkg.mod.foo", depth=1)
     assert callees["results"] == ["pkg.mod.bar"]
@@ -979,3 +980,139 @@ def test_save_uses_sort_keys_true(tmp_path: Path) -> None:
     assert text.startswith('{"content_hash":'), (
         f"save() must use sort_keys=True; first 60 chars: {text[:60]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Determinism property (epic #76 invariant: Corollary 3.2)
+#
+# Same logical edges → byte-identical JSON, regardless of insertion order.
+# This is the test that protects the Law 3 hash-check contract from
+# regressions: anywhere the inversion phase or save() picks up a stray
+# unsorted iteration, this test fails.
+# ---------------------------------------------------------------------------
+
+
+def test_save_byte_identical_across_insertion_orders(tmp_path: Path) -> None:
+    """Two indexes from the same logical edges, items inserted in opposite
+    orders, must produce byte-identical JSON files when saved.
+
+    This catches non-determinism in either ``make_nodes`` (inversion +
+    sort) or ``CallGraphIndex.save`` (canonical layout).  Dict equality
+    alone would not catch a JSON-key ordering bug — we compare the raw
+    bytes the consumer would hash for staleness detection.
+    """
+    edges = [
+        ("pkg.a.alpha", "pkg.b.beta"),
+        ("pkg.a.alpha", "pkg.c.gamma"),
+        ("pkg.b.beta", "pkg.d.delta"),
+        ("pkg.c.gamma", "pkg.d.delta"),
+        ("pkg.c.gamma", "pkg.e.epsilon"),
+        ("pkg.d.delta", "pkg.f.zeta"),
+        ("pkg.f.zeta", "pkg.a.alpha"),  # cycle for good measure
+    ]
+
+    def to_raw(pairs: list[tuple[str, str]]) -> dict[str, list[str]]:
+        out: dict[str, list[str]] = {}
+        for caller, callee in pairs:
+            out.setdefault(caller, []).append(callee)
+        return out
+
+    forward_raw = to_raw(edges)
+    # Same logical edges, but iterate in reversed insertion order so any
+    # order-sensitive code path (sets, dict iteration, sort key ties) has
+    # a chance to diverge.
+    reversed_raw = to_raw(list(reversed(edges)))
+    # Also reverse callee lists within each caller bucket to maximise
+    # iteration-order divergence — the canonical output must still match.
+    for k in reversed_raw:
+        reversed_raw[k] = list(reversed(reversed_raw[k]))
+
+    idx1 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(forward_raw))
+    idx2 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(reversed_raw))
+
+    p1 = tmp_path / "idx1.json"
+    p2 = tmp_path / "idx2.json"
+    idx1.save(p1)
+    idx2.save(p2)
+
+    bytes1 = p1.read_bytes()
+    bytes2 = p2.read_bytes()
+    assert bytes1 == bytes2, (
+        "save() output is not byte-identical across insertion orders — "
+        "Law 3 hash-check contract is broken (Corollary 3.2 violation)."
+    )
+
+    # The content_hash header itself must also match, since it is derived
+    # from the same canonical projection.
+    assert idx1.content_hash == idx2.content_hash
+
+
+# ---------------------------------------------------------------------------
+# Per-kind error isolation (epic #76 invariant: Corollary 1.2 / 4.2 per-kind)
+#
+# A failing visitor for one kind on one file must not drop other kinds'
+# edges for that file.  At the data layer, this means: if a node's
+# ``calls.import`` bucket is missing/empty (because the import visitor
+# raised), the node's ``calls.call`` bucket must remain intact and visible
+# through the public query API.
+# ---------------------------------------------------------------------------
+
+
+def test_per_kind_isolation_call_edges_survive_missing_import_bucket(
+    tmp_path: Path,
+) -> None:
+    """Simulate a visitor failure on the import kind (no import bucket
+    populated) and assert that call edges from the same caller remain
+    visible through ``callers_of`` / ``callees_of`` and the ``nodes`` map.
+
+    Per-kind isolation is enforced inside the visitor (each ``visit_*``
+    wraps its body in try/except + ``_warn_kind_failure``).  This test
+    asserts the *consequence* at the data layer: a node with a failing
+    kind shows the empty bucket while other kinds remain unaffected.
+    """
+    # Build a nodes dict where pkg.mod.caller has call edges populated
+    # but its (hypothetical) import bucket is absent — exactly what the
+    # visitor produces when visit_Import raises before any _emit fires.
+    nodes: dict[str, dict] = {
+        "pkg.mod.caller": {
+            "calls": {"call": ["pkg.helpers.helper_a", "pkg.helpers.helper_b"]},
+            "called_by": {},
+        },
+        "pkg.helpers.helper_a": {
+            "calls": {},
+            "called_by": {"call": ["pkg.mod.caller"]},
+        },
+        "pkg.helpers.helper_b": {
+            "calls": {},
+            "called_by": {"call": ["pkg.mod.caller"]},
+        },
+        # Another caller in the same package that has BOTH call and
+        # import buckets populated — proves isolation is per (file, kind),
+        # not all-or-nothing across files.
+        "pkg.other.caller": {
+            "calls": {
+                "call": ["pkg.helpers.helper_a"],
+                "import": ["json"],
+            },
+            "called_by": {},
+        },
+        "json": {"calls": {}, "called_by": {"import": ["pkg.other.caller"]}},
+    }
+    idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+    # Call edges from the import-failing caller are intact.
+    callees = idx.callees_of("pkg.mod.caller", depth=1)
+    assert sorted(callees["results"]) == [
+        "pkg.helpers.helper_a",
+        "pkg.helpers.helper_b",
+    ]
+    # Import bucket on that caller is absent, not synthesised.
+    assert "import" not in idx.nodes["pkg.mod.caller"].get("calls", {})
+    # The other caller's call AND import edges are both intact — per-kind
+    # isolation is per (caller, kind), not file-global.
+    other_calls = idx.nodes["pkg.other.caller"]["calls"]
+    assert other_calls.get("call") == ["pkg.helpers.helper_a"]
+    assert other_calls.get("import") == ["json"]
+    # Reverse view also intact for the unaffected kinds.
+    a_callers = idx.callers_of("pkg.helpers.helper_a", depth=1)
+    assert sorted(a_callers["results"]) == ["pkg.mod.caller", "pkg.other.caller"]

--- a/tests/test_hub_suppression_integration.py
+++ b/tests/test_hub_suppression_integration.py
@@ -72,8 +72,8 @@ def test_analyzer_resolves_hub_callers(hub_idx: CallGraphIndex) -> None:
     """Analyzer must produce >= N_EXTRA_CALLERS+1 in-edges for shared_helper."""
     in_degree = sum(
         1
-        for callees in hub_idx.raw.values()
-        if "hub_fixture.utils.shared_helper" in callees
+        for node in hub_idx.nodes.values()
+        if "hub_fixture.utils.shared_helper" in node.get("calls", {}).get("call", [])
     )
     assert in_degree >= _N_EXTRA_CALLERS + 1, (
         f"Expected >= {_N_EXTRA_CALLERS + 1} callers of shared_helper, "

--- a/tests/test_misses_summary_rates.py
+++ b/tests/test_misses_summary_rates.py
@@ -33,7 +33,7 @@ def _make_log(
 
 
 def _summary(log: MissLog) -> dict:
-    return log.to_dict(raw={}, known_fqns=set())["summary"]
+    return log.to_dict()["summary"]
 
 
 def test_empty_log_emits_zero_rates() -> None:

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,0 +1,160 @@
+"""Benchmarks for the constitutional Law 2 / Law 4 budgets.
+
+Two budgets are protected here:
+
+- **Law 2 — cold-load p95 < 500 ms** on the self-index.  Measured by
+  spawning 10 fresh ``python`` subprocesses and timing
+  ``CallGraphIndex.load`` end-to-end (process startup + JSON parse +
+  ``from_nodes`` rebuild).  We use subprocesses to defeat any in-process
+  caching and replicate what an MCP client experiences when the server
+  starts.
+
+- **Law 4 — full build < 60 s** on the self-index.  A single in-process
+  measurement of ``build_nodes_with_report`` + ``CallGraphIndex.save``.
+  Build cost is dominated by file I/O and AST parsing; an in-process
+  measurement is faithful to what ``pyscope-mcp build`` does.
+
+These tests are environment-sensitive — they target real wall-clock
+budgets, so they may be noisy on a hot CI runner but they are the only
+way to falsify the kill criterion in epic #76's intent doc.  When the
+self-index does not exist on disk yet, the cold-load test builds it
+once at module setup.
+"""
+
+from __future__ import annotations
+
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "pyscope_mcp"
+SRC_ROOT = REPO_ROOT / "src"
+INDEX_PATH = REPO_ROOT / ".pyscope-mcp" / "index.json"
+
+# Number of subprocess timings for the cold-load p95 test.  10 is the
+# minimum sample size that lets ``statistics.quantiles(n=20)[18]`` resolve
+# the 95th percentile usefully — fewer samples and the metric is noisy.
+_COLD_LOAD_SAMPLES = 10
+
+# Per-attempt timeout (seconds) for the cold-load subprocess.  A real
+# breach of the 500 ms budget will still complete in well under a second;
+# the timeout here just keeps a hung subprocess from stalling the suite.
+_COLD_LOAD_PROCESS_TIMEOUT = 10.0
+
+
+def _build_self_index_inplace() -> None:
+    """Build the pyscope-mcp self-index at the canonical location.
+
+    Used by the cold-load test as a setup step when no index exists yet.
+    Writes to the same path the CLI's ``build`` subcommand would write.
+    """
+    from pyscope_mcp.analyzer.pipeline import build_nodes_with_report
+    from pyscope_mcp.graph import CallGraphIndex
+
+    nodes, _report, skeletons, file_shas = build_nodes_with_report(
+        SRC_ROOT, PACKAGE
+    )
+    idx = CallGraphIndex.from_nodes(
+        SRC_ROOT, nodes, skeletons=skeletons, file_shas=file_shas
+    )
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    idx.save(INDEX_PATH)
+
+
+def _ensure_self_index_exists() -> None:
+    if not INDEX_PATH.exists():
+        _build_self_index_inplace()
+
+
+def test_cold_load_p95_under_500ms() -> None:
+    """Law 2 — cold-load p95 must stay under 500 ms on the self-index.
+
+    Spawns 10 fresh Python subprocesses, each timing
+    ``CallGraphIndex.load(INDEX_PATH)`` end-to-end and printing the
+    elapsed seconds to stdout.  Asserts ``p95 < 0.5``.
+
+    This is the canonical falsifier for epic #76's kill criterion: a
+    sustained breach here means the site-keyed shape lost the Law 2 budget
+    and the bucket-by-kind fallback should be revisited.
+    """
+    _ensure_self_index_exists()
+
+    timings: list[float] = []
+    snippet = (
+        "import time, sys; "
+        "from pyscope_mcp.graph import CallGraphIndex; "
+        f"_p = r'{INDEX_PATH}'; "
+        "_t = time.perf_counter(); "
+        "CallGraphIndex.load(_p); "
+        "sys.stdout.write(f'{time.perf_counter() - _t:.6f}')"
+    )
+    for _ in range(_COLD_LOAD_SAMPLES):
+        result = subprocess.run(
+            [sys.executable, "-c", snippet],
+            capture_output=True,
+            text=True,
+            timeout=_COLD_LOAD_PROCESS_TIMEOUT,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0, (
+            f"cold-load subprocess failed: {result.stderr}"
+        )
+        out = result.stdout.strip()
+        assert out, "cold-load subprocess produced no timing output"
+        timings.append(float(out))
+
+    timings.sort()
+    # Compute p95.  ``statistics.quantiles(n=20)`` returns the 19 cut points
+    # of the distribution; index 18 is the 95th percentile.
+    p95 = statistics.quantiles(timings, n=20)[18]
+    median = statistics.median(timings)
+    print(
+        f"cold-load timings (s): median={median:.4f} p95={p95:.4f} "
+        f"min={min(timings):.4f} max={max(timings):.4f} "
+        f"all={[f'{t:.4f}' for t in timings]}"
+    )
+    assert p95 < 0.5, (
+        f"Law 2 budget breached: cold-load p95 = {p95*1000:.1f} ms "
+        f"(>= 500 ms ceiling).  See epic #76 kill criterion."
+    )
+
+
+def test_full_build_under_60s() -> None:
+    """Law 4 — a fresh build of the self-index must finish within 60 s.
+
+    Times ``build_nodes_with_report`` + ``CallGraphIndex.save`` on the
+    pyscope-mcp source tree.  This is the single-shot equivalent of what
+    ``pyscope-mcp build`` does; the budget includes pass 1 (discovery),
+    pass 2 (visitors), build-time inversion, and serialisation.
+    """
+    from pyscope_mcp.analyzer.pipeline import build_nodes_with_report
+    from pyscope_mcp.graph import CallGraphIndex
+
+    start = time.perf_counter()
+    nodes, _report, skeletons, file_shas = build_nodes_with_report(
+        SRC_ROOT, PACKAGE
+    )
+    idx = CallGraphIndex.from_nodes(
+        SRC_ROOT, nodes, skeletons=skeletons, file_shas=file_shas
+    )
+    # Save to a temporary location to avoid clobbering a pre-existing
+    # canonical index that other tests in the same run may rely on.
+    tmp_out = REPO_ROOT / ".pyscope-mcp" / "index.benchmark.json"
+    tmp_out.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        idx.save(tmp_out)
+        elapsed = time.perf_counter() - start
+    finally:
+        if tmp_out.exists():
+            tmp_out.unlink()
+
+    print(f"full build time: {elapsed:.2f} s")
+    assert elapsed < 60.0, (
+        f"Law 4 budget breached: full build took {elapsed:.1f} s "
+        f"(>= 60 s ceiling).  Investigate analyzer regressions."
+    )

--- a/tests/test_query_logger.py
+++ b/tests/test_query_logger.py
@@ -27,6 +27,7 @@ import pytest
 
 from pyscope_mcp._rpc import RpcServer
 from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +104,7 @@ def raw_graph() -> dict[str, list[str]]:
 @pytest.fixture()
 def tmp_index(tmp_path: Path, raw_graph: dict) -> Path:
     """Minimal v5 index on disk."""
-    idx = CallGraphIndex.from_raw(tmp_path, raw_graph)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_graph))
     idx_path = tmp_path / ".pyscope-mcp" / "index.json"
     idx.save(idx_path)
     return idx_path
@@ -235,7 +236,7 @@ def hub_index(tmp_path: Path) -> Path:
         raw[f"pkg.agent.worker_{i}.run"] = ["pkg.util.common"]
     # Add the target symbol
     raw["pkg.mod.target"] = ["pkg.util.common", "pkg.agent.worker_0.run"]
-    idx = CallGraphIndex.from_raw(tmp_path, raw)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
     idx_path = tmp_path / ".pyscope-mcp" / "index.json"
     idx.save(idx_path)
     return idx_path
@@ -375,8 +376,8 @@ async def test_s6_reload_updates_index_identity(tmp_path: Path):
     # Build two different indexes.
     raw_a = {"pkg.a.foo": ["pkg.a.bar"], "pkg.a.bar": []}
     raw_b = {"pkg.b.hello": ["pkg.b.world"], "pkg.b.world": []}
-    idx_a = CallGraphIndex.from_raw(tmp_path, raw_a)
-    idx_b = CallGraphIndex.from_raw(tmp_path, raw_b)
+    idx_a = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_a))
+    idx_b = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_b))
     idx_path = tmp_path / ".pyscope-mcp" / "index.json"
     idx_a.save(idx_path)
 
@@ -464,7 +465,7 @@ def test_s8_v5_roundtrip_git_sha_content_hash(tmp_path: Path):
     raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
     fake_sha = "a1b2c3d4e5f6789012345678901234567890abcd"
 
-    idx = CallGraphIndex.from_raw(tmp_path, raw, git_sha=fake_sha)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw), git_sha=fake_sha)
     assert idx.git_sha == fake_sha
     assert len(idx.content_hash) == 64  # SHA-256 hex
 
@@ -484,8 +485,8 @@ def test_s8_v5_roundtrip_git_sha_content_hash(tmp_path: Path):
 def test_s8_content_hash_is_deterministic(tmp_path: Path):
     """S8: two builds against the same raw dict produce the same content_hash."""
     raw = {"pkg.mod.foo": ["pkg.mod.bar", "pkg.mod.baz"], "pkg.mod.bar": [], "pkg.mod.baz": []}
-    idx1 = CallGraphIndex.from_raw(tmp_path, raw)
-    idx2 = CallGraphIndex.from_raw(tmp_path, raw)
+    idx1 = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
+    idx2 = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
     assert idx1.content_hash == idx2.content_hash
     assert len(idx1.content_hash) == 64
 
@@ -493,7 +494,7 @@ def test_s8_content_hash_is_deterministic(tmp_path: Path):
 def test_s8_non_git_build_produces_none_git_sha(tmp_path: Path):
     """S8: building without a git_sha produces git_sha=None; load/serve still work."""
     raw = {"pkg.mod.foo": []}
-    idx = CallGraphIndex.from_raw(tmp_path, raw, git_sha=None)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw), git_sha=None)
     assert idx.git_sha is None
     idx_path = tmp_path / "index.json"
     idx.save(idx_path)
@@ -526,6 +527,6 @@ def test_s8_different_raw_produces_different_hash(tmp_path: Path):
     """S8: different raw dicts produce different content hashes."""
     raw_a = {"pkg.a.foo": ["pkg.a.bar"], "pkg.a.bar": []}
     raw_b = {"pkg.b.hello": ["pkg.b.world"], "pkg.b.world": []}
-    idx_a = CallGraphIndex.from_raw(tmp_path, raw_a)
-    idx_b = CallGraphIndex.from_raw(tmp_path, raw_b)
+    idx_a = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_a))
+    idx_b = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_b))
     assert idx_a.content_hash != idx_b.content_hash

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -31,6 +31,7 @@ from pyscope_mcp._rpc import (
     RpcServer,
 )
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +123,7 @@ def tmp_index(tmp_path: Path) -> Path:
         "pkg.mod.bar": [],
         "pkg.other.baz": ["pkg.mod.foo"],
     }
-    idx = CallGraphIndex.from_raw(tmp_path, raw)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
     idx_path = tmp_path / "index.json"
     idx.save(idx_path)
     return idx_path
@@ -1079,7 +1080,7 @@ async def test_reload_reflects_disk_change(server: RpcServer, tmp_index: Path):
         "a.b.f": [],
         "x.y.z": ["a.b.c"],
     }
-    new_idx = CallGraphIndex.from_raw(tmp_index.parent, new_raw)
+    new_idx = CallGraphIndex.from_nodes(tmp_index.parent, make_nodes(new_raw))
     new_idx.save(tmp_index)
 
     # Call reload then stats; must reflect the new counts.

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import make_nodes
+
 
 def _send(proc: subprocess.Popen, msg: dict) -> None:
     assert proc.stdin is not None
@@ -51,7 +53,7 @@ def index_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
         "pkg.mod.bar": [],
     }
     out_dir = tmp_path_factory.mktemp("pyscope_idx")
-    idx = CallGraphIndex.from_raw(out_dir, raw)
+    idx = CallGraphIndex.from_nodes(out_dir, make_nodes(raw))
     out = out_dir / "index.json"
     idx.save(out)
     return out

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +37,7 @@ def _make_idx(
     skeletons: dict[str, list[SymbolSummary]],
     file_shas: dict[str, str] | None,
 ) -> CallGraphIndex:
-    return CallGraphIndex.from_raw(str(tmp_path), raw, skeletons=skeletons, file_shas=file_shas)
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), skeletons=skeletons, file_shas=file_shas)
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +50,7 @@ def test_fqn_to_file_populated(tmp_path: Path) -> None:
         "src/pkg/mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")],
         "src/pkg/other.py": [_sym("pkg.other.fn_c")],
     }
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons=skeletons, file_shas={})
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons=skeletons, file_shas={})
     assert idx._fqn_to_file["pkg.mod.fn_a"] == "src/pkg/mod.py"
     assert idx._fqn_to_file["pkg.mod.fn_b"] == "src/pkg/mod.py"
     assert idx._fqn_to_file["pkg.other.fn_c"] == "src/pkg/other.py"
@@ -57,7 +58,7 @@ def test_fqn_to_file_populated(tmp_path: Path) -> None:
 
 def test_fqn_to_file_empty_skeletons(tmp_path: Path) -> None:
     """Empty skeletons produce an empty _fqn_to_file."""
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={}, file_shas={})
     assert idx._fqn_to_file == {}
 
 


### PR DESCRIPTION
Closes #76
Closes #84
Closes #85
Closes #86

## Epic Summary

Replaces the caller-keyed adjacency index (`raw: {caller_fqn: [callee_fqn, ...]}`) with a site-keyed graph (`nodes: {fqn: {calls: {kind: [...]}, called_by: {kind: [...]}}}`) carrying five edge kinds (`call`, `import`, `except`, `annotation`, `isinstance`). The shape was chosen to align canonical storage with the dominant access pattern (reverse-direction queries outnumber forward 19:3 in observed agent investigation patterns), to natively carry kind tags that every queued consumer issue (#71, #57, #58, #74) requires, and to converge with Kythe's per-symbol serving-table shape. The migration is a one-shot `INDEX_VERSION` bump (4 to 5) with no shim — old indexes raise a clear "rebuild required" error per Corollary 1.3/4.3. Build-time inversion (loose <60s budget) replaces load-time inversion (strict <500ms budget), moving cost from the strict path to the loose path as the constitution prescribes.

## Sub-Issues Resolved

| # | Issue | PR | Title | Summary |
|---|-------|----|-------|---------|
| 1 | #84 | #88 | Schema + index model migration | Bumps `INDEX_VERSION` to 5, replaces `raw` with `nodes` on disk, refactors `MissLog.to_dict()` to take no arguments, adds deterministic `save()` with sorted kind buckets and `sort_keys=True`. Retains `raw` as a read-only call-only projection so the test corpus keeps working until #86. |
| 2 | #85 | #89 | Analyzer: new edge kind visitors + build-time inversion | Adds `visit_Import`, `visit_ImportFrom`, `visit_ExceptHandler`, `visit_AnnAssign`, plus annotation scanning in function signatures and an `isinstance` carve-out inside `visit_Call`. Each new visitor wraps its body in per-kind `try/except` for Corollary 1.2/4.2 isolation. Adds `build_nodes_with_report` which assembles the site-keyed shape via deterministic build-time inversion and wires it into `cli.cmd_build`. |
| 3 | #86 | #90 | Test suite migration and new property tests | Adds `tests/conftest.py` with a `make_nodes(raw, kind="call")` converter and migrates ~140 `from_raw(...)` call sites across 13 test files to `from_nodes(..., make_nodes(...))`. Adds a byte-identical determinism property test, a per-kind isolation test, and `tests/test_perf.py` with cold-load p95 (Law 2) and full-build (Law 4) benchmarks against the self-index. |

## Architecture Decisions

- **Site-keyed shape over bucket-by-kind forward [ONE-WAY-DOOR].** Symbol-centric storage matches the observed access pattern, generalizes naturally to per-symbol attributes the project knows it wants (definition site, symbol kind, member skeleton), and converges with Kythe's serving-layer shape. The kill criterion (cold-load p95 >500ms after optimization) would force a fallback to bucket-by-kind forward; the benchmark in this PR confirms it does not fire.
- **Build-time inversion over load-time inversion [EXPENSIVE-TO-REVERSE].** The analyzer emits forward edges per file; a deterministic build-final step assembles `called_by` per symbol before serialization. Cost moves from the strict <500ms serve path to the loose <60s build path, as Laws 2 and 4 prescribe.
- **Edge kinds restricted to call, import, except, annotation, isinstance [REVERSIBLE].** `attr_access` and `subclass` deferred to follow-ups despite being identified as strong candidates in the original epic body — bundling new visitors compounded migration risk. The site-keyed schema accommodates them additively when they land.
- **Keep `_DiGraph` for in-memory traversal [REVERSIBLE].** Tools' traversal logic does not change in this epic. The site-keyed JSON is parsed at load, then `_DiGraph` is rebuilt from `nodes[s].calls.call`. Dual storage of the reverse direction (JSON `called_by` plus `_DiGraph._pred`) is accepted as a deliberate migration-risk mitigation; native site-keyed traversal is an additive cleanup for a future epic.
- **Refactor `MissLog.to_dict` in this epic [REVERSIBLE].** No `raw`-shaped projection synthesis to keep the old API alive — misses logic changes once, alongside the schema.

## Implementation Walkthrough

**Index model and on-disk format.** `src/pyscope_mcp/graph.py` gains a `nodes` dataclass field carrying the site-keyed records. `from_nodes` is the new canonical constructor; `from_raw` is preserved as a back-compat shim that calls `_raw_to_nodes` and delegates. `save()` writes only `nodes` (no `raw` key), bumps `version` to 5, and uses `json.dumps(..., sort_keys=True)` over a payload whose kind buckets and per-kind lists are pre-sorted by `_invert_to_nodes`. `load()` rejects any version other than 5 and any v5 payload missing the `nodes` key (catching pre-migration in-flight v5s) with errors that explicitly mention `version` and `build`. The legacy `raw` field is now a read-only `@property` that projects `nodes` back to the call-only adjacency dict so existing consumers keep working through the transitional window.

**Analyzer extensions.** `src/pyscope_mcp/analyzer/visitor.py` introduces `EdgeVisitor.kind_edges` (`caller -> kind -> set[callee]`) as the canonical per-caller storage; the legacy `self.edges` view is kept as a derived call-only projection so the existing aggregation in `pipeline.py` keeps working unmodified. New visitor methods (`visit_Import`, `visit_ImportFrom`, `visit_ExceptHandler`, `visit_AnnAssign`, plus `_scan_function_annotations` invoked from `visit_FunctionDef`/`visit_AsyncFunctionDef`) emit kind-tagged edges with a per-method `try/except` that routes failures through `_warn_kind_failure` so a failure in one kind on one file does not drop other kinds' edges from that file. The `isinstance` carve-out lives inside `visit_Call` (`_try_emit_isinstance_edge`) so the builtin does not pollute the miss log or appear as a spurious `call` edge; tuple form `isinstance(x, (A, B))` emits one edge per element. Annotation handling unwraps `Subscript` (e.g. `list[Foo]`) and PEP 604 `BinOp` unions (e.g. `Foo | Bar`) so generic and union annotations contribute the right inner types.

**Build pipeline.** `src/pyscope_mcp/analyzer/pipeline.py` adds `build_nodes_with_report`, which runs the per-file visitor pass, aggregates `all_kind_edges`, then invokes `_invert_to_nodes` to assemble the site-keyed dict — sorted symbols, sorted kind keys, sorted per-kind callee/caller lists. The legacy `build_with_report` and `build_raw` still return the old shape so the test corpus migration could land independently. `cli.cmd_build` switches to `build_nodes_with_report` plus `CallGraphIndex.from_nodes`, which is what gets non-call kinds onto disk.

**Test corpus.** `tests/conftest.py` (new) provides `make_nodes(raw, kind="call")`, a single converter that expands the compact `{caller: [callees]}` author form into the site-keyed shape `from_nodes` expects. Centralising the converter is what makes Success Metric 3 (next-edge-kind PR touches <10 fixtures) achievable. ~140 fixture call sites across 13 test files now read `CallGraphIndex.from_nodes(..., make_nodes(...))`. Two integration tests that previously read `idx.raw.items()` / `idx.raw.values()` now traverse `idx.nodes` directly. The new property tests (`test_save_byte_identical_across_insertion_orders`, `test_per_kind_isolation_call_edges_survive_missing_import_bucket`) and the new `tests/test_perf.py` (cold-load p95 and full-build budget against the self-index) gate Corollary 3.2, Corollary 1.2/4.2, Law 2, and Law 4 respectively.

## QA Checklist

**These checks should be performed by a human reviewer before merging into `main`:**

- [ ] Cold-load benchmark: run `pyscope-mcp build && pyscope-mcp serve` on the self-index, measure p95 startup time across 10 cold starts — must be <500ms (Law 2).
- [ ] Build benchmark: run `pyscope-mcp build` on the self-index — must complete <60s (Law 4).
- [ ] Rebuild required for old indexes: confirm that running `pyscope-mcp serve` against a pre-migration index raises a clear descriptive error.
- [ ] All 8 MCP tools return identical shapes to pre-migration (callers_of, callees_of, module_callers, module_callees, neighborhood, file_skeleton, search, stats).
- [ ] New edge kinds appear in output: verify `callers_of` returns import edges with `kind="import"` for a known module import.
- [ ] Per-kind error isolation: confirm that introducing a deliberate AST error in one visitor method does not drop edges from other kinds.
- [ ] All existing tests pass (`pytest` — 729 tests).
- [ ] Ruff lint clean (`ruff check src/`).

## Acceptance Criteria

From `.agent-work/EPIC_76_VERIFICATION.md` — all 8 acceptance criteria met:

1. **Schema replaced; old indexes invalid; version bumped.** `INDEX_VERSION = 5` in `graph.py`. `save()` writes `nodes`, never `raw`. `load()` rejects non-v5 versions and v5 payloads missing the `nodes` key with clear errors. Pinned by `test_load_version_5_roundtrip` and `test_load_legacy_v5_raw_payload_raises`.
2. **All existing MCP tools work; no observable behavior change.** All 729 tests pass on the epic branch — no regressions in `test_rpc_server.py`, `test_rpc_stdio_e2e.py`, `test_completeness.py`, `test_file_skeleton.py`, `test_component_issue62/66/69.py`. `from_nodes` populates the same `function_graph` / `module_graph` `_DiGraph` instances, preserving traversal semantics.
3. **New edge kinds emitted and indexed.** `call`, `import`, `except`, `annotation`, `isinstance` all present and indexed. Decision for `attr_access` / `subclass` recorded in `intent.md` Section 3 (deferred to follow-ups, schema accommodates them).
4. **Cold load <500ms p95 on self-index (Law 2).** `tests/test_perf.py::test_cold_load_p95_under_500ms` builds the self-index then spawns 10 fresh subprocesses; p95 measured ~50ms on the dev container, well under budget.
5. **Build time <60s on self-index (Law 4).** `tests/test_perf.py::test_full_build_under_60s` times `build_nodes_with_report` + `save`; measured ~1s.
6. **Determinism property test in place.** `test_inversion_is_deterministic` (analyzer level), `test_deterministic_serialization` (byte-identical JSON across insertion orders), `test_save_uses_sort_keys_true`.
7. **Per-file error isolation extends per-kind.** `test_per_kind_isolation_failure_in_annotation_does_not_drop_call_edges` monkey-patches `_scan_annotation` to raise; `call`, `except`, and `import` edges from the same file all survive.
8. **CLAUDE.md updated.** "Unresolved edges" section rewritten to close the axon/confidence direction; the misses-as-telemetry contract is now explicit.

## Outstanding Items

- `_DiGraph` elimination (deferred to a future epic — keeping it reduces migration blast radius; native site-keyed traversal is an additive cleanup).
- `attr_access` and `subclass` edge kinds (deferred to follow-up issues alongside #71, #74).
- Incremental rebuild (future epic; fan-out story for site-keyed is not worse than adjacency, just not yet implemented).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)