### PR TITLE
feat(#84): migrate index to site-keyed nodes shape

### DIFF
--- a/src/pyscope_mcp/analyzer/misses.py
+++ b/src/pyscope_mcp/analyzer/misses.py
@@ -245,6 +245,13 @@ class MissLog:
         self.accepted_counts: dict[str, int] = {}
         self.builtin_method_modules: Counter[str] = Counter()
 
+        # v5 (epic #76 child #1): dead_keys are callers with no incoming
+        # call edges.  We accumulate the caller / callee universes here so
+        # to_dict() can derive dead_keys without taking the legacy ``raw``
+        # dict as a parameter.
+        self._call_callers: set[str] = set()
+        self._call_callees: set[str] = set()
+
     def record_miss(
         self,
         pattern: str,
@@ -285,7 +292,19 @@ class MissLog:
         if pattern == "builtin_method_call":
             self.builtin_method_modules[file_path] += 1
 
-    def to_dict(self, raw: dict[str, list[str]], known_fqns: set[str]) -> dict:
+    def record_call_edge(self, caller: str, callee: str) -> None:
+        """Track a resolved call edge for dead_keys computation.
+
+        Pipeline calls this for every (caller, callee) pair that lands in the
+        final edge dict.  ``to_dict()`` derives ``dead_keys`` as
+        ``sorted(callers - callees)`` from the accumulated sets — the same
+        semantics the pre-migration ``to_dict(raw, known_fqns)`` produced
+        from the ``raw`` dict.
+        """
+        self._call_callers.add(caller)
+        self._call_callees.add(callee)
+
+    def to_dict(self) -> dict:
         """Assemble the full misses.json structure."""
         total = self.calls_total
         in_pkg = self.calls_resolved_in_package
@@ -302,10 +321,10 @@ class MissLog:
         for pattern in sorted(self.unresolved_calls):
             flat_unresolved.extend(self.unresolved_calls[pattern])
 
-        all_callees: set[str] = set()
-        for callees in raw.values():
-            all_callees.update(callees)
-        dead_keys = sorted(k for k in raw if k not in all_callees)
+        # dead_keys: callers that no edge points to — derived from per-edge
+        # tracking in record_call_edge (pre-migration this was computed
+        # from the ``raw`` dict argument).
+        dead_keys = sorted(self._call_callers - self._call_callees)
 
         # unreferenced_modules: requires module_fqns keyset not threaded here.
         unreferenced_modules: list[str] = []

--- a/src/pyscope_mcp/analyzer/pipeline.py
+++ b/src/pyscope_mcp/analyzer/pipeline.py
@@ -124,6 +124,13 @@ def build_with_report(
 ) -> tuple[dict[str, list[str]], dict, dict[str, list[dict]], dict[str, str]]:
     """Pass 1 + pass 2 with MissLog. Returns (raw_edges, miss_report_dict, skeletons, file_shas).
 
+    Returns the legacy caller-keyed ``{caller: [callees]}`` raw shape — the
+    site-keyed v5 inversion happens at the index boundary
+    (``CallGraphIndex.from_nodes`` / ``CallGraphIndex.save``) so this slice
+    (epic #76 child #1) can land without disturbing the analyzer test corpus.
+    Build-pipeline inversion (Child #2/#3) will move the inversion phase here
+    in a follow-up.
+
     ``skeletons`` maps relative file paths to pre-computed symbol lists suitable
     for storage in the index under the ``skeletons`` key (version 3 schema).
 
@@ -217,7 +224,13 @@ def build_with_report(
             _warn(f"error processing {fqn} in pass 2: {type(exc).__name__}: {exc}")
 
     raw = {caller: sorted(callees) for caller, callees in sorted(all_edges.items())}
-    report = miss_log.to_dict(raw, known_fqns)
+    # Track every (caller, callee) pair so MissLog.to_dict() can derive
+    # dead_keys without taking the legacy raw dict as a parameter (epic #76
+    # child #1 — the to_dict signature change).
+    for caller, callees in raw.items():
+        for callee in callees:
+            miss_log.record_call_edge(caller, callee)
+    report = miss_log.to_dict()
     skeletons = _extract_skeletons(root, parsed)
     return raw, report, skeletons, file_shas
 

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -124,27 +124,87 @@ class _DiGraphReverseView:
         )
 
 
-def _compute_content_hash(raw: dict[str, list[str]]) -> str:
-    """Return SHA-256 hex digest of the deterministically serialised *raw* dict.
+def _compute_content_hash(nodes: dict[str, dict]) -> str:
+    """Return SHA-256 hex digest of the deterministically serialised *nodes* dict.
+
+    Hashes the canonical (sorted) projection of the call edges in the
+    site-keyed shape: ``nodes[caller]["calls"]["call"]``.  Only ``call`` edges
+    contribute today (matching pre-migration semantics so freshness checks
+    survive the schema bump for repos that have not added other kinds yet).
 
     Sorted keys and sorted callee lists ensure the same graph always yields
     the same hash, regardless of insertion order.
     """
-    canonical = json.dumps(
-        {k: sorted(v) for k, v in sorted(raw.items())},
-        separators=(",", ":"),
-    ).encode()
+    projection: dict[str, list[str]] = {}
+    for caller in sorted(nodes):
+        record = nodes[caller]
+        callees = list(record.get("calls", {}).get("call", ()))
+        if callees:
+            projection[caller] = sorted(callees)
+    canonical = json.dumps(projection, separators=(",", ":")).encode()
     return hashlib.sha256(canonical).hexdigest()
+
+
+def _raw_to_nodes(raw: dict[str, list[str]]) -> dict[str, dict]:
+    """Convert legacy ``raw`` (caller → [callees]) to site-keyed ``nodes`` shape.
+
+    Build-time inversion: every ``(caller, callee)`` pair in *raw* yields
+    ``nodes[caller]["calls"]["call"]`` (forward) and
+    ``nodes[callee]["called_by"]["call"]`` (reverse).  Both endpoints get a
+    ``NodeRecord`` skeleton with sorted, deduplicated lists per kind so the
+    serialisation determinism invariant (Corollary 3.2) holds regardless of
+    insertion order.
+    """
+    forward: dict[str, set[str]] = {}
+    reverse: dict[str, set[str]] = {}
+    for caller, callees in raw.items():
+        forward.setdefault(caller, set()).update(callees)
+        for callee in callees:
+            reverse.setdefault(callee, set()).add(caller)
+            forward.setdefault(callee, set())  # ensure callee node exists
+        # Keep callers with empty callee list as nodes too.
+        forward.setdefault(caller, set())
+
+    all_symbols = set(forward) | set(reverse)
+    nodes: dict[str, dict] = {}
+    for sym in sorted(all_symbols):
+        record: dict[str, dict[str, list[str]]] = {"calls": {}, "called_by": {}}
+        callees = forward.get(sym, set())
+        if callees:
+            record["calls"]["call"] = sorted(callees)
+        callers = reverse.get(sym, set())
+        if callers:
+            record["called_by"]["call"] = sorted(callers)
+        nodes[sym] = record
+    return nodes
+
+
+def _nodes_to_raw(nodes: dict[str, dict]) -> dict[str, list[str]]:
+    """Project the site-keyed ``nodes`` shape back to the legacy ``raw`` form.
+
+    Used to support the deprecated ``raw`` property and ``from_raw`` constructor
+    while Child #3 of epic #76 migrates the test corpus.  Only ``call`` edges
+    appear in the projection — non-call kinds are not part of the legacy
+    contract and are silently omitted (they remain available via
+    ``CallGraphIndex.nodes``).
+    """
+    out: dict[str, list[str]] = {}
+    for caller in sorted(nodes):
+        callees = nodes[caller].get("calls", {}).get("call")
+        if callees:
+            out[caller] = sorted(callees)
+    return out
 
 
 @dataclass
 class CallGraphIndex:
     """Function- and module-level call graph over a Python repo.
 
-    The source of truth is `raw`: a mapping {caller_fqn: [callee_fqn, ...]}.
-    Graphs are derived from `raw` on construction and on `load`. The backend
-    that populates `raw` from source code lives in pyscope_mcp.analyzer
-    (AST-based; fully implemented — see CLAUDE.md for the contract).
+    The source of truth is ``nodes``: a site-keyed mapping
+    ``{symbol_fqn: {"calls": {kind: [callees]}, "called_by": {kind: [callers]}}}``.
+    Graphs are derived from ``nodes[s]["calls"]["call"]`` on construction and
+    on ``load``.  The legacy ``raw`` property projects the same call edges in
+    the pre-migration shape for transitional callers.
 
     ``skeletons`` maps relative file paths → pre-computed lists of SymbolSummary
     dicts, populated during ``pyscope-mcp build`` (index version 2+).
@@ -153,7 +213,9 @@ class CallGraphIndex:
     root: Path
     function_graph: _DiGraph = field(default_factory=_DiGraph)
     module_graph: _DiGraph = field(default_factory=_DiGraph)
-    raw: dict[str, list[str]] = field(default_factory=dict)
+    # v5+: site-keyed nodes — replaces the legacy ``raw`` field.  The ``raw``
+    # property below derives a call-only projection for transitional callers.
+    nodes: dict[str, dict] = field(default_factory=dict)
     skeletons: dict[str, list[SymbolSummary]] = field(default_factory=dict)
     # None = pre-v3 index (no hashes stored); dict = v3/v5 index with per-file SHA256 digests.
     file_shas: dict[str, str] | None = field(default=None)
@@ -169,27 +231,49 @@ class CallGraphIndex:
     # Derived at load/from_raw time: maps FQN → relative file path (inverted from skeletons).
     # Not serialised — rebuilt on every load.
     _fqn_to_file: dict[str, str] = field(default_factory=dict, repr=False)
-    # Computed at from_raw time: p99 of in-degree distribution, floor of 10.
+    # Computed at from_nodes time: p99 of in-degree distribution, floor of 10.
     # Used by neighborhood() for hub suppression. Not serialised — recomputed on load.
     _in_degree_threshold: int = field(default=10, repr=False)
 
+    @property
+    def raw(self) -> dict[str, list[str]]:
+        """Legacy projection of ``nodes`` to ``{caller: [callees]}`` (call edges only).
+
+        Provided as a transitional read-only view for callers that have not
+        migrated to the ``nodes`` shape yet (Child #3 of epic #76 migrates
+        the remaining test fixtures).  New code should consume ``nodes``
+        directly to keep access to non-call edge kinds.
+        """
+        return _nodes_to_raw(self.nodes)
+
     @classmethod
-    def from_raw(
+    def from_nodes(
         cls,
         root: str | Path,
-        raw: dict[str, list[str]],
+        nodes: dict[str, dict],
         skeletons: dict[str, list[SymbolSummary]] | None = None,
         file_shas: dict[str, str] | None = None,
         missed_callers: dict[str, dict[str, int]] | None = None,
         git_sha: str | None = None,
     ) -> "CallGraphIndex":
+        """Construct a CallGraphIndex from the site-keyed ``nodes`` shape.
+
+        Populates ``function_graph`` and ``module_graph`` from
+        ``nodes[s]["calls"]["call"]`` only — non-call kinds are stored in
+        ``nodes`` but are not used by the existing graph traversal layer
+        (see Decision Prior "Keep _DiGraph" in epic #76's intent doc).
+        """
         root = Path(root).resolve()
         fg = _DiGraph()
         mg = _DiGraph()
-        for caller, callees in raw.items():
+        # Ensure every site key is a graph node, even when its calls bucket
+        # is empty (so callers_of returns empty results, not fqn_not_in_graph).
+        for caller in nodes:
             fg.add_node(caller)
+            mg.add_node(_module_of(caller))
+        for caller, record in nodes.items():
+            callees = record.get("calls", {}).get("call", ())
             cm = _module_of(caller)
-            mg.add_node(cm)
             for callee in callees:
                 fg.add_edge(caller, callee)
                 tm = _module_of(callee)
@@ -202,16 +286,14 @@ class CallGraphIndex:
             for sym in symbols:
                 fqn_to_file[sym["fqn"]] = rel_path
         # Compute in-degree threshold: p99 of in-degree distribution, floor of 10.
-        # One-time O(N) cost at index load; cached for O(1) lookup during BFS.
         in_degree_threshold = _compute_in_degree_threshold(fg)
-        # Compute content_hash: SHA-256 of the deterministically serialised raw dict.
-        # Sorted keys + sorted callee lists ensure same raw → same hash.
-        content_hash = _compute_content_hash(raw)
+        # Compute content_hash from the canonical projection of call edges.
+        content_hash = _compute_content_hash(nodes)
         return cls(
             root=root,
             function_graph=fg,
             module_graph=mg,
-            raw=raw,
+            nodes=nodes,
             skeletons=skeletons,
             file_shas=file_shas,
             missed_callers=missed_callers if missed_callers is not None else {},
@@ -221,20 +303,64 @@ class CallGraphIndex:
             _in_degree_threshold=in_degree_threshold,
         )
 
+    @classmethod
+    def from_raw(
+        cls,
+        root: str | Path,
+        raw: dict[str, list[str]],
+        skeletons: dict[str, list[SymbolSummary]] | None = None,
+        file_shas: dict[str, str] | None = None,
+        missed_callers: dict[str, dict[str, int]] | None = None,
+        git_sha: str | None = None,
+    ) -> "CallGraphIndex":
+        """Deprecated — convert legacy ``raw`` shape to ``nodes`` and delegate.
+
+        Retained for transitional callers (notably the test corpus that Child #3
+        of epic #76 will migrate).  New code should call :meth:`from_nodes`
+        directly so non-call edge kinds can be expressed.
+        """
+        nodes = _raw_to_nodes(raw)
+        return cls.from_nodes(
+            root,
+            nodes,
+            skeletons=skeletons,
+            file_shas=file_shas,
+            missed_callers=missed_callers,
+            git_sha=git_sha,
+        )
+
     def save(self, path: str | Path) -> Path:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Deterministic serialisation: sort node keys, sort kind keys within
+        # each calls/called_by bucket, sort each kind's list.  json.dumps with
+        # sort_keys=True handles the dict layers; we pre-sort the lists.
+        canonical_nodes: dict[str, dict] = {}
+        for sym in sorted(self.nodes):
+            record = self.nodes[sym]
+            calls_buckets = record.get("calls", {}) or {}
+            called_by_buckets = record.get("called_by", {}) or {}
+            canonical_nodes[sym] = {
+                "calls": {
+                    kind: sorted(calls_buckets[kind])
+                    for kind in sorted(calls_buckets)
+                },
+                "called_by": {
+                    kind: sorted(called_by_buckets[kind])
+                    for kind in sorted(called_by_buckets)
+                },
+            }
         payload: dict = {
             "version": INDEX_VERSION,
             "root": str(self.root),
-            "raw": self.raw,
+            "nodes": canonical_nodes,
             "skeletons": self.skeletons,
             "file_shas": self.file_shas if self.file_shas is not None else {},
             "missed_callers": self.missed_callers,
             "git_sha": self.git_sha,
             "content_hash": self.content_hash,
         }
-        path.write_text(json.dumps(payload))
+        path.write_text(json.dumps(payload, sort_keys=True))
         return path
 
     @classmethod
@@ -247,13 +373,22 @@ class CallGraphIndex:
                 f"index schema is v{version}, server requires v{INDEX_VERSION} — "
                 "run 'pyscope-mcp build' to regenerate"
             )
+        # Pre-migration v5 indexes wrote ``raw`` instead of ``nodes``.  Reject
+        # them with the same clear-error contract used for older versions —
+        # there is no migration shim (Corollary 1.3/4.3).
+        if "nodes" not in payload:
+            raise ValueError(
+                f"index schema is v{version} but uses the legacy 'raw' field; "
+                f"server requires v{INDEX_VERSION} with site-keyed 'nodes' — "
+                "run 'pyscope-mcp build' to regenerate"
+            )
         skeletons: dict[str, list[SymbolSummary]] = payload.get("skeletons", {})
         file_shas: dict[str, str] = payload.get("file_shas", {})
         missed_callers: dict[str, dict[str, int]] = payload.get("missed_callers", {})
         git_sha: str | None = payload.get("git_sha")
-        return cls.from_raw(
+        return cls.from_nodes(
             Path(payload["root"]),
-            payload["raw"],
+            payload["nodes"],
             skeletons=skeletons,
             file_shas=file_shas,
             missed_callers=missed_callers,

--- a/tests/test_analyzer_builtin_methods.py
+++ b/tests/test_analyzer_builtin_methods.py
@@ -137,7 +137,7 @@ def test_to_dict_rollup_top5() -> None:
     for _ in range(6):
         log.record_accepted("builtin_method_call", "f.py")
 
-    report = log.to_dict({}, set())
+    report = log.to_dict()
     summary = report["summary"]
 
     assert summary["calls_accepted"] == 21

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -831,3 +831,151 @@ def test_neighborhood_hub_fields_always_present_isolated() -> None:
     assert "hub_threshold" in result
     assert result["hub_suppressed"] == []
     assert isinstance(result["hub_threshold"], int)
+
+
+# ---------------------------------------------------------------------------
+# Issue #84 — Schema + index model migration (epic #76 child #1)
+#
+# These tests pin the four acceptance scenarios from issue #84:
+#   1. Save/load round-trip with the new ``nodes`` shape
+#   2. Old-shape (v5 with ``raw``, or any v<5) indexes are rejected
+#   3. ``MissLog.to_dict()`` takes no arguments
+#   4. Deterministic JSON serialisation across insertion orders
+# ---------------------------------------------------------------------------
+
+import pytest
+
+from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+
+
+def _sample_nodes() -> dict[str, dict]:
+    return {
+        "pkg.mod.foo": {
+            "calls": {"call": ["pkg.mod.bar"]},
+            "called_by": {},
+        },
+        "pkg.mod.bar": {
+            "calls": {},
+            "called_by": {"call": ["pkg.mod.foo"]},
+        },
+    }
+
+
+def test_load_version_5_roundtrip(tmp_path: Path) -> None:
+    """Scenario 1: save() then load() with the new ``nodes`` shape preserves edges and stats."""
+    idx = CallGraphIndex.from_nodes(str(tmp_path), _sample_nodes())
+    out = tmp_path / "index.json"
+    idx.save(out)
+
+    raw_payload = json.loads(out.read_text())
+    assert raw_payload["version"] == INDEX_VERSION == 5
+    assert "nodes" in raw_payload
+    assert "raw" not in raw_payload
+
+    loaded = CallGraphIndex.load(out)
+    assert loaded.stats() == idx.stats()
+    # Forward edge available via callees_of
+    callees = loaded.callees_of("pkg.mod.foo", depth=1)
+    assert callees["results"] == ["pkg.mod.bar"]
+    # Reverse edge available via callers_of (rebuilt _DiGraph._pred)
+    callers = loaded.callers_of("pkg.mod.bar", depth=1)
+    assert callers["results"] == ["pkg.mod.foo"]
+
+
+def test_load_legacy_v5_raw_payload_raises(tmp_path: Path) -> None:
+    """Scenario 2: a v5 payload that still uses the legacy ``raw`` field is rejected.
+
+    Pre-migration v5 indexes (epic #76 in-flight) wrote ``raw`` instead of
+    ``nodes``.  The clear-error contract says: rebuild required, no migration
+    shim (Corollary 1.3/4.3).  The error message must mention both
+    ``version`` (so the user knows it's a schema issue) and ``build`` (so they
+    know how to fix it).
+    """
+    legacy_v5 = {
+        "version": 5,
+        "root": str(tmp_path),
+        "raw": {"pkg.mod.foo": ["pkg.mod.bar"]},
+        "skeletons": {},
+        "file_shas": {},
+        "missed_callers": {},
+    }
+    idx_path = tmp_path / "legacy_v5.json"
+    idx_path.write_text(json.dumps(legacy_v5))
+    with pytest.raises(ValueError, match="build"):
+        CallGraphIndex.load(idx_path)
+
+
+def test_misslog_to_dict_takes_no_arguments() -> None:
+    """Scenario 3: ``MissLog.to_dict()`` is callable with no positional args."""
+    from pyscope_mcp.analyzer.misses import MissLog
+
+    log = MissLog()
+    log.record_call_edge("pkg.mod.foo", "pkg.mod.bar")
+    log.record_call_edge("pkg.mod.foo", "pkg.mod.baz")
+    # No arguments — no raw, no known_fqns
+    report = log.to_dict()
+    assert "summary" in report
+    # dead_keys: callers with no in-edges (foo is the only caller; it has no in-edges)
+    assert report["summary"]["rollups"]["dead_keys"] == ["pkg.mod.foo"]
+
+
+def test_deterministic_serialization(tmp_path: Path) -> None:
+    """Scenario 4: same edges in different insertion orders → byte-identical JSON."""
+    nodes_a: dict[str, dict] = {
+        "pkg.a": {"calls": {"call": ["pkg.b", "pkg.c"]}, "called_by": {}},
+        "pkg.b": {"calls": {}, "called_by": {"call": ["pkg.a"]}},
+        "pkg.c": {"calls": {}, "called_by": {"call": ["pkg.a"]}},
+    }
+    # Reverse insertion order; reverse list orders too.
+    nodes_b: dict[str, dict] = {}
+    nodes_b["pkg.c"] = {"calls": {}, "called_by": {"call": ["pkg.a"]}}
+    nodes_b["pkg.b"] = {"calls": {}, "called_by": {"call": ["pkg.a"]}}
+    nodes_b["pkg.a"] = {"calls": {"call": ["pkg.c", "pkg.a"][::-1]}, "called_by": {}}
+    # Note: nodes_b["pkg.a"]["calls"]["call"] is now ["pkg.a","pkg.c"] reversed → ["pkg.c","pkg.a"]
+    # We want the same edge set as nodes_a, just supplied in a different list order.
+    nodes_b["pkg.a"]["calls"]["call"] = ["pkg.c", "pkg.b"]
+
+    idx_a = CallGraphIndex.from_nodes(str(tmp_path), nodes_a)
+    idx_b = CallGraphIndex.from_nodes(str(tmp_path), nodes_b)
+    path_a = tmp_path / "a.json"
+    path_b = tmp_path / "b.json"
+    idx_a.save(path_a)
+    idx_b.save(path_b)
+
+    assert path_a.read_bytes() == path_b.read_bytes(), (
+        "Same edges in different insertion / list orders must produce "
+        "byte-identical JSON output (Corollary 3.2 — determinism)."
+    )
+
+
+def test_from_raw_delegates_to_from_nodes(tmp_path: Path) -> None:
+    """Backwards-compat: ``from_raw`` still works and yields the same graph as ``from_nodes``."""
+    raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
+    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    # Forward edges visible
+    callees = idx.callees_of("pkg.mod.foo", depth=1)
+    assert callees["results"] == ["pkg.mod.bar"]
+    # Reverse edges visible (build-time inversion happened in _raw_to_nodes)
+    callers = idx.callers_of("pkg.mod.bar", depth=1)
+    assert callers["results"] == ["pkg.mod.foo"]
+    # ``raw`` property projects nodes → raw shape
+    assert idx.raw == {"pkg.mod.foo": ["pkg.mod.bar"]}
+
+
+def test_save_uses_sort_keys_true(tmp_path: Path) -> None:
+    """The on-disk JSON must have sorted top-level keys (sort_keys=True).
+
+    This is a structural prerequisite for Scenario 4 (determinism); also a
+    practical aid for human inspection of the index.  We assert the literal
+    output contains keys in sorted order at the top level.
+    """
+    idx = CallGraphIndex.from_nodes(str(tmp_path), _sample_nodes())
+    out = tmp_path / "index.json"
+    idx.save(out)
+    text = out.read_text()
+    # The first key emitted should be alphabetically first among the
+    # top-level payload keys: content_hash < file_shas < git_sha < missed_callers
+    # < nodes < root < skeletons < version.  ``content_hash`` wins.
+    assert text.startswith('{"content_hash":'), (
+        f"save() must use sort_keys=True; first 60 chars: {text[:60]!r}"
+    )

--- a/tests/test_misses_summary_rates.py
+++ b/tests/test_misses_summary_rates.py
@@ -33,7 +33,7 @@ def _make_log(
 
 
 def _summary(log: MissLog) -> dict:
-    return log.to_dict(raw={}, known_fqns=set())["summary"]
+    return log.to_dict()["summary"]
 
 
 def test_empty_log_emits_zero_rates() -> None:


### PR DESCRIPTION
Closes #84. Epic #76 child #1.

## Summary

Replaces the on-disk ``raw: {caller: [callees]}`` storage with a site-keyed
``nodes: {symbol: {calls: {kind: [callees]}, called_by: {kind: [callers]}}}``
shape. Only the ``call`` kind populates today; the schema is shaped to
accommodate the ``import``, ``except``, ``annotation``, and ``isinstance``
kinds Child #2 will add without further schema work.

The four acceptance scenarios from the refined spec are pinned by new
tests in ``test_graph.py``:

1. **Save/load round-trip** — saving a ``from_nodes`` index produces a JSON
   with ``"version": 5`` and a top-level ``nodes`` key (no ``raw``);
   ``load`` reconstructs ``_DiGraph`` so both ``callees_of`` and
   ``callers_of`` resolve.
2. **Old-shape rejection** — pre-migration v5 indexes (still carrying the
   ``raw`` field) are rejected with a clear error mentioning ``version``
   and ``build``. Older versions (v1–v4) continue to fail with the same
   contract — no migration shim per Corollary 1.3/4.3.
3. **``MissLog.to_dict()`` takes no arguments** — ``dead_keys`` are derived
   from a new ``record_call_edge`` accumulator that the pipeline calls per
   resolved edge.
4. **Deterministic serialisation** — ``save()`` sorts kind keys, per-kind
   lists, and uses ``json.dumps(..., sort_keys=True)``. Same edges
   inserted in any order → byte-identical bytes.

## Scope discipline

This slice keeps ``build_with_report`` returning the legacy ``raw`` shape;
the ``raw`` → ``nodes`` inversion happens at the index boundary
(``CallGraphIndex.from_raw`` delegates to ``from_nodes`` via
``_raw_to_nodes``). Moving build-time inversion into the pipeline is
Child #2/#3 scope (epic #76 dependency graph). The slice independence
statement in the issue body permits this — Child #2 will fill in the
non-call kinds and ``called_by`` entries through the same shape.

The ``raw`` dataclass field is retained as a read-only **property** that
projects ``nodes`` back to the legacy shape, so the 100+ test usages of
``idx.raw`` in the analyzer corpus continue to work. Child #3 owns the
test corpus migration.

## Verification

- ``pytest`` — 709 tests pass (703 existing + 6 new).
- ``pyscope-mcp build`` on the self-repo produces a ``nodes``-shaped index
  (30022 functions / 33774 edges) with ``calls.call`` and
  ``called_by.call`` both populated; load and queries succeed.

## Test plan

- [x] All 709 tests pass on this branch.
- [x] Self-build produces a v5 ``nodes`` index; legacy v5 ``raw`` payloads
  are rejected with the documented clear error.
- [ ] CI green on the epic branch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)