### PR TITLE
test(#86): migrate fixtures to nodes shape + property/perf tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Shared pytest fixtures for the pyscope-mcp test suite.
+
+The single helper exported here, :func:`make_nodes`, converts a compact
+``{caller: [callees]}`` dict (the legacy ``raw`` shape) into the site-keyed
+``nodes`` shape introduced by epic #76 child #1.
+
+Centralising the conversion keeps every fixture site in the test corpus
+compact: each test still expresses its graph as ``{caller: [callees]}`` —
+the most natural representation for call-only tests — and lets the helper
+expand to the site-keyed record shape ``CallGraphIndex.from_nodes``
+expects.
+
+The helper also supports building call edges of an arbitrary kind via the
+``kind`` keyword and unioning multiple kind buckets through repeated calls
+in the same test (``make_nodes(raw1, kind="call")`` then merged with
+``make_nodes(raw2, kind="import")``).  This keeps the next-edge-kind PR
+cost bounded to one helper call per kind, not one fixture migration per
+site (Success Metric 3 of epic #76).
+"""
+
+from __future__ import annotations
+
+
+def make_nodes(
+    raw: dict[str, list[str]],
+    *,
+    kind: str = "call",
+) -> dict[str, dict]:
+    """Convert a ``{caller: [callees]}`` dict to the site-keyed nodes shape.
+
+    Each key in *raw* becomes (or extends) a node with
+    ``calls[kind] = sorted(callees)``.  Each callee gets a corresponding
+    ``called_by[kind]`` entry naming its caller.  Empty callee lists are
+    preserved as nodes with no edges so callers like ``CallGraphIndex
+    .callers_of`` see the FQN as present-but-isolated rather than missing.
+
+    Determinism: callee/caller lists are sorted within each kind bucket so
+    ``make_nodes(raw)`` and ``make_nodes(reversed_raw)`` for the same
+    logical edges produce dict equal output (and, when fed through
+    ``CallGraphIndex.save``, byte-identical JSON).
+
+    Parameters
+    ----------
+    raw:
+        Compact ``{caller_fqn: [callee_fqn, ...]}`` mapping.  Same shape as
+        the pre-migration ``raw`` field; preserved here as the ergonomic
+        author-facing form.
+    kind:
+        Edge kind to file the callees under.  Defaults to ``"call"`` so
+        existing tests get call edges for free; pass ``"import"``,
+        ``"except"``, ``"annotation"``, or ``"isinstance"`` to build
+        fixtures for the other kinds defined by epic #76.
+
+    Returns
+    -------
+    dict[str, dict]
+        Site-keyed nodes mapping suitable for ``CallGraphIndex.from_nodes``.
+        Every symbol that appears as a caller or callee is present as a key,
+        even when its edge buckets are empty for the requested kind.
+    """
+    forward: dict[str, set[str]] = {}
+    reverse: dict[str, set[str]] = {}
+    for caller, callees in raw.items():
+        forward.setdefault(caller, set()).update(callees)
+        for callee in callees:
+            reverse.setdefault(callee, set()).add(caller)
+            forward.setdefault(callee, set())  # ensure node exists
+
+    all_symbols = set(forward) | set(reverse)
+    nodes: dict[str, dict] = {}
+    for sym in sorted(all_symbols):
+        record: dict[str, dict[str, list[str]]] = {"calls": {}, "called_by": {}}
+        callees = forward.get(sym, set())
+        if callees:
+            record["calls"][kind] = sorted(callees)
+        callers = reverse.get(sym, set())
+        if callers:
+            record["called_by"][kind] = sorted(callers)
+        nodes[sym] = record
+    return nodes

--- a/tests/test_bfs_ranking_integration.py
+++ b/tests/test_bfs_ranking_integration.py
@@ -123,7 +123,9 @@ def test_analyzer_resolves_all_depth1_callers(callers_idx: CallGraphIndex) -> No
     """
     target = "ranking_callers_fixture.target.target_fn"
     direct_callers = {
-        fqn for fqn, callees in callers_idx.raw.items() if target in callees
+        fqn
+        for fqn, node in callers_idx.nodes.items()
+        if target in node.get("calls", {}).get("call", [])
     }
     expected = {f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}"
                 for i in range(1, _N_DEPTH1 + 1)}

--- a/tests/test_commit_staleness.py
+++ b/tests/test_commit_staleness.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -40,11 +41,7 @@ def _make_idx(
     raw: dict[str, list[str]] | None = None,
     git_sha: str | None = None,
 ) -> CallGraphIndex:
-    return CallGraphIndex.from_raw(
-        str(tmp_path),
-        raw or {},
-        git_sha=git_sha,
-    )
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw or {}), git_sha=git_sha)
 
 
 _MOCK_HEAD = "abcdef1234567890abcdef1234567890abcdef12"
@@ -130,12 +127,7 @@ def _make_idx_with_raw(tmp_path: Path, git_sha: str = _MOCK_INDEX_SHA) -> CallGr
         "pkg.mod.fn_a": ["pkg.mod.fn_b"],
         "pkg.mod.fn_b": [],
     }
-    return CallGraphIndex.from_raw(
-        str(tmp_path),
-        raw,
-        file_shas={},
-        git_sha=git_sha,
-    )
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), file_shas={}, git_sha=git_sha)
 
 
 def test_callers_of_includes_commit_staleness(tmp_path: Path) -> None:
@@ -211,13 +203,7 @@ def test_file_skeleton_includes_commit_staleness(tmp_path: Path) -> None:
     (tmp_path / "mod.py").write_text("def fn_a(): pass\n")
     import hashlib
     shas = {"mod.py": hashlib.sha256(b"def fn_a(): pass\n").hexdigest()}
-    idx = CallGraphIndex.from_raw(
-        str(tmp_path),
-        {},
-        skeletons=skeletons,
-        file_shas=shas,
-        git_sha=_MOCK_INDEX_SHA,
-    )
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons=skeletons, file_shas=shas, git_sha=_MOCK_INDEX_SHA)
     with patch("subprocess.run", return_value=_mock_git_success(_MOCK_HEAD)):
         result = idx.file_skeleton("mod.py")
     assert "commit_stale" in result
@@ -234,7 +220,7 @@ def server_with_index(tmp_path: Path):
     from pyscope_mcp import server as srv
 
     raw = {"pkg.mod.fn_a": ["pkg.mod.fn_b"], "pkg.mod.fn_b": []}
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
     index_path = tmp_path / "index.json"
     idx.save(index_path)
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -49,9 +50,9 @@ def _make_idx(
     file_shas: dict[str, str] | None = None,
     git_sha: str | None = None,
 ) -> CallGraphIndex:
-    return CallGraphIndex.from_raw(
+    return CallGraphIndex.from_nodes(
         "/tmp/test",
-        raw,
+        make_nodes(raw),
         skeletons=skeletons or {},
         file_shas=file_shas or {},
         missed_callers=missed_callers or {},

--- a/tests/test_component_issue62.py
+++ b/tests/test_component_issue62.py
@@ -27,6 +27,7 @@ from typing import Any
 import pytest
 
 from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -44,7 +45,7 @@ def _make_minimal_raw() -> dict[str, list[str]]:
 def _make_index(tmp_path: Path, raw: dict[str, list[str]] | None = None) -> CallGraphIndex:
     if raw is None:
         raw = _make_minimal_raw()
-    return CallGraphIndex.from_raw(str(tmp_path), raw)
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ def test_load_accepts_v5_index(tmp_path: Path) -> None:
 def test_from_raw_populates_content_hash(tmp_path: Path) -> None:
     """content_hash is computed and non-empty after from_raw()."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     assert isinstance(idx.content_hash, str)
     assert len(idx.content_hash) == 64, "SHA-256 hex digest must be 64 chars"
 
@@ -108,8 +109,8 @@ def test_from_raw_populates_content_hash(tmp_path: Path) -> None:
 def test_content_hash_is_deterministic(tmp_path: Path) -> None:
     """Same raw dict always produces the same content_hash."""
     raw = _make_minimal_raw()
-    idx1 = CallGraphIndex.from_raw(str(tmp_path), raw)
-    idx2 = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx1 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
+    idx2 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     assert idx1.content_hash == idx2.content_hash
 
 
@@ -117,8 +118,8 @@ def test_content_hash_changes_with_raw(tmp_path: Path) -> None:
     """Different raw dicts produce different content_hashes."""
     raw_a = {"pkg.a": ["pkg.b"], "pkg.b": []}
     raw_b = {"pkg.a": ["pkg.c"], "pkg.c": []}
-    idx_a = CallGraphIndex.from_raw(str(tmp_path), raw_a)
-    idx_b = CallGraphIndex.from_raw(str(tmp_path), raw_b)
+    idx_a = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw_a))
+    idx_b = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw_b))
     assert idx_a.content_hash != idx_b.content_hash
 
 
@@ -131,7 +132,7 @@ def test_git_sha_defaults_to_none(tmp_path: Path) -> None:
 def test_git_sha_roundtrips_through_save_load(tmp_path: Path) -> None:
     """git_sha is persisted on save and restored on load."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha="abc123def456")
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha="abc123def456")
     saved = idx.save(tmp_path / "index.json")
     loaded = CallGraphIndex.load(saved)
     assert loaded.git_sha == "abc123def456"
@@ -140,7 +141,7 @@ def test_git_sha_roundtrips_through_save_load(tmp_path: Path) -> None:
 def test_git_sha_none_roundtrips_through_save_load(tmp_path: Path) -> None:
     """git_sha=None round-trips correctly (persisted as null, restored as None)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=None)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=None)
     saved = idx.save(tmp_path / "index.json")
     loaded = CallGraphIndex.load(saved)
     assert loaded.git_sha is None
@@ -149,7 +150,7 @@ def test_git_sha_none_roundtrips_through_save_load(tmp_path: Path) -> None:
 def test_content_hash_roundtrips_through_save_load(tmp_path: Path) -> None:
     """content_hash is persisted on save and identical after load."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     saved = idx.save(tmp_path / "index.json")
     loaded = CallGraphIndex.load(saved)
     assert loaded.content_hash == idx.content_hash
@@ -159,7 +160,7 @@ def test_content_hash_roundtrips_through_save_load(tmp_path: Path) -> None:
 def test_saved_payload_has_git_sha_and_content_hash_keys(tmp_path: Path) -> None:
     """Serialised index JSON must contain git_sha and content_hash keys."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha="deadbeef")
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha="deadbeef")
     saved = idx.save(tmp_path / "index.json")
     payload = json.loads(saved.read_text())
     assert "git_sha" in payload, "git_sha must be present in saved index"
@@ -175,7 +176,7 @@ def test_saved_payload_has_git_sha_and_content_hash_keys(tmp_path: Path) -> None
 def test_callers_of_has_dropped_field(tmp_path: Path) -> None:
     """callers_of result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.callers_of("pkg.mod.bar", depth=1)
     assert "dropped" in result, "callers_of must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -185,7 +186,7 @@ def test_callers_of_has_dropped_field(tmp_path: Path) -> None:
 def test_callees_of_has_dropped_field(tmp_path: Path) -> None:
     """callees_of result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.callees_of("pkg.mod.foo", depth=1)
     assert "dropped" in result, "callees_of must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -195,7 +196,7 @@ def test_callees_of_has_dropped_field(tmp_path: Path) -> None:
 def test_module_callers_has_dropped_field(tmp_path: Path) -> None:
     """module_callers result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.module_callers("pkg.mod", depth=1)
     assert "dropped" in result, "module_callers must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -205,7 +206,7 @@ def test_module_callers_has_dropped_field(tmp_path: Path) -> None:
 def test_module_callees_has_dropped_field(tmp_path: Path) -> None:
     """module_callees result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     result = idx.module_callees("pkg.other", depth=1)
     assert "dropped" in result, "module_callees must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
@@ -271,7 +272,7 @@ async def _run_server(server, lines: list[bytes]) -> list[dict]:
 def _server_with_index(tmp_path: Path):
     """A server fixture wired to a fresh minimal index."""
     raw = _make_minimal_raw()
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     idx_path = tmp_path / "index.json"
     idx.save(idx_path)
 
@@ -407,8 +408,6 @@ def test_hub_suppression_index_accepts_git_sha(tmp_path: Path) -> None:
         "pkg.app.entry_point": ["pkg.utils.shared_helper"],
     }
     # Must not raise
-    idx = CallGraphIndex.from_raw(
-        str(tmp_path), raw, git_sha="cafebabe01234567"
-    )
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha="cafebabe01234567")
     assert idx.git_sha == "cafebabe01234567"
     assert idx.content_hash  # populated, non-empty

--- a/tests/test_component_issue66.py
+++ b/tests/test_component_issue66.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -136,7 +137,7 @@ class TestB1GraphToTypes:
         merge from **commit to a manual copy could omit or coerce fields.
         """
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", return_value=_git_ok(_MOCK_HEAD_SHA)):
             result = idx.callers_of("pkg.mod.beta", depth=1)
@@ -165,7 +166,7 @@ class TestB1GraphToTypes:
         would be absent from the dict entirely rather than present with None.
         """
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", side_effect=FileNotFoundError("no git")):
             result = idx.stats()
@@ -187,7 +188,7 @@ class TestB1GraphToTypes:
         to SearchResult; a merge that drops the value would silently be False/None.
         """
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", return_value=_git_ok(_MOCK_HEAD_SHA)):
             result = idx.search("alpha")
@@ -215,7 +216,7 @@ class TestB2ServerGraphBuildRpcLoop:
     def _wired_server(self, tmp_path: Path):
         """Server fixture with a real saved index, hooked into the RPC loop."""
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=_MOCK_INDEX_SHA)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
         idx_path = tmp_path / "index.json"
         idx.save(idx_path)
 

--- a/tests/test_component_issue69.py
+++ b/tests/test_component_issue69.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 import pyscope_mcp.server as _srv
 
 
@@ -70,9 +71,9 @@ def _make_index_with_skeleton(tmp_path: Path) -> CallGraphIndex:
     # omit file_shas (pre-v3 mode triggers stale=True) or provide matching shas.
     # Use file_shas=None to get pre-v3 staleness path — that still exercises the
     # success case skeleton content correctly.
-    return CallGraphIndex.from_raw(
+    return CallGraphIndex.from_nodes(
         str(tmp_path),
-        raw,
+        make_nodes(raw),
         skeletons=skeletons,
         file_shas=None,  # pre-v3: stale=True path, but results still returned
     )
@@ -153,7 +154,7 @@ class TestB1FqnNotFoundErrorPropagation:
     def _wired_server(self, tmp_path: Path):
         """Server fixture with a real in-memory index, wired into the RPC loop."""
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw, git_sha=None)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=None)
         idx_path = tmp_path / "index.json"
         idx.save(idx_path)
 
@@ -182,7 +183,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -202,7 +203,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-graph] callees_of with absent FQN returns isError:True dict."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -218,7 +219,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-graph] neighborhood with absent FQN returns isError:True dict."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -240,7 +241,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange — pkg.other.gamma has no callers in the raw graph
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -261,7 +262,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-graph] callees_of a known FQN with zero callees returns results:[] not isError."""
         # Arrange — pkg.mod.beta has no callees
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -279,7 +280,7 @@ class TestB1FqnNotFoundErrorPropagation:
         # Arrange — add a node with no edges
         raw = _make_minimal_raw()
         raw["pkg.mod.isolated"] = []
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
@@ -310,7 +311,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 
@@ -340,7 +341,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-server] _dispatch_tool('callees_of', bad FQN) surfaces isError:true."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 
@@ -364,7 +365,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """[B1-server] _dispatch_tool('neighborhood', bad FQN) surfaces isError:true."""
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 
@@ -391,7 +392,7 @@ class TestB1FqnNotFoundErrorPropagation:
         """
         # Arrange
         raw = _make_minimal_raw()
-        idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+        idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
         _srv._INDEX = idx
         _srv._INDEX_PATH = tmp_path / "index.json"
 

--- a/tests/test_file_skeleton.py
+++ b/tests/test_file_skeleton.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 from pyscope_mcp.analyzer.pipeline import _extract_skeletons, _first_def_line
 
 
@@ -34,7 +35,7 @@ def _make_index_with_skeletons(skeletons: dict, file_shas: dict | None = None) -
     Pass ``file_shas=None`` (the default) to simulate a pre-v3 index.
     Pass ``file_shas={}`` (or a populated dict) to simulate a v3 index.
     """
-    return CallGraphIndex.from_raw("/tmp/test", {}, skeletons=skeletons, file_shas=file_shas)
+    return CallGraphIndex.from_nodes("/tmp/test", make_nodes({}), skeletons=skeletons, file_shas=file_shas)
 
 
 def _parse(source: str) -> ast.Module:
@@ -254,7 +255,7 @@ def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
         _make_symbol("pkg.mod.MyClass", "class", 1),
         _make_symbol("pkg.mod.MyClass.run", "method", 5),
     ]
-    idx = CallGraphIndex.from_raw("/tmp/test", {"pkg.mod.MyClass.run": []}, skeletons={"mod.py": symbols})
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({"pkg.mod.MyClass.run": []}), skeletons={"mod.py": symbols})
     out = tmp_path / "index.json"
     idx.save(out)
 
@@ -269,7 +270,7 @@ def test_save_load_roundtrip_with_skeletons(tmp_path: Path) -> None:
 def test_save_version_is_current(tmp_path: Path) -> None:
     """Saved index must have the current INDEX_VERSION."""
     from pyscope_mcp.graph import INDEX_VERSION
-    idx = CallGraphIndex.from_raw("/tmp/test", {})
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({}))
     out = tmp_path / "index.json"
     idx.save(out)
     payload = _json.loads(out.read_text())
@@ -279,7 +280,7 @@ def test_save_version_is_current(tmp_path: Path) -> None:
 def test_save_includes_file_shas(tmp_path: Path) -> None:
     """Saved index includes file_shas key."""
     shas = {"mod.py": "abc123"}
-    idx = CallGraphIndex.from_raw("/tmp/test", {}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({}), file_shas=shas)
     out = tmp_path / "index.json"
     idx.save(out)
     payload = _json.loads(out.read_text())
@@ -290,7 +291,7 @@ def test_save_includes_file_shas(tmp_path: Path) -> None:
 def test_save_load_roundtrip_file_shas(tmp_path: Path) -> None:
     """file_shas survive save() → load() intact."""
     shas = {"a.py": "deadbeef", "b.py": "cafebabe"}
-    idx = CallGraphIndex.from_raw("/tmp/test", {}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes("/tmp/test", make_nodes({}), file_shas=shas)
     out = tmp_path / "index.json"
     idx.save(out)
     loaded = CallGraphIndex.load(out)
@@ -353,7 +354,7 @@ def test_file_skeleton_stale_sha_match(tmp_path: Path) -> None:
 
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": _sha256(content)}
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=shas)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is False
@@ -371,7 +372,7 @@ def test_file_skeleton_stale_sha_mismatch(tmp_path: Path) -> None:
 
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": _sha256(original)}  # stored hash is of original content
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=shas)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
@@ -387,7 +388,7 @@ def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     shas = {"mod.py": "somehex"}
     # Don't create the file on disk
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=shas)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=shas)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True
@@ -399,7 +400,7 @@ def test_file_skeleton_stale_file_not_found(tmp_path: Path) -> None:
 
 def test_file_skeleton_stale_file_not_in_index(tmp_path: Path) -> None:
     """Scenario D: v3 index, path not in skeletons → isError: true, error_reason: 'path_not_in_index', stale: false."""
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={}, file_shas={})
 
     result = idx.file_skeleton("new_mod.py")
     assert result["isError"] is True
@@ -414,7 +415,7 @@ def test_file_skeleton_stale_pre_v3_index(tmp_path: Path) -> None:
     """Scenario E: pre-v3 index (file_shas=None) → stale: true, index_format_incompatible."""
     symbols = [_make_symbol("pkg.mod.foo", "function", 1)]
     # file_shas=None simulates loading a v1 or v2 index
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={"mod.py": symbols}, file_shas=None)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={"mod.py": symbols}, file_shas=None)
 
     result = idx.file_skeleton("mod.py")
     assert result["stale"] is True

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 
 
 def _sample_raw() -> dict[str, list[str]]:
@@ -15,7 +16,7 @@ def _sample_raw() -> dict[str, list[str]]:
 
 
 def test_from_raw_builds_graphs() -> None:
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     stats = idx.stats()
     assert stats["functions"] >= 3
     assert stats["function_edges"] == 2
@@ -23,7 +24,7 @@ def test_from_raw_builds_graphs() -> None:
 
 
 def test_queries() -> None:
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # callers_of / callees_of now return dict shapes
     callees = idx.callees_of("sample.a.top", depth=1)
     assert isinstance(callees, dict)
@@ -48,7 +49,7 @@ def test_queries() -> None:
 
 def test_save_and_load_roundtrip(tmp_path: Path) -> None:
     from pyscope_mcp.graph import INDEX_VERSION
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     out = tmp_path / "index.json"
     idx.save(out)
 
@@ -92,7 +93,7 @@ def _prefix_raw() -> dict[str, list[str]]:
 
 def test_module_callers_prefix_match() -> None:
     """module_callers with a prefix returns callers of all matched modules."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("pkg.agents")
     assert result["truncated"] is False
     # pkg.core calls into pkg.agents.writer and pkg.agents.reader
@@ -104,7 +105,7 @@ def test_module_callers_prefix_match() -> None:
 
 def test_module_callees_prefix_match() -> None:
     """module_callees with a prefix returns callees of all matched modules."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("pkg.agents")
     assert result["truncated"] is False
     # pkg.agents.writer calls pkg.io.disk; pkg.agents.reader calls pkg.io.network
@@ -114,7 +115,7 @@ def test_module_callees_prefix_match() -> None:
 
 def test_module_callers_exact_match_backward_compat() -> None:
     """An exact FQN returns the same callers as before, now in structured form."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("pkg.agents.writer")
     assert isinstance(result, dict)
     assert "results" in result
@@ -125,7 +126,7 @@ def test_module_callers_exact_match_backward_compat() -> None:
 
 def test_module_callers_no_match() -> None:
     """A prefix matching no module nodes returns empty results, no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("nonexistent.pkg")
     assert result["results"] == []
     assert result["truncated"] is False
@@ -134,7 +135,7 @@ def test_module_callers_no_match() -> None:
 
 def test_module_callees_no_match() -> None:
     """A prefix matching no module nodes returns empty results, no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("nonexistent.pkg")
     assert result["results"] == []
     assert result["truncated"] is False
@@ -143,7 +144,7 @@ def test_module_callees_no_match() -> None:
 
 def test_module_callers_empty_prefix() -> None:
     """Empty-string prefix matches all modules; returns structured dict with no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("")
     # All modules are seeds — callers within the same set are excluded.
     # The important invariants are shape and no error.
@@ -156,7 +157,7 @@ def test_module_callers_empty_prefix() -> None:
 
 def test_module_callees_empty_prefix() -> None:
     """Empty-string prefix matches all modules; returns structured dict with no error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("")
     assert isinstance(result, dict)
     assert "results" in result
@@ -172,7 +173,7 @@ def test_module_callers_truncation() -> None:
     for i in range(60):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callers("target")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -185,7 +186,7 @@ def test_module_callees_truncation() -> None:
     }
     for i in range(60):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callees("source")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -195,7 +196,7 @@ def test_search_truncation() -> None:
     """When matches exceed the cap, truncated=True and total_matched reflects the full count."""
     # Build a raw graph with 5 symbols all containing "fn"
     raw = {f"pkg.mod.fn{i}": [] for i in range(5)}
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
 
     # Cap at 3 — should truncate
     result = idx.search("fn", limit=3)
@@ -222,7 +223,7 @@ def test_search_truncation() -> None:
 
 def test_callers_of_returns_dict() -> None:
     """callers_of returns {results: list[str], truncated: bool}, not a bare list."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callers_of("sample.b.helper", depth=1)
     assert isinstance(result, dict)
     assert "results" in result
@@ -234,7 +235,7 @@ def test_callers_of_returns_dict() -> None:
 
 def test_callees_of_returns_dict() -> None:
     """callees_of returns {results: list[str], truncated: bool}, not a bare list."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callees_of("sample.a.top", depth=1)
     assert isinstance(result, dict)
     assert "results" in result
@@ -251,7 +252,7 @@ def test_callers_of_truncation() -> None:
     for i in range(60):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callers_of("target.core.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -264,7 +265,7 @@ def test_callees_of_truncation() -> None:
     }
     for i in range(60):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callees_of("source.mod.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -276,7 +277,7 @@ def test_callees_of_truncation() -> None:
 
 def test_callers_of_dropped_zero_when_not_truncated() -> None:
     """dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callers_of("sample.b.helper", depth=1)
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -285,7 +286,7 @@ def test_callers_of_dropped_zero_when_not_truncated() -> None:
 
 def test_callees_of_dropped_zero_when_not_truncated() -> None:
     """dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callees_of("sample.a.top", depth=1)
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -298,7 +299,7 @@ def test_callers_of_dropped_correct_when_truncated() -> None:
     for i in range(57):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callers_of("target.core.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -312,7 +313,7 @@ def test_callees_of_dropped_correct_when_truncated() -> None:
     }
     for i in range(57):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.callees_of("source.mod.fn", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -347,7 +348,7 @@ def _ranking_raw_callers() -> dict[str, list[str]]:
 
 def test_callers_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
     """Depth-1 callers appear before depth-2 callers in results, even when alphabetically later."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _ranking_raw_callers())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_ranking_raw_callers()))
     result = idx.callers_of("target.fn", depth=2)
 
     # depth-1 callers must be present despite sorting alphabetically after a_depth2 nodes
@@ -391,7 +392,7 @@ def _ranking_raw_callees() -> dict[str, list[str]]:
 
 def test_callees_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
     """Depth-1 callees appear before depth-2 callees, even when alphabetically later."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _ranking_raw_callees())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_ranking_raw_callees()))
     result = idx.callees_of("source.fn", depth=2)
 
     # depth-1 callees: bridge.mod.fn, z_depth1.mod.fn, y_depth1.mod.fn
@@ -424,7 +425,7 @@ def test_callees_of_depth1_precede_depth2_when_alphabetical_would_invert() -> No
 
 def test_module_callers_dropped_zero_when_not_truncated() -> None:
     """module_callers: dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callers("pkg.agents")
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -433,7 +434,7 @@ def test_module_callers_dropped_zero_when_not_truncated() -> None:
 
 def test_module_callees_dropped_zero_when_not_truncated() -> None:
     """module_callees: dropped=0 when results fit within cap."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _prefix_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
     result = idx.module_callees("pkg.agents")
     assert "dropped" in result
     assert result["dropped"] == 0
@@ -446,7 +447,7 @@ def test_module_callers_dropped_correct_when_truncated() -> None:
     for i in range(57):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callers("target")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -460,7 +461,7 @@ def test_module_callees_dropped_correct_when_truncated() -> None:
     }
     for i in range(57):
         raw[f"target.mod{i}.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callees("source")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
@@ -478,7 +479,7 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
     raw["z_depth1.mod.fn"] = ["target.fn"]
     raw["y_depth1.mod.fn"] = ["target.fn"]
     raw["target.fn"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.module_callers("target", depth=2)
 
     assert "z_depth1.mod" in result["results"], (
@@ -498,7 +499,7 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
 
 def test_callers_of_fqn_not_in_graph() -> None:
     """callers_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callers_of("no.such.fqn")
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
@@ -509,7 +510,7 @@ def test_callers_of_fqn_not_in_graph() -> None:
 
 def test_callees_of_fqn_not_in_graph() -> None:
     """callees_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     result = idx.callees_of("no.such.fqn")
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
@@ -520,7 +521,7 @@ def test_callees_of_fqn_not_in_graph() -> None:
 
 def test_callers_of_known_zero_callers() -> None:
     """callers_of on an FQN with no callers returns results:[], not an error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # sample.a.top has no callers
     result = idx.callers_of("sample.a.top")
     assert result.get("isError") is not True
@@ -531,7 +532,7 @@ def test_callers_of_known_zero_callers() -> None:
 
 def test_callees_of_known_zero_callees() -> None:
     """callees_of on an FQN with no callees returns results:[], not an error."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _sample_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # sample.b.inner has no callees
     result = idx.callees_of("sample.b.inner")
     assert result.get("isError") is not True
@@ -559,7 +560,7 @@ def _neighborhood_raw() -> dict[str, list[str]]:
 
 def test_neighborhood_non_truncated() -> None:
     """neighborhood with generous budget returns all edges, truncated=False."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     result = idx.neighborhood("b.middle", depth=2, token_budget=10000)
     assert result["symbol"] == "b.middle"
     assert result["truncated"] is False
@@ -575,7 +576,7 @@ def test_neighborhood_non_truncated() -> None:
 
 def test_neighborhood_truncated() -> None:
     """neighborhood with tiny budget truncates and sets depth_truncated."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     # Budget of 1 token = 4 chars, which cannot fit any edge
     result = idx.neighborhood("b.middle", depth=2, token_budget=1)
     assert result["truncated"] is True
@@ -588,7 +589,7 @@ def test_neighborhood_truncated() -> None:
 
 def test_neighborhood_token_budget_enforced() -> None:
     """neighborhood response content fits within token_budget * 4 chars."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     token_budget = 5  # very tight
     result = idx.neighborhood("b.middle", depth=2, token_budget=token_budget)
     # The edges JSON representation must fit strictly within the budget.
@@ -599,7 +600,7 @@ def test_neighborhood_token_budget_enforced() -> None:
 
 def test_neighborhood_unknown_symbol() -> None:
     """neighborhood on a symbol not in the graph returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     result = idx.neighborhood("nonexistent.symbol", depth=2, token_budget=1000)
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
@@ -610,7 +611,7 @@ def test_neighborhood_unknown_symbol() -> None:
 
 def test_neighborhood_depth_full_reflects_graph() -> None:
     """depth_full reflects actual graph depth, not declared depth parameter."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     # Graph has max depth 2 from b.middle; requesting depth=5 should give depth_full <= 2
     result = idx.neighborhood("b.middle", depth=5, token_budget=10000)
     assert result["depth_full"] <= 2
@@ -618,7 +619,7 @@ def test_neighborhood_depth_full_reflects_graph() -> None:
 
 def test_neighborhood_edges_deduplicated() -> None:
     """Each edge appears at most once in the result."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     result = idx.neighborhood("b.middle", depth=3, token_budget=10000)
     edge_tuples = [tuple(e) for e in result["edges"]]
     assert len(edge_tuples) == len(set(edge_tuples)), "Edges must be deduplicated"
@@ -626,7 +627,7 @@ def test_neighborhood_edges_deduplicated() -> None:
 
 def test_neighborhood_deterministic() -> None:
     """Same input always produces the same output (Law 3)."""
-    idx = CallGraphIndex.from_raw("/tmp/sample", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_neighborhood_raw()))
     r1 = idx.neighborhood("b.middle", depth=2, token_budget=10000)
     r2 = idx.neighborhood("b.middle", depth=2, token_budget=10000)
     assert r1["edges"] == r2["edges"]
@@ -661,7 +662,7 @@ def _hub_raw() -> dict[str, list[str]]:
 
 def test_hub_suppression_default_on() -> None:
     """Hub suppression: default call suppresses high-in-degree H; expand_hubs=True does not."""
-    idx = CallGraphIndex.from_raw("/tmp/hub", _hub_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/hub", make_nodes(_hub_raw()))
 
     # Default: suppression on — H's other callers must NOT appear
     result = idx.neighborhood("queried.symbol", depth=2, token_budget=100000)
@@ -712,7 +713,7 @@ def test_hub_suppression_non_hub_unchanged() -> None:
         "c.leaf": [],
         "d.caller": ["a.top"],
     }
-    idx = CallGraphIndex.from_raw("/tmp/nonhub", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/nonhub", make_nodes(raw))
     result = idx.neighborhood("a.top", depth=2, token_budget=100000)
     assert result["hub_suppressed"] == [], (
         f"Expected empty hub_suppressed, got {result['hub_suppressed']}"
@@ -734,7 +735,7 @@ def test_hub_suppression_symbol_is_hub_exemption() -> None:
     for i in range(20):
         raw[f"caller_{i}"] = ["H"]
 
-    idx = CallGraphIndex.from_raw("/tmp/hubself", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/hubself", make_nodes(raw))
     # Calling neighborhood directly on H — H is exempt
     result = idx.neighborhood("H", depth=2, token_budget=100000)
     # H's callers must appear (queried symbol exempt from suppression)
@@ -755,7 +756,7 @@ def test_hub_suppression_out_degree_not_suppressed() -> None:
     for i in range(30):
         raw[f"callee_{i}"] = []
 
-    idx = CallGraphIndex.from_raw("/tmp/outdeg", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/outdeg", make_nodes(raw))
     result = idx.neighborhood("queried.symbol", depth=2, token_budget=100000)
 
     # M should NOT be in hub_suppressed (only in-degree triggers suppression)
@@ -772,7 +773,7 @@ def test_hub_suppression_out_degree_not_suppressed() -> None:
 
 def test_hub_suppression_per_call_threshold_override() -> None:
     """Per-call hub_threshold override: response echoes the override value."""
-    idx = CallGraphIndex.from_raw("/tmp/hub", _hub_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/hub", make_nodes(_hub_raw()))
 
     # H has 20 callers. Override threshold to 100 → H is NOT a hub at that threshold.
     result_high = idx.neighborhood("queried.symbol", depth=2, token_budget=100000, hub_threshold=100)
@@ -792,7 +793,7 @@ def test_hub_suppression_per_call_threshold_override() -> None:
 def test_hub_threshold_attribute_after_construction() -> None:
     """_in_degree_threshold is computed at from_raw time with floor of 10."""
     # Tiny graph — all nodes have in-degree 0 or 1; p99 will be below floor
-    idx = CallGraphIndex.from_raw("/tmp/small", _neighborhood_raw())
+    idx = CallGraphIndex.from_nodes("/tmp/small", make_nodes(_neighborhood_raw()))
     assert hasattr(idx, "_in_degree_threshold"), "_in_degree_threshold must exist on index"
     assert idx._in_degree_threshold >= 10, (
         f"Threshold must be >= 10 (floor), got {idx._in_degree_threshold}"
@@ -806,7 +807,7 @@ def test_hub_threshold_attribute_reflects_distribution() -> None:
     raw: dict[str, list[str]] = {"hub.node": []}
     for i in range(100):
         raw[f"caller_{i}"] = ["hub.node"]
-    idx = CallGraphIndex.from_raw("/tmp/p99test", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/p99test", make_nodes(raw))
     # p99 of in-degree distribution: 99 nodes have in-degree 0, hub.node has 100
     # p99_idx = int(0.99 * 101) = 99; sorted list: [0]*100 + [100] at index 100 → 100
     # but p99_idx=99 → value=0; floor=10 → threshold=10.
@@ -821,7 +822,7 @@ def test_neighborhood_hub_fields_always_present_isolated() -> None:
     # We add "b.isolated" as a standalone caller with an empty callees list.
     raw = _neighborhood_raw()
     raw["b.isolated"] = []
-    idx = CallGraphIndex.from_raw("/tmp/sample", raw)
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
     result = idx.neighborhood("b.isolated", depth=2, token_budget=10000)
     # An isolated-but-present node returns empty edges, not an error
     assert result.get("isError") is not True
@@ -951,7 +952,7 @@ def test_deterministic_serialization(tmp_path: Path) -> None:
 def test_from_raw_delegates_to_from_nodes(tmp_path: Path) -> None:
     """Backwards-compat: ``from_raw`` still works and yields the same graph as ``from_nodes``."""
     raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
-    idx = CallGraphIndex.from_raw(str(tmp_path), raw)
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
     # Forward edges visible
     callees = idx.callees_of("pkg.mod.foo", depth=1)
     assert callees["results"] == ["pkg.mod.bar"]
@@ -979,3 +980,139 @@ def test_save_uses_sort_keys_true(tmp_path: Path) -> None:
     assert text.startswith('{"content_hash":'), (
         f"save() must use sort_keys=True; first 60 chars: {text[:60]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Determinism property (epic #76 invariant: Corollary 3.2)
+#
+# Same logical edges → byte-identical JSON, regardless of insertion order.
+# This is the test that protects the Law 3 hash-check contract from
+# regressions: anywhere the inversion phase or save() picks up a stray
+# unsorted iteration, this test fails.
+# ---------------------------------------------------------------------------
+
+
+def test_save_byte_identical_across_insertion_orders(tmp_path: Path) -> None:
+    """Two indexes from the same logical edges, items inserted in opposite
+    orders, must produce byte-identical JSON files when saved.
+
+    This catches non-determinism in either ``make_nodes`` (inversion +
+    sort) or ``CallGraphIndex.save`` (canonical layout).  Dict equality
+    alone would not catch a JSON-key ordering bug — we compare the raw
+    bytes the consumer would hash for staleness detection.
+    """
+    edges = [
+        ("pkg.a.alpha", "pkg.b.beta"),
+        ("pkg.a.alpha", "pkg.c.gamma"),
+        ("pkg.b.beta", "pkg.d.delta"),
+        ("pkg.c.gamma", "pkg.d.delta"),
+        ("pkg.c.gamma", "pkg.e.epsilon"),
+        ("pkg.d.delta", "pkg.f.zeta"),
+        ("pkg.f.zeta", "pkg.a.alpha"),  # cycle for good measure
+    ]
+
+    def to_raw(pairs: list[tuple[str, str]]) -> dict[str, list[str]]:
+        out: dict[str, list[str]] = {}
+        for caller, callee in pairs:
+            out.setdefault(caller, []).append(callee)
+        return out
+
+    forward_raw = to_raw(edges)
+    # Same logical edges, but iterate in reversed insertion order so any
+    # order-sensitive code path (sets, dict iteration, sort key ties) has
+    # a chance to diverge.
+    reversed_raw = to_raw(list(reversed(edges)))
+    # Also reverse callee lists within each caller bucket to maximise
+    # iteration-order divergence — the canonical output must still match.
+    for k in reversed_raw:
+        reversed_raw[k] = list(reversed(reversed_raw[k]))
+
+    idx1 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(forward_raw))
+    idx2 = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(reversed_raw))
+
+    p1 = tmp_path / "idx1.json"
+    p2 = tmp_path / "idx2.json"
+    idx1.save(p1)
+    idx2.save(p2)
+
+    bytes1 = p1.read_bytes()
+    bytes2 = p2.read_bytes()
+    assert bytes1 == bytes2, (
+        "save() output is not byte-identical across insertion orders — "
+        "Law 3 hash-check contract is broken (Corollary 3.2 violation)."
+    )
+
+    # The content_hash header itself must also match, since it is derived
+    # from the same canonical projection.
+    assert idx1.content_hash == idx2.content_hash
+
+
+# ---------------------------------------------------------------------------
+# Per-kind error isolation (epic #76 invariant: Corollary 1.2 / 4.2 per-kind)
+#
+# A failing visitor for one kind on one file must not drop other kinds'
+# edges for that file.  At the data layer, this means: if a node's
+# ``calls.import`` bucket is missing/empty (because the import visitor
+# raised), the node's ``calls.call`` bucket must remain intact and visible
+# through the public query API.
+# ---------------------------------------------------------------------------
+
+
+def test_per_kind_isolation_call_edges_survive_missing_import_bucket(
+    tmp_path: Path,
+) -> None:
+    """Simulate a visitor failure on the import kind (no import bucket
+    populated) and assert that call edges from the same caller remain
+    visible through ``callers_of`` / ``callees_of`` and the ``nodes`` map.
+
+    Per-kind isolation is enforced inside the visitor (each ``visit_*``
+    wraps its body in try/except + ``_warn_kind_failure``).  This test
+    asserts the *consequence* at the data layer: a node with a failing
+    kind shows the empty bucket while other kinds remain unaffected.
+    """
+    # Build a nodes dict where pkg.mod.caller has call edges populated
+    # but its (hypothetical) import bucket is absent — exactly what the
+    # visitor produces when visit_Import raises before any _emit fires.
+    nodes: dict[str, dict] = {
+        "pkg.mod.caller": {
+            "calls": {"call": ["pkg.helpers.helper_a", "pkg.helpers.helper_b"]},
+            "called_by": {},
+        },
+        "pkg.helpers.helper_a": {
+            "calls": {},
+            "called_by": {"call": ["pkg.mod.caller"]},
+        },
+        "pkg.helpers.helper_b": {
+            "calls": {},
+            "called_by": {"call": ["pkg.mod.caller"]},
+        },
+        # Another caller in the same package that has BOTH call and
+        # import buckets populated — proves isolation is per (file, kind),
+        # not all-or-nothing across files.
+        "pkg.other.caller": {
+            "calls": {
+                "call": ["pkg.helpers.helper_a"],
+                "import": ["json"],
+            },
+            "called_by": {},
+        },
+        "json": {"calls": {}, "called_by": {"import": ["pkg.other.caller"]}},
+    }
+    idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+    # Call edges from the import-failing caller are intact.
+    callees = idx.callees_of("pkg.mod.caller", depth=1)
+    assert sorted(callees["results"]) == [
+        "pkg.helpers.helper_a",
+        "pkg.helpers.helper_b",
+    ]
+    # Import bucket on that caller is absent, not synthesised.
+    assert "import" not in idx.nodes["pkg.mod.caller"].get("calls", {})
+    # The other caller's call AND import edges are both intact — per-kind
+    # isolation is per (caller, kind), not file-global.
+    other_calls = idx.nodes["pkg.other.caller"]["calls"]
+    assert other_calls.get("call") == ["pkg.helpers.helper_a"]
+    assert other_calls.get("import") == ["json"]
+    # Reverse view also intact for the unaffected kinds.
+    a_callers = idx.callers_of("pkg.helpers.helper_a", depth=1)
+    assert sorted(a_callers["results"]) == ["pkg.mod.caller", "pkg.other.caller"]

--- a/tests/test_hub_suppression_integration.py
+++ b/tests/test_hub_suppression_integration.py
@@ -72,8 +72,8 @@ def test_analyzer_resolves_hub_callers(hub_idx: CallGraphIndex) -> None:
     """Analyzer must produce >= N_EXTRA_CALLERS+1 in-edges for shared_helper."""
     in_degree = sum(
         1
-        for callees in hub_idx.raw.values()
-        if "hub_fixture.utils.shared_helper" in callees
+        for node in hub_idx.nodes.values()
+        if "hub_fixture.utils.shared_helper" in node.get("calls", {}).get("call", [])
     )
     assert in_degree >= _N_EXTRA_CALLERS + 1, (
         f"Expected >= {_N_EXTRA_CALLERS + 1} callers of shared_helper, "

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,0 +1,160 @@
+"""Benchmarks for the constitutional Law 2 / Law 4 budgets.
+
+Two budgets are protected here:
+
+- **Law 2 — cold-load p95 < 500 ms** on the self-index.  Measured by
+  spawning 10 fresh ``python`` subprocesses and timing
+  ``CallGraphIndex.load`` end-to-end (process startup + JSON parse +
+  ``from_nodes`` rebuild).  We use subprocesses to defeat any in-process
+  caching and replicate what an MCP client experiences when the server
+  starts.
+
+- **Law 4 — full build < 60 s** on the self-index.  A single in-process
+  measurement of ``build_nodes_with_report`` + ``CallGraphIndex.save``.
+  Build cost is dominated by file I/O and AST parsing; an in-process
+  measurement is faithful to what ``pyscope-mcp build`` does.
+
+These tests are environment-sensitive — they target real wall-clock
+budgets, so they may be noisy on a hot CI runner but they are the only
+way to falsify the kill criterion in epic #76's intent doc.  When the
+self-index does not exist on disk yet, the cold-load test builds it
+once at module setup.
+"""
+
+from __future__ import annotations
+
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "pyscope_mcp"
+SRC_ROOT = REPO_ROOT / "src"
+INDEX_PATH = REPO_ROOT / ".pyscope-mcp" / "index.json"
+
+# Number of subprocess timings for the cold-load p95 test.  10 is the
+# minimum sample size that lets ``statistics.quantiles(n=20)[18]`` resolve
+# the 95th percentile usefully — fewer samples and the metric is noisy.
+_COLD_LOAD_SAMPLES = 10
+
+# Per-attempt timeout (seconds) for the cold-load subprocess.  A real
+# breach of the 500 ms budget will still complete in well under a second;
+# the timeout here just keeps a hung subprocess from stalling the suite.
+_COLD_LOAD_PROCESS_TIMEOUT = 10.0
+
+
+def _build_self_index_inplace() -> None:
+    """Build the pyscope-mcp self-index at the canonical location.
+
+    Used by the cold-load test as a setup step when no index exists yet.
+    Writes to the same path the CLI's ``build`` subcommand would write.
+    """
+    from pyscope_mcp.analyzer.pipeline import build_nodes_with_report
+    from pyscope_mcp.graph import CallGraphIndex
+
+    nodes, _report, skeletons, file_shas = build_nodes_with_report(
+        SRC_ROOT, PACKAGE
+    )
+    idx = CallGraphIndex.from_nodes(
+        SRC_ROOT, nodes, skeletons=skeletons, file_shas=file_shas
+    )
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    idx.save(INDEX_PATH)
+
+
+def _ensure_self_index_exists() -> None:
+    if not INDEX_PATH.exists():
+        _build_self_index_inplace()
+
+
+def test_cold_load_p95_under_500ms() -> None:
+    """Law 2 — cold-load p95 must stay under 500 ms on the self-index.
+
+    Spawns 10 fresh Python subprocesses, each timing
+    ``CallGraphIndex.load(INDEX_PATH)`` end-to-end and printing the
+    elapsed seconds to stdout.  Asserts ``p95 < 0.5``.
+
+    This is the canonical falsifier for epic #76's kill criterion: a
+    sustained breach here means the site-keyed shape lost the Law 2 budget
+    and the bucket-by-kind fallback should be revisited.
+    """
+    _ensure_self_index_exists()
+
+    timings: list[float] = []
+    snippet = (
+        "import time, sys; "
+        "from pyscope_mcp.graph import CallGraphIndex; "
+        f"_p = r'{INDEX_PATH}'; "
+        "_t = time.perf_counter(); "
+        "CallGraphIndex.load(_p); "
+        "sys.stdout.write(f'{time.perf_counter() - _t:.6f}')"
+    )
+    for _ in range(_COLD_LOAD_SAMPLES):
+        result = subprocess.run(
+            [sys.executable, "-c", snippet],
+            capture_output=True,
+            text=True,
+            timeout=_COLD_LOAD_PROCESS_TIMEOUT,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 0, (
+            f"cold-load subprocess failed: {result.stderr}"
+        )
+        out = result.stdout.strip()
+        assert out, "cold-load subprocess produced no timing output"
+        timings.append(float(out))
+
+    timings.sort()
+    # Compute p95.  ``statistics.quantiles(n=20)`` returns the 19 cut points
+    # of the distribution; index 18 is the 95th percentile.
+    p95 = statistics.quantiles(timings, n=20)[18]
+    median = statistics.median(timings)
+    print(
+        f"cold-load timings (s): median={median:.4f} p95={p95:.4f} "
+        f"min={min(timings):.4f} max={max(timings):.4f} "
+        f"all={[f'{t:.4f}' for t in timings]}"
+    )
+    assert p95 < 0.5, (
+        f"Law 2 budget breached: cold-load p95 = {p95*1000:.1f} ms "
+        f"(>= 500 ms ceiling).  See epic #76 kill criterion."
+    )
+
+
+def test_full_build_under_60s() -> None:
+    """Law 4 — a fresh build of the self-index must finish within 60 s.
+
+    Times ``build_nodes_with_report`` + ``CallGraphIndex.save`` on the
+    pyscope-mcp source tree.  This is the single-shot equivalent of what
+    ``pyscope-mcp build`` does; the budget includes pass 1 (discovery),
+    pass 2 (visitors), build-time inversion, and serialisation.
+    """
+    from pyscope_mcp.analyzer.pipeline import build_nodes_with_report
+    from pyscope_mcp.graph import CallGraphIndex
+
+    start = time.perf_counter()
+    nodes, _report, skeletons, file_shas = build_nodes_with_report(
+        SRC_ROOT, PACKAGE
+    )
+    idx = CallGraphIndex.from_nodes(
+        SRC_ROOT, nodes, skeletons=skeletons, file_shas=file_shas
+    )
+    # Save to a temporary location to avoid clobbering a pre-existing
+    # canonical index that other tests in the same run may rely on.
+    tmp_out = REPO_ROOT / ".pyscope-mcp" / "index.benchmark.json"
+    tmp_out.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        idx.save(tmp_out)
+        elapsed = time.perf_counter() - start
+    finally:
+        if tmp_out.exists():
+            tmp_out.unlink()
+
+    print(f"full build time: {elapsed:.2f} s")
+    assert elapsed < 60.0, (
+        f"Law 4 budget breached: full build took {elapsed:.1f} s "
+        f"(>= 60 s ceiling).  Investigate analyzer regressions."
+    )

--- a/tests/test_query_logger.py
+++ b/tests/test_query_logger.py
@@ -27,6 +27,7 @@ import pytest
 
 from pyscope_mcp._rpc import RpcServer
 from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +104,7 @@ def raw_graph() -> dict[str, list[str]]:
 @pytest.fixture()
 def tmp_index(tmp_path: Path, raw_graph: dict) -> Path:
     """Minimal v5 index on disk."""
-    idx = CallGraphIndex.from_raw(tmp_path, raw_graph)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_graph))
     idx_path = tmp_path / ".pyscope-mcp" / "index.json"
     idx.save(idx_path)
     return idx_path
@@ -235,7 +236,7 @@ def hub_index(tmp_path: Path) -> Path:
         raw[f"pkg.agent.worker_{i}.run"] = ["pkg.util.common"]
     # Add the target symbol
     raw["pkg.mod.target"] = ["pkg.util.common", "pkg.agent.worker_0.run"]
-    idx = CallGraphIndex.from_raw(tmp_path, raw)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
     idx_path = tmp_path / ".pyscope-mcp" / "index.json"
     idx.save(idx_path)
     return idx_path
@@ -375,8 +376,8 @@ async def test_s6_reload_updates_index_identity(tmp_path: Path):
     # Build two different indexes.
     raw_a = {"pkg.a.foo": ["pkg.a.bar"], "pkg.a.bar": []}
     raw_b = {"pkg.b.hello": ["pkg.b.world"], "pkg.b.world": []}
-    idx_a = CallGraphIndex.from_raw(tmp_path, raw_a)
-    idx_b = CallGraphIndex.from_raw(tmp_path, raw_b)
+    idx_a = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_a))
+    idx_b = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_b))
     idx_path = tmp_path / ".pyscope-mcp" / "index.json"
     idx_a.save(idx_path)
 
@@ -464,7 +465,7 @@ def test_s8_v5_roundtrip_git_sha_content_hash(tmp_path: Path):
     raw = {"pkg.mod.foo": ["pkg.mod.bar"], "pkg.mod.bar": []}
     fake_sha = "a1b2c3d4e5f6789012345678901234567890abcd"
 
-    idx = CallGraphIndex.from_raw(tmp_path, raw, git_sha=fake_sha)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw), git_sha=fake_sha)
     assert idx.git_sha == fake_sha
     assert len(idx.content_hash) == 64  # SHA-256 hex
 
@@ -484,8 +485,8 @@ def test_s8_v5_roundtrip_git_sha_content_hash(tmp_path: Path):
 def test_s8_content_hash_is_deterministic(tmp_path: Path):
     """S8: two builds against the same raw dict produce the same content_hash."""
     raw = {"pkg.mod.foo": ["pkg.mod.bar", "pkg.mod.baz"], "pkg.mod.bar": [], "pkg.mod.baz": []}
-    idx1 = CallGraphIndex.from_raw(tmp_path, raw)
-    idx2 = CallGraphIndex.from_raw(tmp_path, raw)
+    idx1 = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
+    idx2 = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
     assert idx1.content_hash == idx2.content_hash
     assert len(idx1.content_hash) == 64
 
@@ -493,7 +494,7 @@ def test_s8_content_hash_is_deterministic(tmp_path: Path):
 def test_s8_non_git_build_produces_none_git_sha(tmp_path: Path):
     """S8: building without a git_sha produces git_sha=None; load/serve still work."""
     raw = {"pkg.mod.foo": []}
-    idx = CallGraphIndex.from_raw(tmp_path, raw, git_sha=None)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw), git_sha=None)
     assert idx.git_sha is None
     idx_path = tmp_path / "index.json"
     idx.save(idx_path)
@@ -526,6 +527,6 @@ def test_s8_different_raw_produces_different_hash(tmp_path: Path):
     """S8: different raw dicts produce different content hashes."""
     raw_a = {"pkg.a.foo": ["pkg.a.bar"], "pkg.a.bar": []}
     raw_b = {"pkg.b.hello": ["pkg.b.world"], "pkg.b.world": []}
-    idx_a = CallGraphIndex.from_raw(tmp_path, raw_a)
-    idx_b = CallGraphIndex.from_raw(tmp_path, raw_b)
+    idx_a = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_a))
+    idx_b = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw_b))
     assert idx_a.content_hash != idx_b.content_hash

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -31,6 +31,7 @@ from pyscope_mcp._rpc import (
     RpcServer,
 )
 from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +123,7 @@ def tmp_index(tmp_path: Path) -> Path:
         "pkg.mod.bar": [],
         "pkg.other.baz": ["pkg.mod.foo"],
     }
-    idx = CallGraphIndex.from_raw(tmp_path, raw)
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
     idx_path = tmp_path / "index.json"
     idx.save(idx_path)
     return idx_path
@@ -1079,7 +1080,7 @@ async def test_reload_reflects_disk_change(server: RpcServer, tmp_index: Path):
         "a.b.f": [],
         "x.y.z": ["a.b.c"],
     }
-    new_idx = CallGraphIndex.from_raw(tmp_index.parent, new_raw)
+    new_idx = CallGraphIndex.from_nodes(tmp_index.parent, make_nodes(new_raw))
     new_idx.save(tmp_index)
 
     # Call reload then stats; must reflect the new counts.

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import make_nodes
+
 
 def _send(proc: subprocess.Popen, msg: dict) -> None:
     assert proc.stdin is not None
@@ -51,7 +53,7 @@ def index_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
         "pkg.mod.bar": [],
     }
     out_dir = tmp_path_factory.mktemp("pyscope_idx")
-    idx = CallGraphIndex.from_raw(out_dir, raw)
+    idx = CallGraphIndex.from_nodes(out_dir, make_nodes(raw))
     out = out_dir / "index.json"
     idx.save(out)
     return out

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
+from conftest import make_nodes
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +37,7 @@ def _make_idx(
     skeletons: dict[str, list[SymbolSummary]],
     file_shas: dict[str, str] | None,
 ) -> CallGraphIndex:
-    return CallGraphIndex.from_raw(str(tmp_path), raw, skeletons=skeletons, file_shas=file_shas)
+    return CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), skeletons=skeletons, file_shas=file_shas)
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +50,7 @@ def test_fqn_to_file_populated(tmp_path: Path) -> None:
         "src/pkg/mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")],
         "src/pkg/other.py": [_sym("pkg.other.fn_c")],
     }
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons=skeletons, file_shas={})
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons=skeletons, file_shas={})
     assert idx._fqn_to_file["pkg.mod.fn_a"] == "src/pkg/mod.py"
     assert idx._fqn_to_file["pkg.mod.fn_b"] == "src/pkg/mod.py"
     assert idx._fqn_to_file["pkg.other.fn_c"] == "src/pkg/other.py"
@@ -57,7 +58,7 @@ def test_fqn_to_file_populated(tmp_path: Path) -> None:
 
 def test_fqn_to_file_empty_skeletons(tmp_path: Path) -> None:
     """Empty skeletons produce an empty _fqn_to_file."""
-    idx = CallGraphIndex.from_raw(str(tmp_path), {}, skeletons={}, file_shas={})
+    idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes({}), skeletons={}, file_shas={})
     assert idx._fqn_to_file == {}
 
 


### PR DESCRIPTION
Closes #86. Epic #76 child #6 (third child of the second decomposition).

## Summary

- Adds ``tests/conftest.py`` with ``make_nodes(raw, *, kind=\"call\")`` — the single converter every test uses to expand the compact ``{caller: [callees]}`` author form into the site-keyed ``nodes`` shape ``CallGraphIndex.from_nodes`` expects. Centralising the converter is what makes Success Metric 3 of the epic (next-edge-kind PR touches <10 fixtures) actually achievable.
- Migrates ~140 ``CallGraphIndex.from_raw(...)`` call sites across 13 test files to ``CallGraphIndex.from_nodes(..., make_nodes(...))``. ``from_raw`` itself is left in place as the back-compat shim it always was; nothing in the test corpus relies on it now except the explicit shim regression test.
- Two integration tests (``test_bfs_ranking_integration``, ``test_hub_suppression_integration``) now read ``idx.nodes`` instead of the deprecated ``idx.raw`` projection.

## New tests

- ``tests/test_graph.py::test_save_byte_identical_across_insertion_orders`` — Corollary 3.2 (Law 3) determinism property: same logical edges, two opposite insertion / iteration orders → byte-identical JSON files. Catches non-determinism in either ``make_nodes`` or ``CallGraphIndex.save``.
- ``tests/test_graph.py::test_per_kind_isolation_call_edges_survive_missing_import_bucket`` — Corollary 1.2/4.2 per-kind: a node with no ``calls.import`` bucket (the data-layer trace of a failing ``visit_Import``) still serves its ``calls.call`` edges through ``callers_of``/``callees_of``, and other callers' ``call`` + ``import`` buckets remain unaffected.
- ``tests/test_perf.py::test_cold_load_p95_under_500ms`` — Law 2: 10 subprocess timings of ``CallGraphIndex.load`` on the self-index, asserts p95 < 500 ms. Auto-builds the self-index if absent.
- ``tests/test_perf.py::test_full_build_under_60s`` — Law 4: in-process timing of ``build_nodes_with_report`` + ``save``, asserts < 60 s.

## Scope notes

- Test-only slice — no changes under ``src/``.
- ``from_raw`` and ``idx.raw`` are intentionally retained as the transitional shim Child #1 designed; only the test fixtures move off them.
- Version-rejection tests already updated by Child #1 / #84 — not touched here.

## Test plan

- [x] ``pytest tests/`` — 729 pass on a clean run including the new property and perf tests.
- [x] Both perf budgets observed to pass on this dev container (cold-load p95 ~50 ms; full build ~1 s).
- [x] Determinism test verified to fail when ``save()`` is patched to skip ``sort_keys=True`` (manually checked during authoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)