### PR TITLE
feat(#71): add refers_to — typed symbol reference lookup, remove callers_of and module_callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install
         run: pip install -e '.[dev]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: pip install -e '.[dev]'
+
+      - name: Lint
+        run: ruff check src tests
+
+      - name: Test
+        run: pytest -m "not integration_artifact" --tb=short -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ When adding a new MCP tool that needs graph data, assume the index is already lo
 
 ## MCP tool surface
 
-Currently shipping: `stats`, `reload`, `build`, `callers_of`, `callees_of`, `module_callers`, `module_callees`, `search`, `file_skeleton`, `neighborhood`.
+Currently shipping: `stats`, `reload`, `build`, `refers_to`, `callees_of`, `module_callees`, `search`, `file_skeleton`, `neighborhood`.
 
 Missing but recurring across every other code-graph MCP — add in this order:
 
@@ -98,6 +98,29 @@ Conventions when adding tools:
 - `PYSCOPE_MCP_ROOT` — repo to analyze / serve from (default: cwd).
 - `PYSCOPE_MCP_PACKAGE` — root package name passed to the analyzer (default: root dir name).
 - `PYSCOPE_MCP_INDEX` — index file path (default: `.pyscope-mcp/index.json` relative to root).
+
+## CI
+
+`.github/workflows/ci.yml` runs on every push and PR:
+
+- **Python**: 3.11 (matches dev venv)
+- **Lint**: `ruff check src tests` — must pass with zero errors before tests run
+- **Test**: `pytest -m "not integration_artifact"` — runs all tests except artifact-tier integration tests (those require a built index on disk and are intended for nightly/label runs)
+
+To run the full suite locally including artifact-tier tests:
+
+```bash
+pytest
+```
+
+To run only what CI runs:
+
+```bash
+ruff check src tests
+pytest -m "not integration_artifact"
+```
+
+**Lint discipline**: ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = "py310"`). Fix violations with `ruff check --fix` before pushing.
 
 ## Testing
 

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -1130,6 +1130,11 @@ class CallGraphIndex:
         """
         symbol_fqns: list[str] = []
         for mod in module_fqns:
+            if not isinstance(mod, str):
+                raise TypeError(
+                    f"_expand_modules_to_symbols expects str elements, "
+                    f"got {type(mod)!r}: {mod!r}"
+                )
             prefix = mod + "."
             for fqn in self._fqn_to_file:
                 if fqn.startswith(prefix):

--- a/src/pyscope_mcp/graph.py
+++ b/src/pyscope_mcp/graph.py
@@ -10,10 +10,11 @@ from typing import TypedDict
 
 from pyscope_mcp.types import (
     CalleesResult,
-    CallersResult,
     Completeness,
     ModuleResult,
     NeighborhoodResult,
+    ReferencedByEntry,
+    ReferencedByResult,
     SearchResult,
     StatsResult,
 )
@@ -650,24 +651,61 @@ class CallGraphIndex:
             key=lambda n: (bfs_result[n], -degree_cache[n], n),
         )
 
-    def callers_of(self, fqn: str, depth: int = 1) -> CallersResult:
-        """Return functions that (transitively, up to depth) call *fqn*.
+    def refers_to(
+        self,
+        fqn: str,
+        kind: str = "all",
+        granularity: str = "function",
+        depth: int = 1,
+    ) -> ReferencedByResult:
+        """Return all typed AST references to *fqn* across the codebase.
 
-        Results are capped at 50; ``truncated`` signals when the cap fires.
-        ``dropped`` is the number of results cut by the cap (always present; 0
-        when the cap does not fire).  Results are ranked by
-        ``(hop_depth ASC, -total_degree DESC, fqn ASC)`` so depth-1 callers
-        always precede depth-2 ones regardless of alphabetical order.
-        Response includes uniform staleness fields (``stale``, ``stale_files``,
-        and optionally ``stale_action`` / ``index_stale_reason``) and a
-        ``completeness`` field (``"complete"`` or ``"partial"``).
+        Replaces the deleted ``callers_of`` (call-only) and ``module_callers``
+        (module-level call-only).  Covers all reference kinds stored in
+        ``nodes[fqn]["called_by"]``: ``"call"``, ``"import"``, ``"except"``,
+        ``"annotation"``, ``"isinstance"``.
 
-        If *fqn* is not present in the graph at all, returns an error dict
-        with ``isError: True``, ``error_reason: "fqn_not_in_graph"``, and
-        ``stale: False``.  An FQN that is present but has zero callers returns
-        ``results: []`` (not an error).
+        Parameters
+        ----------
+        fqn:
+            Fully-qualified name of the symbol to look up.
+        kind:
+            ``"all"`` — all reference kinds (default, for refactor safety).
+            ``"callers"`` — call edges only (replaces ``callers_of``).
+        granularity:
+            ``"function"`` — results are ``{fqn, context, depth}`` dicts
+            (default).  Each function appears once; ``"call"`` context wins
+            when a function references the symbol in multiple ways.
+            ``"module"`` — flat deduplicated list of module FQN strings
+            (replaces ``module_callers`` when used with ``kind="callers"``).
+        depth:
+            BFS hop depth (1 or 2).  Depth > 2 returns an error.  Depth > 1
+            traverses transitively through the ``"call"`` edges in the reverse
+            function graph (same BFS as the deleted ``callers_of``) for
+            ``kind="callers"``, and through the nodes dict for ``kind="all"``.
+
+        Returns
+        -------
+        :class:`ReferencedByResult` with ``results``, ``truncated``,
+        ``dropped``, ``completeness``, and staleness fields.
+
+        Error shapes
+        ------------
+        - ``fqn`` not in ``nodes``: ``{isError: true, error_reason:
+          "fqn_not_in_graph", stale: false, stale_files: []}``
+        - ``depth > 2``: ``{isError: true, error_reason: "depth_exceeds_max"}``
+        - FQN present, zero references: ``{results: [], ...}`` — not an error.
+
+        NOTE: Wildcard imports (``from module import *``) are not tracked and
+        are silently absent from results. See issue #74.
         """
-        if fqn not in self.function_graph.nodes:
+        if depth > 2:
+            return {  # type: ignore[return-value]
+                "isError": True,
+                "error_reason": "depth_exceeds_max",
+            }
+
+        if fqn not in self.nodes:
             commit = self._commit_staleness()
             return {  # type: ignore[return-value]
                 "isError": True,
@@ -676,19 +714,100 @@ class CallGraphIndex:
                 "stale_files": [],
                 **commit,
             }
-        rev_fg = self.function_graph.reverse(copy=False)
-        bfs_result = _bfs(rev_fg, fqn, depth)
-        ranked = self._rank_bfs_results(bfs_result, rev_fg)
-        dropped = max(0, len(ranked) - self._CALLERS_CALLEES_CAP)
+
+        if kind == "callers":
+            # Reuse existing call-edge BFS on the reversed function_graph.
+            rev_fg = self.function_graph.reverse(copy=False)
+            bfs_result = _bfs(rev_fg, fqn, depth)
+            ranked_fqns = self._rank_bfs_results(bfs_result, rev_fg)
+            dropped = max(0, len(ranked_fqns) - self._CALLERS_CALLEES_CAP)
+            truncated = dropped > 0
+            ranked_fqns = ranked_fqns[: self._CALLERS_CALLEES_CAP]
+
+            if granularity == "module":
+                module_results = _dedup_modules(ranked_fqns)
+                staleness = self._staleness_for_modules(module_results)
+                symbol_fqns = self._expand_modules_to_symbols(module_results)
+                commit = self._commit_staleness()
+                return ReferencedByResult(
+                    results=module_results,
+                    truncated=truncated,
+                    dropped=dropped,
+                    completeness=self.completeness_for(symbol_fqns),
+                    **staleness,  # type: ignore[arg-type]
+                    **commit,  # type: ignore[arg-type]
+                )
+
+            # granularity == "function"
+            entries: list[ReferencedByEntry] = [
+                ReferencedByEntry(fqn=f, context="call", depth=bfs_result[f])
+                for f in ranked_fqns
+            ]
+            staleness = self._staleness_for(ranked_fqns)
+            commit = self._commit_staleness()
+            return ReferencedByResult(
+                results=entries,
+                truncated=truncated,
+                dropped=dropped,
+                completeness=self.completeness_for(ranked_fqns),
+                **staleness,  # type: ignore[arg-type]
+                **commit,  # type: ignore[arg-type]
+            )
+
+        # kind == "all" — walk nodes["called_by"] for all edge kinds.
+        # Context priority: "call" > all other kinds (first-encountered non-call).
+        _CONTEXT_PRIORITY = ("call", "import", "except", "annotation", "isinstance")
+        bfs_all = _bfs_nodes_called_by(self.nodes, fqn, depth)
+        # bfs_all: dict[referencing_fqn -> (min_hop, {kind: hop_at_which_seen})]
+        # Rank by (hop ASC, -total_degree DESC, fqn ASC).
+        # total_degree from function_graph (call edges only — proxy for importance).
+        fg = self.function_graph
+
+        def _total_degree_all(n: str) -> int:
+            out_d = sum(1 for _ in fg.successors(n))
+            in_d = len(fg._pred.get(n, ()))
+            return out_d + in_d
+
+        sorted_fqns = sorted(
+            bfs_all,
+            key=lambda n: (bfs_all[n][0], -_total_degree_all(n), n),
+        )
+        dropped = max(0, len(sorted_fqns) - self._CALLERS_CALLEES_CAP)
         truncated = dropped > 0
-        results = ranked[: self._CALLERS_CALLEES_CAP]
-        staleness = self._staleness_for(results)
+        sorted_fqns = sorted_fqns[: self._CALLERS_CALLEES_CAP]
+
+        if granularity == "module":
+            module_results = _dedup_modules(sorted_fqns)
+            staleness = self._staleness_for_modules(module_results)
+            symbol_fqns = self._expand_modules_to_symbols(module_results)
+            commit = self._commit_staleness()
+            return ReferencedByResult(
+                results=module_results,
+                truncated=truncated,
+                dropped=dropped,
+                completeness=self.completeness_for(symbol_fqns),
+                **staleness,  # type: ignore[arg-type]
+                **commit,  # type: ignore[arg-type]
+            )
+
+        # granularity == "function" — pick highest-priority context per FQN.
+        entries = []
+        for ref_fqn in sorted_fqns:
+            hop, kinds_seen = bfs_all[ref_fqn]
+            chosen_context = "import"  # fallback if no call kind present
+            for ctx in _CONTEXT_PRIORITY:
+                if ctx in kinds_seen:
+                    chosen_context = ctx
+                    break
+            entries.append(ReferencedByEntry(fqn=ref_fqn, context=chosen_context, depth=hop))
+
+        staleness = self._staleness_for(sorted_fqns)
         commit = self._commit_staleness()
-        return CallersResult(
-            results=results,
+        return ReferencedByResult(
+            results=entries,
             truncated=truncated,
             dropped=dropped,
-            completeness=self.completeness_for(results),
+            completeness=self.completeness_for(sorted_fqns),
             **staleness,  # type: ignore[arg-type]
             **commit,  # type: ignore[arg-type]
         )
@@ -974,44 +1093,6 @@ class CallGraphIndex:
             key=lambda n: (bfs_result[n], -degree_cache[n], n),
         )
 
-    def module_callers(self, module: str, depth: int = 1) -> ModuleResult:
-        """Return callers of all modules whose FQN starts with *module* (prefix query).
-
-        An exact FQN is a degenerate prefix and behaves identically to the
-        pre-change implementation.  Results are capped at 50 items; the
-        ``truncated`` key in the returned dict signals when the cap triggers.
-        ``dropped`` is the number of results cut by the cap (always present; 0
-        when the cap does not fire).  Results are ranked by
-        ``(hop_depth ASC, -total_degree DESC, fqn ASC)`` so depth-1 module
-        callers always precede depth-2 ones regardless of alphabetical order.
-        An empty-string prefix matches all modules.  A prefix that matches no
-        module nodes returns ``{"results": [], "truncated": false, "dropped": 0, ...}``.
-
-        Staleness is result-scoped: module FQNs are expanded to file paths via
-        prefix-matching against ``_fqn_to_file`` (find all symbol FQNs that start
-        with ``result_module + "."``).  Completeness is computed over the same
-        expanded symbol FQN set.
-        """
-        base = _prefix_module_bfs(
-            self.module_graph.reverse(copy=False), self.module_graph, module, depth
-        )
-        raw_union: dict[str, int] = base["results"]  # type: ignore[assignment]
-        ranked = self._rank_module_bfs_results(raw_union, self.module_graph)
-        cap = _MODULE_BFS_CAP
-        dropped: int = base["dropped"]  # type: ignore[assignment]
-        result_modules = ranked[:cap]
-        staleness = self._staleness_for_modules(result_modules)
-        symbol_fqns = self._expand_modules_to_symbols(result_modules)
-        commit = self._commit_staleness()
-        return ModuleResult(
-            results=result_modules,
-            truncated=base["truncated"],  # type: ignore[typeddict-item]
-            dropped=dropped,
-            completeness=self.completeness_for(symbol_fqns),
-            **staleness,  # type: ignore[arg-type]
-            **commit,  # type: ignore[arg-type]
-        )
-
     def module_callees(self, module: str, depth: int = 1) -> ModuleResult:
         """Return callees of all modules whose FQN starts with *module* (prefix query).
 
@@ -1205,3 +1286,81 @@ def _bfs(g: _DiGraph | _DiGraphReverseView, start: str, depth: int) -> dict[str,
                     nxt.append(s)
         frontier = nxt
     return seen
+
+
+def _bfs_nodes_called_by(
+    nodes: dict[str, dict],
+    start: str,
+    depth: int,
+) -> dict[str, tuple[int, dict[str, int]]]:
+    """BFS over ``nodes[fqn]["called_by"]`` for all reference kinds.
+
+    Used by :meth:`CallGraphIndex.refers_to` with ``kind="all"`` to traverse
+    all typed reference edges (``call``, ``import``, ``except``,
+    ``annotation``, ``isinstance``) stored in the site-keyed nodes dict.
+
+    Unlike :func:`_bfs` (which operates on a :class:`_DiGraph` containing only
+    call edges), this function walks the ``nodes`` dict directly so that
+    non-call edge kinds are included.
+
+    Returns a mapping of
+    ``{referencing_fqn -> (min_hop_depth, {kind -> hop_at_first_seen})}``
+    where ``min_hop_depth`` is the minimum hop at which the FQN was reached
+    across all kinds.  A referencing FQN may appear under multiple kinds;
+    ``min_hop_depth`` is the minimum across them.
+
+    ``depth=0`` returns ``{}``.  ``depth=1`` returns direct references only.
+    ``depth=2`` traverses through call-only edges (``called_by["call"]``) to
+    find hop-2 references.
+    """
+    if depth <= 0 or start not in nodes:
+        return {}
+
+    # seen: referencing_fqn -> (min_hop, {kind: hop_at_first_seen})
+    seen: dict[str, tuple[int, dict[str, int]]] = {}
+
+    # Hop 1: collect all referencing FQNs from nodes[start]["called_by"]
+    hop1_callers: set[str] = set()
+    called_by = nodes[start].get("called_by", {}) or {}
+    for kind, referrers in called_by.items():
+        for ref_fqn in referrers:
+            if ref_fqn == start:
+                continue
+            if ref_fqn not in seen:
+                seen[ref_fqn] = (1, {kind: 1})
+                hop1_callers.add(ref_fqn)
+            else:
+                seen[ref_fqn][1][kind] = 1
+
+    if depth == 1:
+        return seen
+
+    # Hop 2: traverse through call-only edges from hop-1 FQNs
+    # (We follow "who calls the hop-1 referrers" via call edges only —
+    # consistent with the callers_of depth-2 semantics.)
+    for ref_fqn in list(hop1_callers):
+        hop2_called_by = nodes.get(ref_fqn, {}).get("called_by", {}) or {}
+        hop2_callers = hop2_called_by.get("call", [])
+        for h2_fqn in hop2_callers:
+            if h2_fqn == start or h2_fqn in hop1_callers:
+                continue
+            if h2_fqn not in seen:
+                seen[h2_fqn] = (2, {"call": 2})
+            else:
+                cur_hop, cur_kinds = seen[h2_fqn]
+                if cur_hop > 2:
+                    seen[h2_fqn] = (2, {**cur_kinds, "call": 2})
+
+    return seen
+
+
+def _dedup_modules(fqns: list[str]) -> list[str]:
+    """Deduplicate function FQNs to their module FQNs (preserving order)."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for fqn in fqns:
+        mod = _module_of(fqn)
+        if mod not in seen:
+            seen.add(mod)
+            result.append(mod)
+    return result

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -65,8 +65,9 @@ _SERVER = RpcServer(
     version=__version__,
     instructions=(
         "Query the prebuilt Python call-graph index. "
-        "Use stats to check graph size, callers_of/callees_of for function-level "
-        "traversal, module_callers/module_callees for module-level traversal, "
+        "Use stats to check graph size, refers_to for finding all typed references "
+        "to a symbol (calls, imports, except handlers, isinstance checks, annotations), "
+        "callees_of for what a function calls, module_callees for module-level callees, "
         "search for symbol lookup, file_skeleton for a file's symbol list, "
         "neighborhood for a bounded bidirectional subgraph around a symbol, "
         "build to rebuild the index from source (triggers pyscope-mcp build as a "
@@ -109,33 +110,78 @@ _TOOL_LIST = [
         "annotations": {"readOnlyHint": False, "idempotentHint": False},
     },
     {
-        "name": "callers_of",
+        "name": "refers_to",
         "description": (
-            "List functions that (transitively, up to depth) call the given function. "
-            "Results are capped at 50 and ranked by (hop_depth ASC, -total_degree DESC, fqn ASC) "
-            "so depth-1 callers always appear before depth-2 ones. "
-            "When the cap triggers, `truncated` is true and `dropped` is the number of results cut. "
-            "`dropped` is always present (0 when cap does not fire) — use it to detect partial views "
-            "and narrow your query or escalate accordingly. "
+            "Find everything that references a given symbol or module — calls, imports, "
+            "except handlers, type annotations, isinstance checks. "
+            "Use `kind` to narrow by reference type and `granularity` to switch between "
+            "function-level and module-level results.\n"
+            "\n"
+            "kind (default: \"all\")\n"
+            "  \"all\"     — all AST reference types: calls, imports, except handlers, type "
+            "annotations, isinstance checks. Use for refactor safety: gives the complete set "
+            "of locations that will break if you rename or move the symbol.\n"
+            "  \"callers\" — call edges only (AST Call nodes: raise, instantiation, direct "
+            "invocation). Use for call-graph navigation: who drives this function?\n"
+            "\n"
+            "granularity (default: \"function\")\n"
+            "  \"function\" — results are individual function/method FQNs. Each result carries "
+            "a `context` field: \"call\" | \"import\" | \"except\" | \"annotation\" | \"isinstance\". "
+            "\"call\" wins when a function references the symbol in multiple ways.\n"
+            "  \"module\"   — results are deduplicated module FQNs (flat list, no per-entry "
+            "context). Use for dependency-graph views.\n"
+            "\n"
+            "depth: 1 or 2. depth > 2 returns {isError: true, error_reason: \"depth_exceeds_max\"}.\n"
+            "\n"
+            "Common patterns:\n"
+            "  refers_to(fqn)                                    — full reference map, "
+            "function-level (refactor audit)\n"
+            "  refers_to(fqn, kind=\"callers\")                   — call graph only (who runs this?)\n"
+            "  refers_to(fqn, granularity=\"module\")             — which modules reference this?\n"
+            "  refers_to(fqn, kind=\"callers\", granularity=\"module\") — replaces module_callers\n"
+            "\n"
+            "NOTE: Wildcard imports (from module import *) are not tracked and are silently "
+            "absent from results. See issue #74.\n"
+            "\n"
+            "Results are capped at 50 and ranked by (hop_depth ASC, -total_degree DESC, fqn ASC). "
+            "When the cap triggers, `truncated` is true and `dropped` is the count cut. "
+            "`dropped` is always present (0 when cap does not fire). "
+            "Response includes `completeness: 'complete' | 'partial'`. "
+            "'partial' means at least one result FQN has unresolved static-dispatch call edges "
+            "— it does NOT signal missing wildcard-import references. "
             "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
             "and `stale_action: str` when stale is true. "
             "Response includes commit-level staleness: `commit_stale: bool|null`, "
             "`index_git_sha: str|null`, `head_git_sha: str|null`. "
-            "Response includes `completeness: 'complete' | 'partial'`. "
-            "'partial' means at least one result FQN has unresolved static-dispatch calls "
-            "(e.g. getattr, duck typing, decorator registries) — verify with grep before "
-            "treating the result as exhaustive. "
-            "'complete' means no result FQN (or its class siblings) appears in the miss log. "
-            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...], commit_stale, index_git_sha, head_git_sha}. "
-            "If the FQN is not in the index at all, returns {isError: true, error_reason: 'fqn_not_in_graph', stale: false, stale_files: []} — "
-            "this means the FQN is wrong; rebuilding the index will not help. "
-            "An FQN with zero callers returns results: [] (not an error)."
+            "Returns "
+            "{results: [{fqn, context, depth}, ...], truncated, dropped, completeness, stale, "
+            "stale_files, ...} for granularity=\"function\", or "
+            "{results: [module_fqn, ...], ...} for granularity=\"module\". "
+            "If the FQN is not in the index at all, returns {isError: true, "
+            "error_reason: 'fqn_not_in_graph', stale: false, stale_files: []} — "
+            "this means the FQN is wrong; rebuilding will not help. "
+            "Zero references returns results: [] (not an error)."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
-                "fqn": {"type": "string", "description": "Fully-qualified name, e.g. pkg.mod.func"},
-                "depth": {"type": "integer", "minimum": 1, "maximum": 10, "default": 1},
+                "fqn": {
+                    "type": "string",
+                    "description": "Fully-qualified name or dotted module prefix, e.g. pkg.mod.ClassName or pkg.agents",
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["all", "callers"],
+                    "default": "all",
+                    "description": "\"all\" returns every reference type; \"callers\" returns call edges only",
+                },
+                "granularity": {
+                    "type": "string",
+                    "enum": ["function", "module"],
+                    "default": "function",
+                    "description": "\"function\" returns individual FQNs with context; \"module\" returns deduplicated module FQNs",
+                },
+                "depth": {"type": "integer", "minimum": 1, "maximum": 2, "default": 1},
             },
             "required": ["fqn"],
         },
@@ -171,43 +217,6 @@ _TOOL_LIST = [
                 "depth": {"type": "integer", "minimum": 1, "maximum": 10, "default": 1},
             },
             "required": ["fqn"],
-        },
-        "annotations": {"readOnlyHint": True, "idempotentHint": True},
-    },
-    {
-        "name": "module_callers",
-        "description": (
-            "List modules that import/call into the given module or package prefix. "
-            "The `module` argument is treated as a dotted-prefix query: supply a full "
-            "FQN (e.g. `pkg.mod`) for an exact match, or a package prefix "
-            "(e.g. `pkg.agents`) to aggregate callers across all matching modules. "
-            "An empty string matches all modules. "
-            "Results are capped at 50, deduplicated, and ranked by "
-            "(hop_depth ASC, -total_degree DESC, fqn ASC) so depth-1 module callers "
-            "always appear before depth-2 ones. "
-            "When the cap triggers, `truncated` is true and `dropped` is the number of results cut. "
-            "`dropped` is always present (0 when cap does not fire) — use it to detect partial views "
-            "and narrow the prefix or escalate accordingly. "
-            "Response includes result-scoped staleness: `stale: bool`, `stale_files: list[str]`, "
-            "and `stale_action: str` when stale is true. "
-            "Response includes commit-level staleness: `commit_stale: bool|null`, "
-            "`index_git_sha: str|null`, `head_git_sha: str|null`. "
-            "Response includes `completeness: 'complete' | 'partial'`. "
-            "'partial' means at least one symbol in the result modules has unresolved "
-            "static-dispatch calls — verify with grep before treating as exhaustive. "
-            "'complete' means no symbol in the result modules appears in the miss log. "
-            "Returns {results: [...], truncated: bool, dropped: int, completeness: str, stale: bool, stale_files: [...], commit_stale, index_git_sha, head_git_sha}."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "module": {
-                    "type": "string",
-                    "description": "Dotted module prefix or exact FQN, e.g. 'pkg.agents' or 'pkg.agents.writer'",
-                },
-                "depth": {"type": "integer", "minimum": 1, "maximum": 10, "default": 1},
-            },
-            "required": ["module"],
         },
         "annotations": {"readOnlyHint": True, "idempotentHint": True},
     },
@@ -518,11 +527,14 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
     if name == "stats":
         return _text(idx.stats())
 
-    if name == "callers_of":
+    if name == "refers_to":
         fqn = arguments.get("fqn")
         if not fqn:
-            return _error_result("callers_of requires 'fqn'")
-        result = idx.callers_of(fqn, int(arguments.get("depth", 1)))
+            return _error_result("refers_to requires 'fqn'")
+        kind = str(arguments.get("kind", "all"))
+        granularity = str(arguments.get("granularity", "function"))
+        depth = int(arguments.get("depth", 1))
+        result = idx.refers_to(fqn, kind=kind, granularity=granularity, depth=depth)
         if result.get("isError"):
             return {"content": [{"type": "text", "text": _json.dumps(result, indent=2)}], "isError": True}
         return _text(result)
@@ -535,12 +547,6 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
         if result.get("isError"):
             return {"content": [{"type": "text", "text": _json.dumps(result, indent=2)}], "isError": True}
         return _text(result)
-
-    if name == "module_callers":
-        module = arguments.get("module")
-        if module is None:
-            return _error_result("module_callers requires 'module'")
-        return _text(idx.module_callers(module, int(arguments.get("depth", 1))))
 
     if name == "module_callees":
         module = arguments.get("module")

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -22,6 +22,7 @@ import json as _json
 import logging
 import os
 import subprocess
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -507,7 +508,7 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
             # Pass the current process environment so PYSCOPE_MCP_ROOT / PACKAGE / INDEX
             # env vars are forwarded to the subprocess.
             proc_result = subprocess.run(
-                ["pyscope-mcp", "build"],
+                [sys.executable, "-m", "pyscope_mcp.cli", "build"],
                 env=os.environ.copy(),
                 capture_output=True,
                 text=True,

--- a/src/pyscope_mcp/types.py
+++ b/src/pyscope_mcp/types.py
@@ -47,22 +47,6 @@ class StatsResult(TypedDict):
     head_git_sha: NotRequired[str | None]
 
 
-class CallersResult(TypedDict):
-    """Return shape for :meth:`CallGraphIndex.callers_of`."""
-
-    results: list[str]
-    truncated: bool
-    dropped: int  # number of results cut by the cap; 0 when cap does not fire
-    completeness: Completeness
-    stale: bool
-    stale_files: list[str]
-    stale_action: NotRequired[str]
-    index_stale_reason: NotRequired[str]
-    commit_stale: NotRequired[bool | None]
-    index_git_sha: NotRequired[str | None]
-    head_git_sha: NotRequired[str | None]
-
-
 class CalleesResult(TypedDict):
     """Return shape for :meth:`CallGraphIndex.callees_of`."""
 
@@ -80,10 +64,51 @@ class CalleesResult(TypedDict):
 
 
 class ModuleResult(TypedDict):
-    """Return shape for :meth:`CallGraphIndex.module_callers` and
-    :meth:`CallGraphIndex.module_callees`."""
+    """Return shape for :meth:`CallGraphIndex.module_callees`."""
 
     results: list[str]
+    truncated: bool
+    dropped: int  # number of results cut by the cap; 0 when cap does not fire
+    completeness: Completeness
+    stale: bool
+    stale_files: list[str]
+    stale_action: NotRequired[str]
+    index_stale_reason: NotRequired[str]
+    commit_stale: NotRequired[bool | None]
+    index_git_sha: NotRequired[str | None]
+    head_git_sha: NotRequired[str | None]
+
+
+# Reference context kinds for refers_to.
+RefContext = Literal["call", "import", "except", "annotation", "isinstance"]
+
+
+class ReferencedByEntry(TypedDict):
+    """One entry in refers_to results for granularity="function".
+
+    ``fqn`` is the fully-qualified name of the referencing function.
+    ``context`` is the highest-priority reference kind found (``"call"`` wins).
+    ``depth`` is the BFS hop depth at which this entry was first reached.
+    """
+
+    fqn: str
+    context: str  # RefContext value
+    depth: int
+
+
+class ReferencedByResult(TypedDict):
+    """Return shape for :meth:`CallGraphIndex.refers_to`.
+
+    ``results`` is:
+    - For ``granularity="function"``: list of :class:`ReferencedByEntry` dicts.
+    - For ``granularity="module"``: flat list of module FQN strings.
+
+    ``completeness`` retains its existing meaning (unresolved dynamic-dispatch
+    call edges only). It does NOT signal missing wildcard-import references
+    (those are silently excluded — see issue #74).
+    """
+
+    results: list  # list[ReferencedByEntry] or list[str]
     truncated: bool
     dropped: int  # number of results cut by the cap; 0 when cap does not fire
     completeness: Completeness

--- a/tests/test_analyzer_alias_stdlib.py
+++ b/tests/test_analyzer_alias_stdlib.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pyscope_mcp.analyzer import build_raw, build_with_report
+from pyscope_mcp.analyzer import build_with_report
 
 
 def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:

--- a/tests/test_analyzer_classifier_widening.py
+++ b/tests/test_analyzer_classifier_widening.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.analyzer import build_raw
 from pyscope_mcp.analyzer.misses import classify_miss

--- a/tests/test_analyzer_local_var_builtin.py
+++ b/tests/test_analyzer_local_var_builtin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pyscope_mcp.analyzer import build_raw, build_with_report
+from pyscope_mcp.analyzer import build_with_report
 
 
 def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:

--- a/tests/test_analyzer_m1.py
+++ b/tests/test_analyzer_m1.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.analyzer import _collect_defs, _discover_modules, build_raw
 

--- a/tests/test_analyzer_m2.py
+++ b/tests/test_analyzer_m2.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.analyzer import (
     _build_import_table,
-    _EdgeVisitor,
-    _collect_defs,
     build_raw,
 )
 

--- a/tests/test_analyzer_m3.py
+++ b/tests/test_analyzer_m3.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.analyzer import build_raw
 

--- a/tests/test_analyzer_m4.py
+++ b/tests/test_analyzer_m4.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.analyzer import build_raw
 

--- a/tests/test_analyzer_m5.py
+++ b/tests/test_analyzer_m5.py
@@ -18,7 +18,6 @@ import sys
 import textwrap
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.analyzer import build_with_report
 

--- a/tests/test_analyzer_m7_external_whitelist.py
+++ b/tests/test_analyzer_m7_external_whitelist.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from pyscope_mcp.analyzer import build_raw, build_with_report, _classify_miss
+from pyscope_mcp.analyzer import build_with_report, _classify_miss
 
 
 def _parse_call(src: str) -> ast.Call:

--- a/tests/test_analyzer_m9.py
+++ b/tests/test_analyzer_m9.py
@@ -285,7 +285,6 @@ def test_deeply_nested_func_no_double_processing(tmp_path: Path) -> None:
     # inner's scope has o: Other — edge to Other.run from inner is valid but
     # innermost should not inherit it
     # Also verify inner and outer scopes are independent
-    inner_callees = raw.get("pkg.mod.outer.inner", [])
     outer_callees = raw.get("pkg.mod.outer", [])
     # outer binds w: Worker but makes no calls — no Worker.process edge from outer
     assert "pkg.mod.Worker.process" not in outer_callees
@@ -314,7 +313,6 @@ def test_lambda_outer_scope_not_inherited(tmp_path: Path) -> None:
     # NOTE: The runner() call to x.process() IS directly tracked in runner's scope,
     # so we check the lambda scope separately.
     # Lambda doesn't have a named FQN in our scheme — so just check runner:
-    runner_callees = raw.get("pkg.mod.runner", [])
     # runner may resolve x.process() (x is bound there before lambda).
     # But we ensure the lambda body call doesn't somehow create a wrong edge.
     # This test mainly checks that lambda-scoped access doesn't produce false edges

--- a/tests/test_analyzer_self_attr_builtin.py
+++ b/tests/test_analyzer_self_attr_builtin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pyscope_mcp.analyzer import build_raw, build_with_report
+from pyscope_mcp.analyzer import build_with_report
 
 
 def _make_package(tmp_path: Path, pkg_name: str, files: dict[str, str]) -> Path:

--- a/tests/test_bfs_ranking_integration.py
+++ b/tests/test_bfs_ranking_integration.py
@@ -141,9 +141,10 @@ def test_callers_of_preserves_depth1_under_cap_via_analyzer(
 ) -> None:
     """Issue #59 regression: depth-1 callers must survive the 50-item cap
     even when 55 depth-2 callers sort alphabetically before them."""
-    result = callers_idx.callers_of(
-        "ranking_callers_fixture.target.target_fn", depth=2
+    result = callers_idx.refers_to(
+        "ranking_callers_fixture.target.target_fn", kind="callers", depth=2
     )
+    fqns = [e["fqn"] for e in result["results"]]
 
     assert result["truncated"] is True
     assert len(result["results"]) == _CAP
@@ -151,19 +152,19 @@ def test_callers_of_preserves_depth1_under_cap_via_analyzer(
 
     for i in range(1, _N_DEPTH1 + 1):
         fqn = f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}"
-        assert fqn in result["results"], (
+        assert fqn in fqns, (
             f"depth-1 caller {fqn} dropped by cap — ranking did not run "
             f"before truncation"
         )
 
     z_indices = [
-        result["results"].index(f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}")
+        fqns.index(f"ranking_callers_fixture.zdepth1.z_caller_{i:02d}")
         for i in range(1, _N_DEPTH1 + 1)
     ]
     last_depth1 = max(z_indices)
-    for item in result["results"]:
+    for item in fqns:
         if "adepth2.a_caller_" in item:
-            assert result["results"].index(item) > last_depth1, (
+            assert fqns.index(item) > last_depth1, (
                 f"depth-2 caller {item} ranked before a depth-1 caller"
             )
 
@@ -205,8 +206,8 @@ def test_callers_of_dropped_zero_when_under_cap_via_analyzer(
     callers_idx: CallGraphIndex,
 ) -> None:
     """Querying a depth-1-only result set must yield dropped=0, not absent."""
-    result = callers_idx.callers_of(
-        "ranking_callers_fixture.target.target_fn", depth=1
+    result = callers_idx.refers_to(
+        "ranking_callers_fixture.target.target_fn", kind="callers", depth=1
     )
     assert result["truncated"] is False
     assert result["dropped"] == 0

--- a/tests/test_commit_staleness.py
+++ b/tests/test_commit_staleness.py
@@ -133,7 +133,7 @@ def _make_idx_with_raw(tmp_path: Path, git_sha: str = _MOCK_INDEX_SHA) -> CallGr
 def test_callers_of_includes_commit_staleness(tmp_path: Path) -> None:
     idx = _make_idx_with_raw(tmp_path, git_sha=_MOCK_INDEX_SHA)
     with patch("subprocess.run", return_value=_mock_git_success(_MOCK_HEAD)):
-        result = idx.callers_of("pkg.mod.fn_b", depth=1)
+        result = idx.refers_to("pkg.mod.fn_b", kind="callers", depth=1)
     assert "commit_stale" in result
     assert "index_git_sha" in result
     assert "head_git_sha" in result
@@ -186,7 +186,7 @@ def test_neighborhood_includes_commit_staleness(tmp_path: Path) -> None:
 def test_module_callers_includes_commit_staleness(tmp_path: Path) -> None:
     idx = _make_idx_with_raw(tmp_path, git_sha=_MOCK_INDEX_SHA)
     with patch("subprocess.run", return_value=_mock_git_success(_MOCK_HEAD)):
-        result = idx.module_callers("pkg.mod", depth=1)
+        result = idx.refers_to("pkg.mod.fn_b", kind="callers", granularity="module", depth=1)
     assert "commit_stale" in result
 
 

--- a/tests/test_commit_staleness.py
+++ b/tests/test_commit_staleness.py
@@ -13,7 +13,6 @@ Covers:
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -259,7 +258,6 @@ async def test_build_tool_success(server_with_index, tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_build_tool_concurrent_rejection(server_with_index) -> None:
     """Concurrent build calls: second call returns isError:true immediately."""
-    import asyncio
     srv, _ = server_with_index
     srv._BUILD_LOCK = None  # ensure fresh lock
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -157,15 +157,16 @@ class TestCallersOfCompleteness:
 
     def test_complete_when_no_misses(self) -> None:
         idx = _make_idx(self._RAW, missed_callers={})
-        result = idx.callers_of("pkg.mod.helper")
+        result = idx.refers_to("pkg.mod.helper", kind="callers")
         assert result["completeness"] == "complete"
 
     def test_partial_when_result_has_direct_miss(self) -> None:
         missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
         idx = _make_idx(self._RAW, missed_callers=missed)
-        result = idx.callers_of("pkg.mod.helper")
+        result = idx.refers_to("pkg.mod.helper", kind="callers")
         # pkg.mod.MyClass.foo is in results and directly in missed_callers
-        assert "pkg.mod.MyClass.foo" in result["results"]
+        fqns = [e["fqn"] for e in result["results"]]
+        assert "pkg.mod.MyClass.foo" in fqns
         assert result["completeness"] == "partial"
 
     def test_partial_when_result_has_class_sibling_miss(self) -> None:
@@ -177,8 +178,9 @@ class TestCallersOfCompleteness:
         }
         missed = {"pkg.mod.MyClass.foo": {"getattr_nonliteral": 3}}
         idx = _make_idx(raw, missed_callers=missed)
-        result = idx.callers_of("pkg.mod.helper")
-        assert "pkg.mod.MyClass.bar" in result["results"]
+        result = idx.refers_to("pkg.mod.helper", kind="callers")
+        fqns = [e["fqn"] for e in result["results"]]
+        assert "pkg.mod.MyClass.bar" in fqns
         assert result["completeness"] == "partial"
 
     def test_complete_for_top_level_sibling_miss(self) -> None:
@@ -190,12 +192,12 @@ class TestCallersOfCompleteness:
         }
         missed = {"pkg.mod.dirty_func": {"bare_name_unresolved": 1}}
         idx = _make_idx(raw, missed_callers=missed)
-        result = idx.callers_of("pkg.mod.helper")
+        result = idx.refers_to("pkg.mod.helper", kind="callers")
         assert result["completeness"] == "complete"
 
     def test_completeness_field_always_present(self) -> None:
         idx = _make_idx(self._RAW, missed_callers={})
-        result = idx.callers_of("pkg.mod.helper")
+        result = idx.refers_to("pkg.mod.helper", kind="callers")
         assert "completeness" in result
 
 
@@ -296,7 +298,7 @@ class TestModuleCompleteness:
 
     def test_module_callers_complete_when_no_misses(self) -> None:
         idx = _make_idx(self._RAW, missed_callers={}, skeletons=self._SKELETONS)
-        result = idx.module_callers("pkg.target")
+        result = idx.refers_to("pkg.target.helper", kind="callers", granularity="module")
         assert result["completeness"] == "complete"
 
     def test_module_callers_partial_when_symbol_in_result_module_is_missed(self) -> None:
@@ -305,7 +307,7 @@ class TestModuleCompleteness:
         # is what appears in the module graph and in the module_callers result.
         missed = {"pkg.other.SomeClass.method": {"getattr_nonliteral": 2}}
         idx = _make_idx(self._RAW, missed_callers=missed, skeletons=self._SKELETONS)
-        result = idx.module_callers("pkg.target")
+        result = idx.refers_to("pkg.target.helper", kind="callers", granularity="module")
         # The module graph reports the caller as "pkg.other.SomeClass"
         assert "pkg.other.SomeClass" in result["results"]
         assert result["completeness"] == "partial"
@@ -322,7 +324,7 @@ class TestModuleCompleteness:
             "pkg/target.py": [_sym("pkg.target.helper")],
         }
         idx = _make_idx(self._RAW, missed_callers=missed, skeletons=skeletons)
-        result = idx.module_callers("pkg.target")
+        result = idx.refers_to("pkg.target.helper", kind="callers", granularity="module")
         assert result["completeness"] == "partial"
 
     def test_module_callees_complete_when_no_misses(self) -> None:
@@ -340,7 +342,7 @@ class TestModuleCompleteness:
 
     def test_module_completeness_field_always_present(self) -> None:
         idx = _make_idx(self._RAW, missed_callers={}, skeletons=self._SKELETONS)
-        result = idx.module_callers("pkg.target")
+        result = idx.refers_to("pkg.target.helper", kind="callers", granularity="module")
         assert "completeness" in result
         result2 = idx.module_callees("pkg.other")
         assert "completeness" in result2

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -409,7 +409,6 @@ class TestV5Schema:
 
     @pytest.mark.parametrize("old_version", [1, 2, 3, 4])
     def test_load_rejects_old_versions(self, tmp_path: Path, old_version: int) -> None:
-        from pyscope_mcp.graph import INDEX_VERSION
         payload = {
             "version": old_version,
             "root": "/tmp/test",

--- a/tests/test_component_issue62.py
+++ b/tests/test_component_issue62.py
@@ -174,11 +174,11 @@ def test_saved_payload_has_git_sha_and_content_hash_keys(tmp_path: Path) -> None
 # ---------------------------------------------------------------------------
 
 def test_callers_of_has_dropped_field(tmp_path: Path) -> None:
-    """callers_of result always contains a 'dropped' key (0 when not truncated)."""
+    """refers_to result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
     idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
-    result = idx.callers_of("pkg.mod.bar", depth=1)
-    assert "dropped" in result, "callers_of must include 'dropped' in result dict"
+    result = idx.refers_to("pkg.mod.bar", kind="callers", depth=1)
+    assert "dropped" in result, "refers_to must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
     assert result["dropped"] == 0  # small fixture, no truncation
 
@@ -194,11 +194,11 @@ def test_callees_of_has_dropped_field(tmp_path: Path) -> None:
 
 
 def test_module_callers_has_dropped_field(tmp_path: Path) -> None:
-    """module_callers result always contains a 'dropped' key (0 when not truncated)."""
+    """refers_to(module) result always contains a 'dropped' key (0 when not truncated)."""
     raw = _make_minimal_raw()
     idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw))
-    result = idx.module_callers("pkg.mod", depth=1)
-    assert "dropped" in result, "module_callers must include 'dropped' in result dict"
+    result = idx.refers_to("pkg.mod.bar", kind="callers", granularity="module", depth=1)
+    assert "dropped" in result, "refers_to(module) must include 'dropped' in result dict"
     assert isinstance(result["dropped"], int)
     assert result["dropped"] == 0
 
@@ -286,15 +286,15 @@ def _server_with_index(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_rpc_callers_of_response_has_dropped(_server_with_index) -> None:
-    """callers_of tool response JSON must include 'dropped' key."""
-    lines = [_req("tools/call", {"name": "callers_of", "arguments": {"fqn": "pkg.mod.bar"}}, req_id=1)]
+    """refers_to tool response JSON must include 'dropped' key."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "kind": "callers"}}, req_id=1)]
     responses = await _run_server(_server_with_index, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
     payload = json.loads(r["content"][0]["text"])
     assert "dropped" in payload, (
-        "callers_of RPC response must include 'dropped' field — "
-        "types.CallersResult was updated in issue #62 but server serialisation may be missing it"
+        "refers_to RPC response must include 'dropped' field — "
+        "types.ReferencedByResult was updated in issue #71 but server serialisation may be missing it"
     )
     assert isinstance(payload["dropped"], int)
     assert payload["dropped"] == 0  # small fixture, no cap triggered
@@ -317,14 +317,14 @@ async def test_rpc_callees_of_response_has_dropped(_server_with_index) -> None:
 
 @pytest.mark.asyncio
 async def test_rpc_module_callers_response_has_dropped(_server_with_index) -> None:
-    """module_callers tool response JSON must include 'dropped' key."""
-    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "pkg.mod"}}, req_id=1)]
+    """refers_to(module) tool response JSON must include 'dropped' key."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "kind": "callers", "granularity": "module"}}, req_id=1)]
     responses = await _run_server(_server_with_index, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
     payload = json.loads(r["content"][0]["text"])
     assert "dropped" in payload, (
-        "module_callers RPC response must include 'dropped' field"
+        "refers_to(module) RPC response must include 'dropped' field"
     )
     assert isinstance(payload["dropped"], int)
     assert payload["dropped"] == 0

--- a/tests/test_component_issue66.py
+++ b/tests/test_component_issue66.py
@@ -21,7 +21,6 @@ Three cross-module boundaries tested:
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -327,7 +326,6 @@ class TestB3CliToGraph:
         When git rev-parse HEAD succeeds, cmd_build() calls from_raw(..., git_sha=sha)
         and the resulting index must contain that SHA after save+load.
         """
-        from unittest.mock import call
 
         # Create a minimal package structure so the analyzer can run.
         pkg_dir = tmp_path / "mypkg"

--- a/tests/test_component_issue66.py
+++ b/tests/test_component_issue66.py
@@ -140,12 +140,12 @@ class TestB1GraphToTypes:
         idx = CallGraphIndex.from_nodes(str(tmp_path), make_nodes(raw), git_sha=_MOCK_INDEX_SHA)
 
         with patch("subprocess.run", return_value=_git_ok(_MOCK_HEAD_SHA)):
-            result = idx.callers_of("pkg.mod.beta", depth=1)
+            result = idx.refers_to("pkg.mod.beta", kind="callers", depth=1)
 
         # [Assert] All three commit fields are present.
-        assert "commit_stale" in result, "commit_stale must be in callers_of result"
-        assert "index_git_sha" in result, "index_git_sha must be in callers_of result"
-        assert "head_git_sha" in result, "head_git_sha must be in callers_of result"
+        assert "commit_stale" in result, "commit_stale must be in refers_to result"
+        assert "index_git_sha" in result, "index_git_sha must be in refers_to result"
+        assert "head_git_sha" in result, "head_git_sha must be in refers_to result"
 
         # [Assert] Types match the TypedDict contract (NotRequired[bool|None] / NotRequired[str|None]).
         assert isinstance(result["commit_stale"], bool), (

--- a/tests/test_component_issue69.py
+++ b/tests/test_component_issue69.py
@@ -174,7 +174,7 @@ class TestB1FqnNotFoundErrorPropagation:
     # ------------------------------------------------------------------
 
     def test_graph_callers_of_bad_fqn_returns_is_error(self, tmp_path: Path) -> None:
-        """[B1-graph] callers_of with absent FQN returns isError:True dict.
+        """[B1-graph] refers_to with absent FQN returns isError:True dict.
 
         Verifies the graph-layer contract in isolation: the dict must have
         isError=True and error_reason="fqn_not_in_graph".  Stale must be
@@ -187,11 +187,11 @@ class TestB1FqnNotFoundErrorPropagation:
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
-            result = idx.callers_of("does.not.exist", depth=1)
+            result = idx.refers_to("does.not.exist", kind="callers", depth=1)
 
         # Assert
         assert result.get("isError") is True, (
-            "callers_of must return isError:True for an absent FQN"
+            "refers_to must return isError:True for an absent FQN"
         )
         assert result.get("error_reason") == "fqn_not_in_graph", (
             f"error_reason must be 'fqn_not_in_graph', got {result.get('error_reason')!r}"
@@ -234,7 +234,7 @@ class TestB1FqnNotFoundErrorPropagation:
     def test_graph_callers_of_known_fqn_zero_callers_returns_empty_results(
         self, tmp_path: Path
     ) -> None:
-        """[B1-graph] callers_of a known FQN with zero callers returns results:[] not isError.
+        """[B1-graph] refers_to a known FQN with zero callers returns results:[] not isError.
 
         Negative case: the isError path must NOT trigger when the FQN is present
         but simply has no callers.
@@ -245,15 +245,15 @@ class TestB1FqnNotFoundErrorPropagation:
 
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
-            result = idx.callers_of("pkg.other.gamma", depth=1)
+            result = idx.refers_to("pkg.other.gamma", kind="callers", depth=1)
 
         # Assert
         assert result.get("isError") is not True, (
-            "callers_of must NOT set isError for a known FQN with zero callers"
+            "refers_to must NOT set isError for a known FQN with zero callers"
         )
-        assert "results" in result, "callers_of must include 'results' key"
+        assert "results" in result, "refers_to must include 'results' key"
         assert result["results"] == [], (
-            "callers_of for a node with zero callers must return results:[]"
+            "refers_to for a node with zero callers must return results:[]"
         )
 
     def test_graph_callees_of_known_fqn_zero_callees_returns_empty_results(
@@ -303,9 +303,9 @@ class TestB1FqnNotFoundErrorPropagation:
     async def test_server_dispatch_callers_of_bad_fqn_is_error_true(
         self, tmp_path: Path
     ) -> None:
-        """[B1-server] _dispatch_tool('callers_of', bad FQN) surfaces isError:true.
+        """[B1-server] _dispatch_tool('refers_to', bad FQN) surfaces isError:true.
 
-        Verifies the server.py isError-check path for callers_of:
+        Verifies the server.py isError-check path for refers_to:
           result.get("isError") → True  ⟹  MCP response isError:True
         The content text must be valid JSON and must contain error_reason.
         """
@@ -318,7 +318,7 @@ class TestB1FqnNotFoundErrorPropagation:
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
             response = await _srv._dispatch_tool(
-                "callers_of", {"fqn": "no.such.function"}
+                "refers_to", {"fqn": "no.such.function", "kind": "callers"}
             )
 
         # Assert
@@ -385,7 +385,7 @@ class TestB1FqnNotFoundErrorPropagation:
     async def test_server_dispatch_callers_of_known_fqn_is_error_false(
         self, tmp_path: Path
     ) -> None:
-        """[B1-server] _dispatch_tool('callers_of', known FQN) returns isError:false.
+        """[B1-server] _dispatch_tool('refers_to', known FQN) returns isError:false.
 
         Negative case: server must NOT set isError:true for a valid FQN that
         simply has zero callers.  Verifies the _text() path is taken instead.
@@ -399,7 +399,7 @@ class TestB1FqnNotFoundErrorPropagation:
         # Act
         with patch("subprocess.run", return_value=_git_fail()):
             response = await _srv._dispatch_tool(
-                "callers_of", {"fqn": "pkg.other.gamma"}
+                "refers_to", {"fqn": "pkg.other.gamma", "kind": "callers"}
             )
 
         # Assert
@@ -419,10 +419,10 @@ class TestB1FqnNotFoundErrorPropagation:
     async def test_rpc_callers_of_bad_fqn_is_error_true(
         self, _wired_server
     ) -> None:
-        """[B1-rpc] callers_of with absent FQN: full RPC loop propagates isError:true.
+        """[B1-rpc] refers_to with absent FQN: full RPC loop propagates isError:true.
 
         Exercises: JSON-RPC request → _SERVER._loop → _tools_call →
-        _dispatch_tool("callers_of") → isError check → MCP response with
+        _dispatch_tool("refers_to") → isError check → MCP response with
         isError:true and error_reason in content JSON.
         """
         server, srv, _ = _wired_server
@@ -431,7 +431,7 @@ class TestB1FqnNotFoundErrorPropagation:
         lines = [
             _rpc_req(
                 "tools/call",
-                {"name": "callers_of", "arguments": {"fqn": "absolute.garbage.fqn"}},
+                {"name": "refers_to", "arguments": {"fqn": "absolute.garbage.fqn", "kind": "callers"}},
                 req_id=1,
             )
         ]
@@ -513,7 +513,7 @@ class TestB1FqnNotFoundErrorPropagation:
     async def test_rpc_callers_of_valid_fqn_is_error_false(
         self, _wired_server
     ) -> None:
-        """[B1-rpc] callers_of with a valid FQN: full RPC loop does NOT set isError.
+        """[B1-rpc] refers_to with a valid FQN: full RPC loop does NOT set isError.
 
         Negative-path test: ensures the isError propagation is gated correctly
         and a well-formed FQN with zero callers does not accidentally surface as
@@ -525,7 +525,7 @@ class TestB1FqnNotFoundErrorPropagation:
         lines = [
             _rpc_req(
                 "tools/call",
-                {"name": "callers_of", "arguments": {"fqn": "pkg.other.gamma"}},
+                {"name": "refers_to", "arguments": {"fqn": "pkg.other.gamma", "kind": "callers"}},
                 req_id=4,
             )
         ]

--- a/tests/test_component_issue71.py
+++ b/tests/test_component_issue71.py
@@ -1,0 +1,595 @@
+"""Component tests for issue #71 — refers_to typed symbol lookup.
+
+Three cross-module boundaries tested:
+
+  B1 (graph.py → server.py): refers_to with kind='all' uses the new
+     _bfs_nodes_called_by path and context-priority logic.  The server's
+     _dispatch_tool must pass kind/granularity/depth arguments through
+     correctly and must NOT wrap a successful multi-kind result in
+     isError:True.  The result dict content text must deserialize to a
+     payload with a 'results' list of function-granularity entries, each
+     containing 'fqn', 'context', and 'depth' fields.
+
+  B2 (graph.py → server.py): refers_to with granularity='module' returns
+     a flat list of module FQN strings, not a list of dicts.  The server's
+     _text() serialization path must not trigger the isError branch.  The
+     content text must deserialize to a payload where 'results' is a list
+     of strings (module FQNs), not a list of dicts.
+
+  B3 (graph.py → server.py): refers_to with depth=2 traverses hop-2 BFS
+     in _bfs_nodes_called_by.  Results must include both depth-1 and
+     depth-2 referrers, and every entry in the function-granularity result
+     must carry a 'depth' field that correctly distinguishes the two hops.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
+import pyscope_mcp.server as _srv
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _git_fail() -> MagicMock:
+    """Fake subprocess.run result: git unavailable."""
+    m = MagicMock()
+    m.returncode = 128
+    m.stdout = ""
+    return m
+
+
+def _nodes_with_kind(fqn_from: str, fqn_to: str, kind: str) -> dict[str, dict]:
+    """Build a minimal nodes dict with one directional edge of the given kind."""
+    return {
+        fqn_from: {
+            "calls": {kind: [fqn_to]},
+            "called_by": {},
+        },
+        fqn_to: {
+            "calls": {},
+            "called_by": {kind: [fqn_from]},
+        },
+    }
+
+
+def _merge_nodes(*node_dicts: dict[str, dict]) -> dict[str, dict]:
+    """Merge multiple node dicts, union-ing their calls/called_by buckets."""
+    merged: dict[str, dict] = {}
+    for nd in node_dicts:
+        for fqn, node in nd.items():
+            if fqn not in merged:
+                merged[fqn] = {"calls": {}, "called_by": {}}
+            for kind, targets in node.get("calls", {}).items():
+                merged[fqn]["calls"].setdefault(kind, [])
+                merged[fqn]["calls"][kind] = sorted(
+                    set(merged[fqn]["calls"][kind]) | set(targets)
+                )
+            for kind, sources in node.get("called_by", {}).items():
+                merged[fqn]["called_by"].setdefault(kind, [])
+                merged[fqn]["called_by"][kind] = sorted(
+                    set(merged[fqn]["called_by"][kind]) | set(sources)
+                )
+    return merged
+
+
+def _make_multi_kind_nodes() -> dict[str, dict]:
+    """Graph with import and annotation (non-call) edges to target.
+
+    pkg.target.Symbol  ← import     — pkg.a.importer
+    pkg.target.Symbol  ← annotation — pkg.b.annotator
+    """
+    target = "pkg.target.Symbol"
+    return _merge_nodes(
+        _nodes_with_kind("pkg.a.importer", target, "import"),
+        _nodes_with_kind("pkg.b.annotator", target, "annotation"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# B1 — graph.py → server.py: kind='all' multi-kind edge propagation
+# ---------------------------------------------------------------------------
+
+class TestB1KindAllPath:
+    """B1: server dispatches refers_to(kind='all') — _bfs_nodes_called_by path."""
+
+    def test_graph_refers_to_kind_all_finds_non_call_referrer(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-graph] refers_to(kind='all') must find an import-edge referrer.
+
+        Verifies that _bfs_nodes_called_by is reached and returns the
+        import-edge referrer when kind='all' is specified.
+        """
+        # Arrange
+        nodes = _make_multi_kind_nodes()
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to("pkg.target.Symbol", kind="all", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True, (
+            f"refers_to(kind='all') must not set isError for a present FQN; got: {result}"
+        )
+        fqns = [e["fqn"] for e in result["results"]]
+        assert "pkg.a.importer" in fqns, (
+            f"import-edge referrer must appear in kind='all' results; got fqns={fqns}"
+        )
+        assert "pkg.b.annotator" in fqns, (
+            f"annotation-edge referrer must appear in kind='all' results; got fqns={fqns}"
+        )
+
+    def test_graph_refers_to_kind_all_context_field_reflects_edge_kind(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-graph] context field must reflect the actual edge kind in kind='all' mode.
+
+        An import-edge referrer must have context='import'; an annotation-edge
+        referrer must have context='annotation'.
+        """
+        # Arrange
+        nodes = _make_multi_kind_nodes()
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to("pkg.target.Symbol", kind="all", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True
+        by_fqn = {e["fqn"]: e for e in result["results"]}
+
+        importer_entry = by_fqn.get("pkg.a.importer")
+        assert importer_entry is not None, "import-edge referrer must be in results"
+        assert importer_entry["context"] == "import", (
+            f"import-edge referrer must have context='import', "
+            f"got context={importer_entry['context']!r}"
+        )
+
+        annotator_entry = by_fqn.get("pkg.b.annotator")
+        assert annotator_entry is not None, "annotation-edge referrer must be in results"
+        assert annotator_entry["context"] == "annotation", (
+            f"annotation-edge referrer must have context='annotation', "
+            f"got context={annotator_entry['context']!r}"
+        )
+
+    def test_graph_refers_to_kind_all_call_wins_context_priority(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-graph] When a function has both import and call edges, context must be 'call'.
+
+        Context priority: call > import > except > annotation > isinstance.
+        """
+        # Arrange — one referrer with both call and import edges to target
+        target = "pkg.target.Symbol"
+        referrer = "pkg.dual.consumer"
+        nodes = _merge_nodes(
+            _nodes_with_kind(referrer, target, "call"),
+            _nodes_with_kind(referrer, target, "import"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to(target, kind="all", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True
+        entries = [e for e in result["results"] if e["fqn"] == referrer]
+        assert len(entries) == 1, (
+            f"referrer must appear exactly once; got {len(entries)} entries"
+        )
+        assert entries[0]["context"] == "call", (
+            f"'call' must win context priority over 'import'; "
+            f"got context={entries[0]['context']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_refers_to_kind_all_is_not_error(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-server] _dispatch_tool('refers_to', kind='all') must return isError:False.
+
+        Verifies the wiring: server.py passes kind='all' to graph.py, receives
+        a non-error result, and wraps it with _text() rather than the isError
+        branch.
+        """
+        # Arrange
+        nodes = _make_multi_kind_nodes()
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "refers_to",
+                {"fqn": "pkg.target.Symbol", "kind": "all", "granularity": "function"},
+            )
+
+        # Assert
+        assert response.get("isError") is False, (
+            "server _dispatch_tool must return isError:False for a successful "
+            f"kind='all' lookup; got response={response}"
+        )
+        content_text = response["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert "results" in payload, (
+            f"response content must contain 'results' key; keys={list(payload)}"
+        )
+        fqns = [e["fqn"] for e in payload["results"]]
+        assert "pkg.a.importer" in fqns, (
+            f"import-edge referrer must appear in server response; fqns={fqns}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_refers_to_kind_all_function_entry_shape(
+        self, tmp_path: Path
+    ) -> None:
+        """[B1-server] Function-granularity entries in kind='all' response must have fqn/context/depth.
+
+        Verifies that the context field (reflecting edge kind) survives
+        serialisation through _text() and JSON deserialization.
+        """
+        # Arrange — single referrer via import edge
+        target = "pkg.target.Symbol"
+        nodes = _nodes_with_kind("pkg.a.importer", target, "import")
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "refers_to",
+                {"fqn": target, "kind": "all", "granularity": "function"},
+            )
+
+        # Assert
+        assert response.get("isError") is False
+        payload = json.loads(response["content"][0]["text"])
+        results = payload["results"]
+        assert len(results) == 1, f"expected 1 result, got {len(results)}"
+        entry = results[0]
+        for field in ("fqn", "context", "depth"):
+            assert field in entry, (
+                f"function-granularity entry must have '{field}' field; keys={list(entry)}"
+            )
+        assert entry["fqn"] == "pkg.a.importer"
+        assert entry["context"] == "import", (
+            f"context must be 'import' for an import-edge referrer; got {entry['context']!r}"
+        )
+        assert entry["depth"] == 1
+
+
+# ---------------------------------------------------------------------------
+# B2 — graph.py → server.py: granularity='module' result shape
+# ---------------------------------------------------------------------------
+
+class TestB2ModuleGranularity:
+    """B2: server dispatches refers_to(granularity='module') — flat string list path."""
+
+    def test_graph_refers_to_module_granularity_returns_string_list(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2-graph] refers_to(granularity='module') must return a flat list of module FQN strings."""
+        # Arrange — two referrers from different modules
+        target = "pkg.target.fn"
+        nodes = _merge_nodes(
+            _nodes_with_kind("pkg.mod_a.caller", target, "call"),
+            _nodes_with_kind("pkg.mod_b.importer", target, "import"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to(target, kind="all", granularity="module", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True
+        assert "results" in result
+        for item in result["results"]:
+            assert isinstance(item, str), (
+                f"module-granularity results must be strings, got {type(item)}: {item!r}"
+            )
+        assert "pkg.mod_a" in result["results"], (
+            f"pkg.mod_a must appear; results={result['results']}"
+        )
+        assert "pkg.mod_b" in result["results"], (
+            f"pkg.mod_b must appear; results={result['results']}"
+        )
+
+    def test_graph_refers_to_module_granularity_deduplicates(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2-graph] Two referrers from the same module must produce that module only once."""
+        # Arrange — both callers are in pkg.shared_mod
+        target = "pkg.target.fn"
+        nodes = _merge_nodes(
+            _nodes_with_kind("pkg.shared_mod.func_a", target, "call"),
+            _nodes_with_kind("pkg.shared_mod.func_b", target, "import"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to(target, kind="all", granularity="module", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True
+        count = result["results"].count("pkg.shared_mod")
+        assert count == 1, (
+            f"pkg.shared_mod must appear exactly once; results={result['results']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_refers_to_module_granularity_is_not_error(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2-server] _dispatch_tool('refers_to', granularity='module') must return isError:False.
+
+        The server _text() serialization path must accept a flat list of strings
+        without triggering the isError branch.
+        """
+        # Arrange
+        target = "pkg.target.fn"
+        nodes = _merge_nodes(
+            _nodes_with_kind("pkg.mod_a.caller", target, "call"),
+            _nodes_with_kind("pkg.mod_b.importer", target, "import"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "refers_to",
+                {"fqn": target, "kind": "all", "granularity": "module"},
+            )
+
+        # Assert
+        assert response.get("isError") is False, (
+            "server _dispatch_tool must return isError:False for module-granularity "
+            f"refers_to; got response={response}"
+        )
+        content_text = response["content"][0]["text"]
+        payload = json.loads(content_text)
+        assert "results" in payload
+        for item in payload["results"]:
+            assert isinstance(item, str), (
+                f"module-granularity results in server response must be strings; "
+                f"got {type(item)}: {item!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_refers_to_module_granularity_modules_present(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2-server] Module FQNs must survive serialization through the server layer."""
+        # Arrange
+        target = "pkg.target.fn"
+        nodes = _merge_nodes(
+            _nodes_with_kind("pkg.mod_a.caller", target, "call"),
+            _nodes_with_kind("pkg.mod_b.importer", target, "import"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "refers_to",
+                {"fqn": target, "kind": "all", "granularity": "module"},
+            )
+
+        # Assert
+        payload = json.loads(response["content"][0]["text"])
+        assert "pkg.mod_a" in payload["results"], (
+            f"pkg.mod_a must survive server serialization; results={payload['results']}"
+        )
+        assert "pkg.mod_b" in payload["results"], (
+            f"pkg.mod_b must survive server serialization; results={payload['results']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B3 — graph.py → server.py: depth=2 multi-hop BFS propagation
+# ---------------------------------------------------------------------------
+
+class TestB3Depth2Propagation:
+    """B3: server dispatches refers_to(depth=2) — hop-2 BFS in _bfs_nodes_called_by."""
+
+    def test_graph_refers_to_depth2_includes_hop2_referrer(
+        self, tmp_path: Path
+    ) -> None:
+        """[B3-graph] refers_to(depth=2) must include depth-2 referrers via call edges.
+
+        Hop-2 traversal: start ← (import) hop1_ref ← (call) hop2_caller.
+        The hop-2 caller reaches start through hop1_ref via a call edge.
+        """
+        # Arrange
+        target = "pkg.target.fn"
+        hop1 = "pkg.hop1.importer"   # imports target
+        hop2 = "pkg.hop2.caller"     # calls hop1
+
+        nodes = _merge_nodes(
+            _nodes_with_kind(hop1, target, "import"),  # hop1 → target (import)
+            _nodes_with_kind(hop2, hop1, "call"),      # hop2 → hop1 (call)
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to(target, kind="all", depth=2)
+
+        # Assert
+        assert result.get("isError") is not True, (
+            f"refers_to(depth=2) must not be an error; got: {result}"
+        )
+        fqns = [e["fqn"] for e in result["results"]]
+        assert hop1 in fqns, f"hop-1 referrer {hop1!r} must be in depth=2 results; fqns={fqns}"
+        assert hop2 in fqns, f"hop-2 caller {hop2!r} must be in depth=2 results; fqns={fqns}"
+
+    def test_graph_refers_to_depth2_depth_field_distinguishes_hops(
+        self, tmp_path: Path
+    ) -> None:
+        """[B3-graph] depth field in results must correctly distinguish hop-1 vs hop-2."""
+        # Arrange
+        target = "pkg.target.fn"
+        hop1 = "pkg.hop1.importer"
+        hop2 = "pkg.hop2.caller"
+
+        nodes = _merge_nodes(
+            _nodes_with_kind(hop1, target, "import"),
+            _nodes_with_kind(hop2, hop1, "call"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to(target, kind="all", depth=2)
+
+        # Assert
+        assert result.get("isError") is not True
+        by_fqn = {e["fqn"]: e for e in result["results"]}
+
+        hop1_entry = by_fqn.get(hop1)
+        assert hop1_entry is not None, f"{hop1!r} must be in results"
+        assert hop1_entry["depth"] == 1, (
+            f"hop-1 referrer must have depth=1; got depth={hop1_entry['depth']}"
+        )
+
+        hop2_entry = by_fqn.get(hop2)
+        assert hop2_entry is not None, f"{hop2!r} must be in results"
+        assert hop2_entry["depth"] == 2, (
+            f"hop-2 caller must have depth=2; got depth={hop2_entry['depth']}"
+        )
+
+    def test_graph_refers_to_depth1_excludes_hop2(
+        self, tmp_path: Path
+    ) -> None:
+        """[B3-graph] depth=1 must NOT include hop-2 callers.
+
+        Negative control for the depth parameter: the same graph with depth=1
+        must exclude the hop-2 caller that depth=2 includes.
+        """
+        # Arrange
+        target = "pkg.target.fn"
+        hop1 = "pkg.hop1.importer"
+        hop2 = "pkg.hop2.caller"
+
+        nodes = _merge_nodes(
+            _nodes_with_kind(hop1, target, "import"),
+            _nodes_with_kind(hop2, hop1, "call"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            result = idx.refers_to(target, kind="all", depth=1)
+
+        # Assert
+        assert result.get("isError") is not True
+        fqns = [e["fqn"] for e in result["results"]]
+        assert hop1 in fqns, "hop-1 referrer must still appear with depth=1"
+        assert hop2 not in fqns, (
+            f"hop-2 caller must NOT appear with depth=1; got fqns={fqns}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_refers_to_depth2_is_not_error(
+        self, tmp_path: Path
+    ) -> None:
+        """[B3-server] _dispatch_tool('refers_to', depth=2) must return isError:False.
+
+        Verifies that the server correctly passes depth=2 to graph.py and
+        serializes the multi-hop result without triggering the isError branch.
+        """
+        # Arrange
+        target = "pkg.target.fn"
+        hop1 = "pkg.hop1.importer"
+        hop2 = "pkg.hop2.caller"
+        nodes = _merge_nodes(
+            _nodes_with_kind(hop1, target, "import"),
+            _nodes_with_kind(hop2, hop1, "call"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "refers_to",
+                {"fqn": target, "kind": "all", "depth": 2},
+            )
+
+        # Assert
+        assert response.get("isError") is False, (
+            f"server must return isError:False for depth=2 refers_to; got: {response}"
+        )
+        payload = json.loads(response["content"][0]["text"])
+        assert "results" in payload
+        fqns = [e["fqn"] for e in payload["results"]]
+        assert hop1 in fqns, f"hop-1 referrer must be in server response; fqns={fqns}"
+        assert hop2 in fqns, f"hop-2 caller must be in server response; fqns={fqns}"
+
+    @pytest.mark.asyncio
+    async def test_server_dispatch_refers_to_depth2_depth_field_survives_serialization(
+        self, tmp_path: Path
+    ) -> None:
+        """[B3-server] depth field per entry must survive _text() serialization.
+
+        The depth field distinguishes hop-1 from hop-2 referrers.  It must be
+        present in the deserialized server response.
+        """
+        # Arrange
+        target = "pkg.target.fn"
+        hop1 = "pkg.hop1.importer"
+        hop2 = "pkg.hop2.caller"
+        nodes = _merge_nodes(
+            _nodes_with_kind(hop1, target, "import"),
+            _nodes_with_kind(hop2, hop1, "call"),
+        )
+        idx = CallGraphIndex.from_nodes(str(tmp_path), nodes)
+        _srv._INDEX = idx
+        _srv._INDEX_PATH = tmp_path / "index.json"
+
+        # Act
+        with patch("subprocess.run", return_value=_git_fail()):
+            response = await _srv._dispatch_tool(
+                "refers_to",
+                {"fqn": target, "kind": "all", "depth": 2},
+            )
+
+        # Assert
+        assert response.get("isError") is False
+        payload = json.loads(response["content"][0]["text"])
+        by_fqn = {e["fqn"]: e for e in payload["results"]}
+
+        hop1_entry = by_fqn.get(hop1)
+        assert hop1_entry is not None
+        assert "depth" in hop1_entry, "depth field must survive serialization"
+        assert hop1_entry["depth"] == 1, (
+            f"hop-1 referrer depth must be 1; got {hop1_entry['depth']}"
+        )
+
+        hop2_entry = by_fqn.get(hop2)
+        assert hop2_entry is not None
+        assert "depth" in hop2_entry, "depth field must survive serialization"
+        assert hop2_entry["depth"] == 2, (
+            f"hop-2 caller depth must be 2; got {hop2_entry['depth']}"
+        )

--- a/tests/test_component_issue71.py
+++ b/tests/test_component_issue71.py
@@ -26,13 +26,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pyscope_mcp.graph import CallGraphIndex
-from conftest import make_nodes
 import pyscope_mcp.server as _srv
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -25,7 +25,7 @@ def test_from_raw_builds_graphs() -> None:
 
 def test_queries() -> None:
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
-    # callers_of / callees_of now return dict shapes
+    # callees_of returns dict shape
     callees = idx.callees_of("sample.a.top", depth=1)
     assert isinstance(callees, dict)
     assert "results" in callees
@@ -35,11 +35,14 @@ def test_queries() -> None:
     callees_deep = idx.callees_of("sample.a.top", depth=2)
     assert "sample.b.inner" in callees_deep["results"]
 
-    callers = idx.callers_of("sample.b.helper", depth=1)
+    # refers_to(kind="callers") replaces callers_of
+    callers = idx.refers_to("sample.b.helper", kind="callers", depth=1)
     assert isinstance(callers, dict)
     assert "results" in callers
     assert "truncated" in callers
-    assert "sample.a.top" in callers["results"]
+    # function granularity returns entries with fqn field
+    fqns = [e["fqn"] for e in callers["results"]]
+    assert "sample.a.top" in fqns
 
     result = idx.search("helper")
     assert result["results"] == ["sample.b.helper"]
@@ -92,15 +95,14 @@ def _prefix_raw() -> dict[str, list[str]]:
 
 
 def test_module_callers_prefix_match() -> None:
-    """module_callers with a prefix returns callers of all matched modules."""
+    """refers_to(kind="callers", granularity="module") with a prefix returns callers of all matched modules."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
-    result = idx.module_callers("pkg.agents")
+    result = idx.refers_to("pkg.agents.writer.write", kind="callers", granularity="module")
     assert result["truncated"] is False
-    # pkg.core calls into pkg.agents.writer and pkg.agents.reader
+    # pkg.core calls into pkg.agents.writer.write
     assert "pkg.core" in result["results"]
     # The matched seeds themselves must NOT appear in results
     assert "pkg.agents.writer" not in result["results"]
-    assert "pkg.agents.reader" not in result["results"]
 
 
 def test_module_callees_prefix_match() -> None:
@@ -114,9 +116,9 @@ def test_module_callees_prefix_match() -> None:
 
 
 def test_module_callers_exact_match_backward_compat() -> None:
-    """An exact FQN returns the same callers as before, now in structured form."""
+    """An exact FQN via refers_to(kind='callers', granularity='module') returns structured form."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
-    result = idx.module_callers("pkg.agents.writer")
+    result = idx.refers_to("pkg.agents.writer.write", kind="callers", granularity="module")
     assert isinstance(result, dict)
     assert "results" in result
     assert "truncated" in result
@@ -125,12 +127,12 @@ def test_module_callers_exact_match_backward_compat() -> None:
 
 
 def test_module_callers_no_match() -> None:
-    """A prefix matching no module nodes returns empty results, no error."""
+    """A nonexistent FQN via refers_to returns fqn_not_in_graph error."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
-    result = idx.module_callers("nonexistent.pkg")
-    assert result["results"] == []
-    assert result["truncated"] is False
-    assert "stale" in result  # staleness fields always present
+    result = idx.refers_to("nonexistent.pkg.fn", kind="callers", granularity="module")
+    # nonexistent FQN → isError
+    assert result.get("isError") is True
+    assert result["error_reason"] == "fqn_not_in_graph"
 
 
 def test_module_callees_no_match() -> None:
@@ -143,11 +145,10 @@ def test_module_callees_no_match() -> None:
 
 
 def test_module_callers_empty_prefix() -> None:
-    """Empty-string prefix matches all modules; returns structured dict with no error."""
+    """refers_to with a function FQN that has no callers returns empty results."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
-    result = idx.module_callers("")
-    # All modules are seeds — callers within the same set are excluded.
-    # The important invariants are shape and no error.
+    # pkg.io.disk.save has no callers in the call graph
+    result = idx.refers_to("pkg.io.disk.save", kind="callers", granularity="module")
     assert isinstance(result, dict)
     assert "results" in result
     assert "truncated" in result
@@ -168,13 +169,13 @@ def test_module_callees_empty_prefix() -> None:
 
 def test_module_callers_truncation() -> None:
     """When more than 50 distinct callers exist, truncated=True and len==50."""
-    # Build a graph where one "target" module has 60 distinct callers
+    # Build a graph where one "target" function has 60 distinct callers
     raw: dict[str, list[str]] = {}
     for i in range(60):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
-    result = idx.module_callers("target")
+    result = idx.refers_to("target.core.fn", kind="callers", granularity="module")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
 
@@ -218,19 +219,24 @@ def test_search_truncation() -> None:
 
 
 # ---------------------------------------------------------------------------
-# callers_of / callees_of — dict shape
+# refers_to — replaces callers_of / module_callers
 # ---------------------------------------------------------------------------
 
-def test_callers_of_returns_dict() -> None:
-    """callers_of returns {results: list[str], truncated: bool}, not a bare list."""
+def test_refers_to_callers_returns_dict() -> None:
+    """refers_to(kind='callers') returns {results: list[{fqn,context,depth}], truncated: bool}."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
-    result = idx.callers_of("sample.b.helper", depth=1)
+    result = idx.refers_to("sample.b.helper", kind="callers", depth=1)
     assert isinstance(result, dict)
     assert "results" in result
     assert "truncated" in result
     assert isinstance(result["results"], list)
     assert isinstance(result["truncated"], bool)
-    assert "sample.a.top" in result["results"]
+    fqns = [e["fqn"] for e in result["results"]]
+    assert "sample.a.top" in fqns
+    # All contexts should be "call" for kind="callers"
+    for entry in result["results"]:
+        assert entry["context"] == "call"
+        assert "depth" in entry
 
 
 def test_callees_of_returns_dict() -> None:
@@ -245,15 +251,15 @@ def test_callees_of_returns_dict() -> None:
     assert "sample.b.helper" in result["results"]
 
 
-def test_callers_of_truncation() -> None:
-    """callers_of caps at 50 and sets truncated=True when exceeded."""
+def test_refers_to_truncation() -> None:
+    """refers_to caps at 50 and sets truncated=True when exceeded."""
     # Build a raw graph where one function has 60 distinct callers
     raw: dict[str, list[str]] = {}
     for i in range(60):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
-    result = idx.callers_of("target.core.fn", depth=1)
+    result = idx.refers_to("target.core.fn", kind="callers", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
 
@@ -272,13 +278,13 @@ def test_callees_of_truncation() -> None:
 
 
 # ---------------------------------------------------------------------------
-# dropped field — callers_of / callees_of
+# dropped field — refers_to / callees_of
 # ---------------------------------------------------------------------------
 
-def test_callers_of_dropped_zero_when_not_truncated() -> None:
+def test_refers_to_dropped_zero_when_not_truncated() -> None:
     """dropped=0 when results fit within cap."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
-    result = idx.callers_of("sample.b.helper", depth=1)
+    result = idx.refers_to("sample.b.helper", kind="callers", depth=1)
     assert "dropped" in result
     assert result["dropped"] == 0
     assert result["truncated"] is False
@@ -293,14 +299,14 @@ def test_callees_of_dropped_zero_when_not_truncated() -> None:
     assert result["truncated"] is False
 
 
-def test_callers_of_dropped_correct_when_truncated() -> None:
+def test_refers_to_dropped_correct_when_truncated() -> None:
     """dropped equals the number of results beyond the 50-item cap."""
     raw: dict[str, list[str]] = {}
     for i in range(57):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
-    result = idx.callers_of("target.core.fn", depth=1)
+    result = idx.refers_to("target.core.fn", kind="callers", depth=1)
     assert result["truncated"] is True
     assert len(result["results"]) == 50
     assert result["dropped"] == 7
@@ -346,26 +352,27 @@ def _ranking_raw_callers() -> dict[str, list[str]]:
     return raw
 
 
-def test_callers_of_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
+def test_refers_to_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
     """Depth-1 callers appear before depth-2 callers in results, even when alphabetically later."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_ranking_raw_callers()))
-    result = idx.callers_of("target.fn", depth=2)
+    result = idx.refers_to("target.fn", kind="callers", depth=2)
+    fqns = [e["fqn"] for e in result["results"]]
 
     # depth-1 callers must be present despite sorting alphabetically after a_depth2 nodes
-    assert "z_depth1.mod.fn" in result["results"], (
+    assert "z_depth1.mod.fn" in fqns, (
         "depth-1 caller z_depth1.mod.fn absent — cap dropped it before depth-2 entries"
     )
-    assert "y_depth1.mod.fn" in result["results"], (
+    assert "y_depth1.mod.fn" in fqns, (
         "depth-1 caller y_depth1.mod.fn absent — cap dropped it before depth-2 entries"
     )
 
     # depth-1 callers must appear in the first part of the list
-    z_idx = result["results"].index("z_depth1.mod.fn")
-    y_idx = result["results"].index("y_depth1.mod.fn")
+    z_idx = fqns.index("z_depth1.mod.fn")
+    y_idx = fqns.index("y_depth1.mod.fn")
     # All depth-2 nodes that appear must come after both depth-1 callers
-    for item in result["results"]:
+    for item in fqns:
         if item.startswith("a_depth2"):
-            item_idx = result["results"].index(item)
+            item_idx = fqns.index(item)
             assert item_idx > z_idx and item_idx > y_idx, (
                 f"depth-2 caller {item!r} at index {item_idx} appears before depth-1 callers"
             )
@@ -420,13 +427,13 @@ def test_callees_of_depth1_precede_depth2_when_alphabetical_would_invert() -> No
 
 
 # ---------------------------------------------------------------------------
-# dropped field — module_callers / module_callees
+# dropped field — module_callees
 # ---------------------------------------------------------------------------
 
 def test_module_callers_dropped_zero_when_not_truncated() -> None:
-    """module_callers: dropped=0 when results fit within cap."""
+    """refers_to(kind='callers', granularity='module'): dropped=0 when results fit within cap."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_prefix_raw()))
-    result = idx.module_callers("pkg.agents")
+    result = idx.refers_to("pkg.agents.writer.write", kind="callers", granularity="module")
     assert "dropped" in result
     assert result["dropped"] == 0
     assert result["truncated"] is False
@@ -442,13 +449,13 @@ def test_module_callees_dropped_zero_when_not_truncated() -> None:
 
 
 def test_module_callers_dropped_correct_when_truncated() -> None:
-    """module_callers: dropped equals number of results beyond cap."""
+    """refers_to(kind='callers', granularity='module'): dropped equals number of results beyond cap."""
     raw: dict[str, list[str]] = {}
     for i in range(57):
         raw[f"callers.mod{i}.fn"] = ["target.core.fn"]
     raw["target.core.fn"] = []
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
-    result = idx.module_callers("target")
+    result = idx.refers_to("target.core.fn", kind="callers", granularity="module")
     assert result["truncated"] is True
     assert len(result["results"]) == 50
     assert result["dropped"] == 7
@@ -469,7 +476,7 @@ def test_module_callees_dropped_correct_when_truncated() -> None:
 
 
 def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -> None:
-    """Depth-1 module callers appear before depth-2 ones, even when alphabetically later."""
+    """Depth-1 refers_to(kind='callers', granularity='module') appear before depth-2 ones."""
     raw: dict[str, list[str]] = {}
     # depth-2 module callers: a_depth2.modN.fn → bridge.mod.fn → target.fn
     for i in range(55):
@@ -480,7 +487,7 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
     raw["y_depth1.mod.fn"] = ["target.fn"]
     raw["target.fn"] = []
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(raw))
-    result = idx.module_callers("target", depth=2)
+    result = idx.refers_to("target.fn", kind="callers", granularity="module", depth=2)
 
     assert "z_depth1.mod" in result["results"], (
         "depth-1 module caller z_depth1.mod absent — ranking failed"
@@ -494,18 +501,26 @@ def test_module_callers_depth1_precede_depth2_when_alphabetical_would_invert() -
 
 
 # ---------------------------------------------------------------------------
-# callers_of / callees_of — not-found error shape
+# refers_to / callees_of — not-found error shape
 # ---------------------------------------------------------------------------
 
-def test_callers_of_fqn_not_in_graph() -> None:
-    """callers_of with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
+def test_refers_to_fqn_not_in_graph() -> None:
+    """refers_to with a nonexistent FQN returns isError:true, error_reason:'fqn_not_in_graph', stale:false."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
-    result = idx.callers_of("no.such.fqn")
+    result = idx.refers_to("no.such.fqn")
     assert result["isError"] is True
     assert result["error_reason"] == "fqn_not_in_graph"
     assert result["stale"] is False
     assert result["stale_files"] == []
     assert "stale_action" not in result
+
+
+def test_refers_to_depth_exceeds_max() -> None:
+    """refers_to with depth > 2 returns isError:true, error_reason:'depth_exceeds_max'."""
+    idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
+    result = idx.refers_to("sample.b.helper", depth=3)
+    assert result["isError"] is True
+    assert result["error_reason"] == "depth_exceeds_max"
 
 
 def test_callees_of_fqn_not_in_graph() -> None:
@@ -519,11 +534,11 @@ def test_callees_of_fqn_not_in_graph() -> None:
     assert "stale_action" not in result
 
 
-def test_callers_of_known_zero_callers() -> None:
-    """callers_of on an FQN with no callers returns results:[], not an error."""
+def test_refers_to_known_zero_callers() -> None:
+    """refers_to on an FQN with no callers returns results:[], not an error."""
     idx = CallGraphIndex.from_nodes("/tmp/sample", make_nodes(_sample_raw()))
     # sample.a.top has no callers
-    result = idx.callers_of("sample.a.top")
+    result = idx.refers_to("sample.a.top", kind="callers")
     assert result.get("isError") is not True
     assert result["results"] == []
     # Not a not-found error; staleness value depends on test fixture setup
@@ -804,7 +819,7 @@ def test_hub_threshold_attribute_reflects_distribution() -> None:
     """_in_degree_threshold reflects actual p99 when distribution exceeds floor."""
     # Build a graph where one node has very high in-degree (25 callers)
     # p99 of [0]*N_nodes + [25] will be 25 for large enough N
-    raw: dict[str, list[str]] = {"hub.node": []}
+    raw: dict[str, int] = {"hub.node": []}
     for i in range(100):
         raw[f"caller_{i}"] = ["hub.node"]
     idx = CallGraphIndex.from_nodes("/tmp/p99test", make_nodes(raw))
@@ -878,9 +893,9 @@ def test_load_version_5_roundtrip(tmp_path: Path) -> None:
     # Forward edge available via callees_of
     callees = loaded.callees_of("pkg.mod.foo", depth=1)
     assert callees["results"] == ["pkg.mod.bar"]
-    # Reverse edge available via callers_of (rebuilt _DiGraph._pred)
-    callers = loaded.callers_of("pkg.mod.bar", depth=1)
-    assert callers["results"] == ["pkg.mod.foo"]
+    # Reverse edge available via refers_to(kind="callers")
+    callers = loaded.refers_to("pkg.mod.bar", kind="callers", depth=1)
+    assert [e["fqn"] for e in callers["results"]] == ["pkg.mod.foo"]
 
 
 def test_load_legacy_v5_raw_payload_raises(tmp_path: Path) -> None:
@@ -956,9 +971,9 @@ def test_from_raw_delegates_to_from_nodes(tmp_path: Path) -> None:
     # Forward edges visible
     callees = idx.callees_of("pkg.mod.foo", depth=1)
     assert callees["results"] == ["pkg.mod.bar"]
-    # Reverse edges visible (build-time inversion happened in _raw_to_nodes)
-    callers = idx.callers_of("pkg.mod.bar", depth=1)
-    assert callers["results"] == ["pkg.mod.foo"]
+    # Reverse edges visible via refers_to
+    callers = idx.refers_to("pkg.mod.bar", kind="callers", depth=1)
+    assert [e["fqn"] for e in callers["results"]] == ["pkg.mod.foo"]
     # ``raw`` property projects nodes → raw shape
     assert idx.raw == {"pkg.mod.foo": ["pkg.mod.bar"]}
 
@@ -1063,7 +1078,7 @@ def test_per_kind_isolation_call_edges_survive_missing_import_bucket(
 ) -> None:
     """Simulate a visitor failure on the import kind (no import bucket
     populated) and assert that call edges from the same caller remain
-    visible through ``callers_of`` / ``callees_of`` and the ``nodes`` map.
+    visible through ``refers_to`` / ``callees_of`` and the ``nodes`` map.
 
     Per-kind isolation is enforced inside the visitor (each ``visit_*``
     wraps its body in try/except + ``_warn_kind_failure``).  This test
@@ -1114,5 +1129,6 @@ def test_per_kind_isolation_call_edges_survive_missing_import_bucket(
     assert other_calls.get("call") == ["pkg.helpers.helper_a"]
     assert other_calls.get("import") == ["json"]
     # Reverse view also intact for the unaffected kinds.
-    a_callers = idx.callers_of("pkg.helpers.helper_a", depth=1)
-    assert sorted(a_callers["results"]) == ["pkg.mod.caller", "pkg.other.caller"]
+    a_callers = idx.refers_to("pkg.helpers.helper_a", kind="callers", depth=1)
+    caller_fqns = sorted(e["fqn"] for e in a_callers["results"])
+    assert caller_fqns == ["pkg.mod.caller", "pkg.other.caller"]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from pyscope_mcp.graph import CallGraphIndex
+import pytest
+
+from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
 from conftest import make_nodes
 
 
@@ -858,11 +860,6 @@ def test_neighborhood_hub_fields_always_present_isolated() -> None:
 #   3. ``MissLog.to_dict()`` takes no arguments
 #   4. Deterministic JSON serialisation across insertion orders
 # ---------------------------------------------------------------------------
-
-import pytest
-
-from pyscope_mcp.graph import INDEX_VERSION, CallGraphIndex
-
 
 def _sample_nodes() -> dict[str, dict]:
     return {

--- a/tests/test_integration_issue66.py
+++ b/tests/test_integration_issue66.py
@@ -339,7 +339,7 @@ class TestCommitStalenessQueryWiring:
 
     @pytest.mark.integration_wiring
     def test_callers_of_response_has_commit_staleness_fields(self, built_index) -> None:
-        """[wiring] callers_of response includes commit staleness keys over real stdio-RPC."""
+        """[wiring] refers_to response includes commit staleness keys over real stdio-RPC."""
         index_file, pkg_root, _, _ = built_index
         proc = _spawn_server(index_file, root=pkg_root)
         try:
@@ -347,7 +347,7 @@ class TestCommitStalenessQueryWiring:
 
             _send(proc, {
                 "jsonrpc": "2.0", "id": 2, "method": "tools/call",
-                "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.alpha"}},
+                "params": {"name": "refers_to", "arguments": {"fqn": "mypkg.core.alpha", "kind": "callers"}},
             })
             r = _recv(proc)
             assert r["id"] == 2
@@ -358,7 +358,7 @@ class TestCommitStalenessQueryWiring:
 
             # [Assert] Commit staleness keys present
             assert "commit_stale" in body, (
-                "callers_of response must include 'commit_stale' over the wire"
+                "refers_to response must include 'commit_stale' over the wire"
             )
             assert "index_git_sha" in body
             assert "head_git_sha" in body

--- a/tests/test_integration_issue66.py
+++ b/tests/test_integration_issue66.py
@@ -218,20 +218,22 @@ class TestBuildToolWiring:
 
     @pytest.mark.integration_wiring
     def test_build_tool_missing_env_returns_error(self, built_index) -> None:
-        """[wiring] build tool fails gracefully when pyscope-mcp binary not on PATH.
+        """[wiring] build tool fails gracefully when the build subprocess exits non-zero.
 
-        Serves with a PATH that lacks the pyscope-mcp entry point; the tool
-        must return isError:true (not a JSON-RPC error, not a server crash).
+        Points PYSCOPE_MCP_INDEX at an unwritable path so the build subprocess
+        fails with a PermissionError. The tool must return isError:true (not a
+        JSON-RPC error, not a server crash).
         """
         index_file, pkg_root, repo_root, env = built_index
 
-        # Strip pyscope-mcp from PATH by removing the venv bin directory
-        venv_bin = str(Path(sys.executable).parent)
-        broken_path = ":".join(
-            p for p in env.get("PATH", "").split(":")
-            if p != venv_bin and "pyscope" not in p.lower()
-        )
-        broken_env = dict(env, PATH=broken_path)
+        # Point the index at a path whose parent dir cannot be created — the
+        # build subprocess will exit 1 with a PermissionError on mkdir.
+        # Also pin PYSCOPE_MCP_ROOT to the small fixture package so the
+        # subprocess doesn't scan the entire repo before hitting the error.
+        broken_env = dict(env,
+                          PYSCOPE_MCP_ROOT=str(pkg_root),
+                          PYSCOPE_MCP_PACKAGE="mypkg",
+                          PYSCOPE_MCP_INDEX="/nonexistent_ro_dir/index.json")
 
         proc = subprocess.Popen(
             [
@@ -257,9 +259,9 @@ class TestBuildToolWiring:
                 f"got JSON-RPC error instead of isError:true — {r}"
             )
 
-            # [Assert] isError:true when subprocess unavailable
+            # [Assert] isError:true when build subprocess fails
             assert r["result"]["isError"] is True, (
-                "build with missing binary must return isError:true"
+                "build with failing subprocess must return isError:true"
             )
 
             _shutdown(proc)

--- a/tests/test_integration_issue66.py
+++ b/tests/test_integration_issue66.py
@@ -26,7 +26,6 @@ import json
 import os
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/test_integration_issue69.py
+++ b/tests/test_integration_issue69.py
@@ -236,9 +236,9 @@ class TestSliceNotFoundErrorReasonWiring:
     def test_callers_of_bad_fqn_is_error_with_error_reason(
         self, built_index
     ) -> None:
-        """[wiring] callers_of(bad_fqn) → isError:true, error_reason present, stale=false, no stale_action.
+        """[wiring] refers_to(bad_fqn) → isError:true, error_reason present, stale=false, no stale_action.
 
-        AC2: callers_of with an FQN not in the graph must return the not-found
+        AC2: refers_to with an FQN not in the graph must return the not-found
         error shape — not an empty results list and not a server crash.
         """
         index_file, pkg_root, _, _ = built_index
@@ -251,8 +251,8 @@ class TestSliceNotFoundErrorReasonWiring:
             _send(proc, {
                 "jsonrpc": "2.0", "id": 2, "method": "tools/call",
                 "params": {
-                    "name": "callers_of",
-                    "arguments": {"fqn": "mypkg.does_not_exist.whatever"},
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever", "kind": "callers"},
                 },
             })
             r = _recv(proc)
@@ -265,7 +265,7 @@ class TestSliceNotFoundErrorReasonWiring:
 
             # [Assert] MCP tool level: isError:true
             assert result.get("isError") is True, (
-                f"callers_of with bad FQN must return isError:true; got {result}"
+                f"refers_to with bad FQN must return isError:true; got {result}"
             )
 
             # [Assert] content is parseable JSON with error_reason
@@ -407,7 +407,7 @@ class TestSliceNotFoundErrorReasonWiring:
     def test_callers_of_present_fqn_with_zero_callers_is_not_error(
         self, built_index
     ) -> None:
-        """[wiring] AC5 regression guard: callers_of(present-but-no-callers FQN) → isError NOT true, results list present.
+        """[wiring] AC5 regression guard: refers_to(present-but-no-callers FQN) → isError NOT true, results list present.
 
         mypkg.core.gamma is in the index (so isError must NOT be true) but
         nothing calls gamma, so results must be a list (possibly empty).
@@ -424,8 +424,8 @@ class TestSliceNotFoundErrorReasonWiring:
             _send(proc, {
                 "jsonrpc": "2.0", "id": 2, "method": "tools/call",
                 "params": {
-                    "name": "callers_of",
-                    "arguments": {"fqn": "mypkg.core.gamma"},
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.gamma", "kind": "callers"},
                 },
             })
             r = _recv(proc)
@@ -438,14 +438,14 @@ class TestSliceNotFoundErrorReasonWiring:
 
             # [Assert] isError must NOT be true for a present FQN
             assert result.get("isError") is not True, (
-                "callers_of with a present FQN (gamma) must NOT return isError:true — "
+                "refers_to with a present FQN (gamma) must NOT return isError:true — "
                 "zero callers is not an error; got isError=True"
             )
 
             # [Assert] content is parseable JSON and includes 'results' key
             body = json.loads(result["content"][0]["text"])
             assert "results" in body, (
-                "callers_of(gamma) must include 'results' key in response body"
+                "refers_to(gamma) must include 'results' key in response body"
             )
             assert isinstance(body["results"], list), (
                 f"results must be a list, got {type(body['results'])}"
@@ -453,7 +453,7 @@ class TestSliceNotFoundErrorReasonWiring:
 
             # [Assert] stale is present (and False for fresh index)
             assert "stale" in body, (
-                "callers_of response must include 'stale' key"
+                "refers_to response must include 'stale' key"
             )
 
             _shutdown(proc)
@@ -533,9 +533,9 @@ class TestSliceNotFoundErrorReasonArtifact:
 
     @pytest.mark.integration_artifact
     def test_callers_of_bad_fqn_exact_error_reason(self, built_index) -> None:
-        """[artifact] callers_of(bad_fqn) → error_reason=='fqn_not_in_graph', stale==False, stale_files==[], no stale_action.
+        """[artifact] refers_to(bad_fqn) → error_reason=='fqn_not_in_graph', stale==False, stale_files==[], no stale_action.
 
-        Golden: error_reason='fqn_not_in_graph' (defined in graph.py callers_of).
+        Golden: error_reason='fqn_not_in_graph' (defined in graph.py refers_to).
         """
         index_file, pkg_root, _, _ = built_index
         proc = _spawn_server(index_file, root=pkg_root)
@@ -547,8 +547,8 @@ class TestSliceNotFoundErrorReasonArtifact:
             _send(proc, {
                 "jsonrpc": "2.0", "id": 2, "method": "tools/call",
                 "params": {
-                    "name": "callers_of",
-                    "arguments": {"fqn": "mypkg.does_not_exist.whatever"},
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever", "kind": "callers"},
                 },
             })
             r = _recv(proc)
@@ -691,7 +691,7 @@ class TestSliceNotFoundErrorReasonArtifact:
     def test_callers_of_present_fqn_with_zero_callers_exact_values(
         self, built_index
     ) -> None:
-        """[artifact] AC5: callers_of(gamma) → results==[], stale==False exactly.
+        """[artifact] AC5: refers_to(gamma) → results==[], stale==False exactly.
 
         mypkg.core.gamma is present in the index (it calls beta) but nothing
         calls gamma itself.  The response must be a success (isError NOT true)
@@ -707,8 +707,8 @@ class TestSliceNotFoundErrorReasonArtifact:
             _send(proc, {
                 "jsonrpc": "2.0", "id": 2, "method": "tools/call",
                 "params": {
-                    "name": "callers_of",
-                    "arguments": {"fqn": "mypkg.core.gamma"},
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.gamma", "kind": "callers"},
                 },
             })
             r = _recv(proc)
@@ -716,7 +716,7 @@ class TestSliceNotFoundErrorReasonArtifact:
 
             # [Assert] isError must NOT be true
             assert result.get("isError") is not True, (
-                "callers_of(gamma) must NOT be isError:true — "
+                "refers_to(gamma) must NOT be isError:true — "
                 "gamma is present in the index; zero callers is not an error"
             )
 
@@ -724,7 +724,7 @@ class TestSliceNotFoundErrorReasonArtifact:
 
             # [Assert] results is exactly [] (golden: gamma has no callers)
             assert body["results"] == [], (
-                f"callers_of(gamma) must return results=[] since nothing calls gamma; "
+                f"refers_to(gamma) must return results=[] since nothing calls gamma; "
                 f"got {body['results']!r}"
             )
 

--- a/tests/test_integration_issue71.py
+++ b/tests/test_integration_issue71.py
@@ -1,0 +1,1004 @@
+"""Integration tests for issue #71 — refers_to typed symbol reference lookup.
+
+Two scenarios, two tiers each:
+
+  slice-refers-to-tool-e2e (wiring):
+    Verifies that the `refers_to` MCP tool is reachable over the real stdio-RPC wire,
+    accepts kind/granularity/depth parameters, returns the correct response structure
+    (results list with fqn/context/depth entries), and that removed tools callers_of
+    and module_callers are absent from tools/list.
+
+  slice-refers-to-multi-kind-e2e (wiring + artifact):
+    Verifies that refers_to correctly returns all typed reference kinds (call, import,
+    except, annotation, isinstance) when queried against a synthetic package that
+    exercises each kind. The artifact tier pins exact result counts and context tags.
+
+Pattern: real subprocess, real OS pipes, stdio JSON-RPC 2.0.
+Mirrors test_integration_issue66.py conventions exactly (same _send/_recv helpers,
+same index fixture shape, same env dict).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_integration_issue66.py)
+# ---------------------------------------------------------------------------
+
+
+def _send(proc: subprocess.Popen, msg: dict) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write((json.dumps(msg) + "\n").encode())
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen, timeout: float = 10.0) -> dict:
+    assert proc.stdout is not None
+    line = proc.stdout.readline()
+    if not line:
+        err = proc.stderr.read().decode() if proc.stderr else ""
+        raise AssertionError(f"server produced no stdout; stderr={err!r}")
+    return json.loads(line.decode())
+
+
+def _handshake(proc: subprocess.Popen, client_name: str = "it-test") -> None:
+    """Send MCP initialize + initialized notification; assert initialize OK."""
+    _send(proc, {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": "0"},
+        },
+    })
+    r = _recv(proc)
+    assert r["id"] == 1
+    assert r["result"]["protocolVersion"] == "2024-11-05"
+    _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+
+def _shutdown(proc: subprocess.Popen, req_id: int = 99) -> None:
+    """Send shutdown + close stdin; assert server exits 0."""
+    _send(proc, {"jsonrpc": "2.0", "id": req_id, "method": "shutdown"})
+    r = _recv(proc)
+    assert r == {"jsonrpc": "2.0", "id": req_id, "result": {}}
+    assert proc.stdin is not None
+    proc.stdin.close()
+    assert proc.wait(timeout=5) == 0
+
+
+def _spawn_server(index_path: Path, root: Path | None = None) -> subprocess.Popen:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+    args = [
+        sys.executable, "-m", "pyscope_mcp.cli", "serve",
+        "--root", str(root or repo_root),
+        "--index", str(index_path),
+    ]
+    return subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def built_index(tmp_path_factory: pytest.TempPathFactory):
+    """Build a real index for a synthetic 3-function call-chain package.
+
+    Package structure:
+        mypkg/
+            __init__.py
+            core.py   # alpha, beta (calls alpha), gamma (calls beta)
+
+    Real FQNs in index (call graph):
+        mypkg.core.alpha  — has callers: [mypkg.core.beta]
+        mypkg.core.beta   — calls alpha, has callers: [mypkg.core.gamma]
+        mypkg.core.gamma  — calls beta; zero callers
+
+    This fixture is shared across all wiring tests in this module.
+    Returns (index_file, pkg_root, repo_root, env).
+    """
+    tmp = tmp_path_factory.mktemp("it71")
+    pkg = tmp / "mypkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "core.py").write_text(
+        "def alpha(): pass\n\n"
+        "def beta(): return alpha()\n\n"
+        "def gamma(): return beta()\n"
+    )
+
+    index_file = tmp / ".pyscope-mcp" / "index.json"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "build",
+            "--root", str(tmp),
+            "--package", "mypkg",
+            "--output", str(index_file),
+        ],
+        capture_output=True, env=env,
+    )
+    assert result.returncode == 0, (
+        f"pyscope-mcp build failed in fixture:\n{result.stderr.decode()}"
+    )
+    return index_file, tmp, repo_root, env
+
+
+# ===========================================================================
+# Scenario 1: slice-refers-to-tool-e2e
+# ===========================================================================
+# SCENARIO: slice-refers-to-tool-e2e
+# layers_involved: src/pyscope_mcp/server.py, src/pyscope_mcp/graph.py, src/pyscope_mcp/types.py
+
+
+class TestRefersToToolWiring:
+    """Wiring tier — slice-refers-to-tool-e2e.
+
+    Verifies:
+    - refers_to is in tools/list; callers_of and module_callers are absent
+    - refers_to with kind='callers' returns a valid call-only result structure
+    - refers_to with kind='all' returns a valid multi-kind result structure
+    - refers_to with granularity='module' returns a flat list of strings
+    - refers_to with depth=3 returns isError:true with error_reason='depth_exceeds_max'
+    - refers_to with a nonexistent FQN returns isError:true with error_reason='fqn_not_in_graph'
+    - response always includes truncated, dropped, stale, stale_files, completeness keys
+    """
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_in_tool_list_callers_of_absent(self, built_index) -> None:
+        """[wiring] tools/list must include refers_to and must NOT include callers_of or module_callers."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-tool-list")
+
+            _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            tool_names = {t["name"] for t in r["result"]["tools"]}
+
+            # [Assert] refers_to is present
+            assert "refers_to" in tool_names, (
+                f"'refers_to' must be in tools/list; found: {sorted(tool_names)}"
+            )
+
+            # [Assert] deleted tools are absent
+            assert "callers_of" not in tool_names, (
+                "'callers_of' must be absent from tools/list — it was hard-deleted in #71"
+            )
+            assert "module_callers" not in tool_names, (
+                "'module_callers' must be absent from tools/list — it was hard-deleted in #71"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_callers_kind_response_structure(self, built_index) -> None:
+        """[wiring] refers_to(kind='callers') returns valid result structure over real stdio-RPC.
+
+        Calls refers_to(fqn='mypkg.core.alpha', kind='callers') which should
+        return mypkg.core.beta (the only direct caller of alpha).
+        Verifies: no JSON-RPC error, isError:false, content[0].type='text',
+        body contains results/truncated/dropped/stale/stale_files/completeness.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-callers")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.alpha", "kind": "callers"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] Tool-level isError:false
+            assert result.get("isError") is not True, (
+                f"refers_to(kind='callers') must not return isError:true; got {result}"
+            )
+
+            # [Assert] content structure — type=text, parseable JSON
+            content = result["content"]
+            assert len(content) >= 1, "result must have at least one content item"
+            assert content[0]["type"] == "text", "content type must be 'text'"
+
+            body = json.loads(content[0]["text"])
+
+            # [Assert] Required structural keys are present
+            for field in ("results", "truncated", "dropped", "stale", "stale_files", "completeness"):
+                assert field in body, (
+                    f"refers_to response must include '{field}' key; body keys: {list(body.keys())}"
+                )
+
+            # [Assert] results is a list
+            assert isinstance(body["results"], list), (
+                f"results must be a list, got {type(body['results'])}"
+            )
+
+            # [Assert] entries (if any) have fqn, context, depth shape
+            for entry in body["results"]:
+                assert isinstance(entry, dict), f"each result entry must be a dict, got {entry!r}"
+                assert "fqn" in entry, f"result entry must have 'fqn'; got {entry}"
+                assert "context" in entry, f"result entry must have 'context'; got {entry}"
+                assert "depth" in entry, f"result entry must have 'depth'; got {entry}"
+
+            # [Assert] truncated and dropped are correct types
+            assert isinstance(body["truncated"], bool), (
+                f"truncated must be bool, got {type(body['truncated'])}"
+            )
+            assert isinstance(body["dropped"], int), (
+                f"dropped must be int, got {type(body['dropped'])}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_all_kind_response_structure(self, built_index) -> None:
+        """[wiring] refers_to(kind='all') returns valid result structure over real stdio-RPC."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-all")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.alpha", "kind": "all"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+            assert result.get("isError") is not True, (
+                f"refers_to(kind='all') must not return isError:true; got {result}"
+            )
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Required keys
+            for field in ("results", "truncated", "dropped", "stale", "stale_files", "completeness"):
+                assert field in body, f"refers_to response must include '{field}'"
+
+            # [Assert] results is a list of dicts with fqn/context/depth
+            assert isinstance(body["results"], list)
+            for entry in body["results"]:
+                assert "fqn" in entry
+                assert "context" in entry
+                assert entry["context"] in ("call", "import", "except", "annotation", "isinstance"), (
+                    f"context must be a known kind, got {entry['context']!r}"
+                )
+                assert "depth" in entry
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_module_granularity_response_structure(self, built_index) -> None:
+        """[wiring] refers_to(granularity='module') returns flat string list over real stdio-RPC."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-module-gran")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {
+                        "fqn": "mypkg.core.alpha",
+                        "kind": "callers",
+                        "granularity": "module",
+                    },
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r
+
+            result = r["result"]
+            assert result.get("isError") is not True
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Required keys
+            for field in ("results", "truncated", "dropped", "stale", "stale_files", "completeness"):
+                assert field in body, f"module granularity response must include '{field}'"
+
+            # [Assert] results is a list of strings (module FQNs)
+            assert isinstance(body["results"], list)
+            for item in body["results"]:
+                assert isinstance(item, str), (
+                    f"module granularity result items must be strings; got {type(item)}: {item!r}"
+                )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_depth_exceeds_max_returns_error(self, built_index) -> None:
+        """[wiring] refers_to(depth=3) returns isError:true with error_reason='depth_exceeds_max'."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-depth-max")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.alpha", "kind": "all", "depth": 3},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] MCP tool-level isError:true
+            assert result.get("isError") is True, (
+                f"refers_to(depth=3) must return isError:true; got {result}"
+            )
+
+            # [Assert] error_reason is depth_exceeds_max
+            content = result["content"]
+            body = json.loads(content[0]["text"])
+            assert "error_reason" in body, "depth error response must include 'error_reason'"
+            assert body["error_reason"] == "depth_exceeds_max", (
+                f"expected error_reason='depth_exceeds_max', got {body['error_reason']!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_fqn_not_in_graph_returns_error(self, built_index) -> None:
+        """[wiring] refers_to(bad_fqn) returns isError:true with error_reason='fqn_not_in_graph'."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-not-found")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever", "kind": "all"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+
+            # [Assert] MCP tool-level isError:true
+            assert result.get("isError") is True, (
+                f"refers_to with absent FQN must return isError:true; got {result}"
+            )
+
+            # [Assert] error_reason is fqn_not_in_graph
+            body = json.loads(result["content"][0]["text"])
+            assert "error_reason" in body
+            assert body["error_reason"] == "fqn_not_in_graph", (
+                f"expected error_reason='fqn_not_in_graph', got {body['error_reason']!r}"
+            )
+
+            # [Assert] stale is False on not-found errors
+            assert "stale" in body
+            assert body["stale"] is False, (
+                f"stale must be False on fqn_not_in_graph error, got {body['stale']!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_zero_callers_is_not_error(self, built_index) -> None:
+        """[wiring] refers_to(present FQN with zero callers) returns results=[] not isError.
+
+        mypkg.core.gamma has zero callers (nothing calls gamma in the fixture).
+        Regression guard: presence in graph + zero callers must yield empty results,
+        not an error response.
+        """
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-wiring-zero-callers")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.gamma", "kind": "callers"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r
+
+            result = r["result"]
+
+            # [Assert] NOT isError
+            assert result.get("isError") is not True, (
+                "refers_to with present FQN and zero callers must NOT return isError:true"
+            )
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] results is empty list
+            assert body["results"] == [], (
+                f"expected results=[], got {body['results']}"
+            )
+            assert body["truncated"] is False
+            assert body["dropped"] == 0
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+
+# ===========================================================================
+# Scenario 2: slice-refers-to-multi-kind-e2e
+# ===========================================================================
+# SCENARIO: slice-refers-to-multi-kind-e2e
+# layers_involved: src/pyscope_mcp/server.py, src/pyscope_mcp/graph.py,
+#                  src/pyscope_mcp/analyzer/visitor.py, src/pyscope_mcp/types.py
+
+
+@pytest.fixture(scope="module")
+def multi_kind_index(tmp_path_factory: pytest.TempPathFactory):
+    """Build a real index for a synthetic package that exercises all reference kinds.
+
+    Package structure:
+        refpkg/
+            __init__.py
+            target.py    # defines TargetError (exception class)
+            consumer.py  # references TargetError via: call, import, except, annotation,
+                         #                              isinstance
+
+    The analyzer AST visitor records all five reference kinds into 'called_by'
+    buckets.  This fixture builds a real index so the integration tier exercises
+    the full pipeline: AST analysis → index write → server load → refers_to query.
+
+    Note: the analyzer's ability to detect all five kinds depends on the
+    analyzer/visitor.py implementation, which is part of the issue #71 diff.
+    If the analyzer only tracks call edges, the wiring test will still pass
+    (structural checks only); the artifact test will detect the missing kinds.
+
+    Returns (index_file, pkg_root, repo_root, env).
+    """
+    tmp = tmp_path_factory.mktemp("it71mk")
+    pkg = tmp / "refpkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+
+    # Target module: defines a class that consumers reference in various ways
+    (pkg / "target.py").write_text(textwrap.dedent("""\
+        class TargetError(Exception):
+            pass
+
+        def target_factory() -> "TargetError":
+            return TargetError()
+    """))
+
+    # Consumer module: references TargetError via multiple AST edge kinds
+    (pkg / "consumer.py").write_text(textwrap.dedent("""\
+        from refpkg.target import TargetError
+
+        def call_it():
+            # call: creates an instance (constructor call)
+            return TargetError("msg")
+
+        def catch_it():
+            # except: catches the exception class
+            try:
+                pass
+            except TargetError:
+                pass
+
+        def annotate_it(x: TargetError) -> None:
+            # annotation: uses it as a type annotation
+            pass
+
+        def check_it(obj):
+            # isinstance: uses it in isinstance check
+            return isinstance(obj, TargetError)
+    """))
+
+    index_file = tmp / ".pyscope-mcp" / "index.json"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "build",
+            "--root", str(tmp),
+            "--package", "refpkg",
+            "--output", str(index_file),
+        ],
+        capture_output=True, env=env,
+    )
+    assert result.returncode == 0, (
+        f"pyscope-mcp build (multi_kind_index) failed:\n{result.stderr.decode()}"
+    )
+    return index_file, tmp, repo_root, env
+
+
+class TestRefersToMultiKindWiring:
+    """Wiring tier — slice-refers-to-multi-kind-e2e.
+
+    Verifies:
+    - refers_to(kind='all') returns a results list (non-empty when consumers present)
+    - response schema: content[0].type='text', body parseable, required keys present
+    - context field values are from the valid set
+    - kind='callers' subset is structurally correct (call contexts only)
+    - module granularity returns strings, not dicts
+    - each result entry has fqn/context/depth structure
+    """
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_kind_all_returns_results_list(self, multi_kind_index) -> None:
+        """[wiring] refers_to(kind='all') on a symbol with multiple reference kinds returns non-empty list."""
+        index_file, pkg_root, _, _ = multi_kind_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71mk-wiring-all")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "refpkg.target.TargetError", "kind": "all"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"unexpected JSON-RPC error: {r}"
+
+            result = r["result"]
+            assert result.get("isError") is not True, (
+                f"refers_to(kind='all') on TargetError must not return isError; got {result}"
+            )
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Required structural keys
+            for field in ("results", "truncated", "dropped", "stale", "stale_files", "completeness"):
+                assert field in body, f"response must include '{field}'"
+
+            # [Assert] results is a list
+            assert isinstance(body["results"], list)
+
+            # [Assert] each entry has fqn, context, depth
+            for entry in body["results"]:
+                assert "fqn" in entry, f"entry missing 'fqn': {entry}"
+                assert "context" in entry, f"entry missing 'context': {entry}"
+                assert "depth" in entry, f"entry missing 'depth': {entry}"
+                assert entry["context"] in (
+                    "call", "import", "except", "annotation", "isinstance"
+                ), f"context must be known kind, got {entry['context']!r}"
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_callers_subset_excludes_non_call(self, multi_kind_index) -> None:
+        """[wiring] refers_to(kind='callers') must only include call-context entries."""
+        index_file, pkg_root, _, _ = multi_kind_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71mk-wiring-callers")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "refpkg.target.TargetError", "kind": "callers"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r
+
+            result = r["result"]
+            assert result.get("isError") is not True
+
+            body = json.loads(result["content"][0]["text"])
+            assert isinstance(body["results"], list)
+
+            # [Assert] All returned context values must be 'call'
+            for entry in body["results"]:
+                assert entry["context"] == "call", (
+                    f"kind='callers' must only return call-context entries; "
+                    f"got context='{entry['context']}' for fqn={entry['fqn']!r}"
+                )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_refers_to_module_granularity_returns_strings(self, multi_kind_index) -> None:
+        """[wiring] refers_to(granularity='module') returns flat list of module FQN strings."""
+        index_file, pkg_root, _, _ = multi_kind_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71mk-wiring-module")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {
+                        "fqn": "refpkg.target.TargetError",
+                        "kind": "callers",
+                        "granularity": "module",
+                    },
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r
+
+            result = r["result"]
+            assert result.get("isError") is not True
+
+            body = json.loads(result["content"][0]["text"])
+            assert isinstance(body["results"], list)
+
+            # [Assert] Every item is a string (module FQN), not a dict
+            for item in body["results"]:
+                assert isinstance(item, str), (
+                    f"module granularity items must be strings; got {type(item)}: {item!r}"
+                )
+                # Module FQN must not contain function segments (no parentheses, no trailing name)
+                assert "." in item or item.isidentifier(), (
+                    f"module FQN looks malformed: {item!r}"
+                )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+
+# ===========================================================================
+# Artifact tier — slice-refers-to-tool-e2e
+# ===========================================================================
+
+
+class TestRefersToToolArtifact:
+    """Artifact tier — slice-refers-to-tool-e2e.
+
+    Verifies the exact output of refers_to against the synthetic 3-function
+    call-chain package (built_index fixture):
+        alpha  ← beta  ← gamma
+    (gamma calls beta calls alpha; nothing calls gamma)
+
+    Golden facts:
+    - refers_to(alpha, kind='callers') → results=[{fqn=beta, context=call, depth=1}]
+    - refers_to(alpha, kind='callers', depth=2) → results=[beta(depth=1), gamma(depth=2)]
+    - refers_to(gamma, kind='callers') → results=[] (nothing calls gamma)
+    - refers_to(alpha, kind='callers', granularity='module') → ['mypkg.core']
+    """
+
+    @pytest.mark.integration_artifact
+    def test_refers_to_direct_caller_exact(self, built_index) -> None:
+        """[artifact] refers_to(alpha, kind='callers', depth=1) → exactly one result: beta with context=call."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-artifact-direct")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.alpha", "kind": "callers", "depth": 1},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            result = r["result"]
+            assert result.get("isError") is not True, (
+                f"unexpected isError: {result}"
+            )
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact result count — golden: 1 (only beta is a direct caller)
+            assert len(body["results"]) == 1, (
+                f"expected 1 direct caller of alpha; got {body['results']}"
+            )
+
+            # [Assert] Exact entry values
+            entry = body["results"][0]
+            assert entry["fqn"] == "mypkg.core.beta", (
+                f"expected caller fqn='mypkg.core.beta'; got {entry['fqn']!r}"
+            )
+            assert entry["context"] == "call", (
+                f"expected context='call'; got {entry['context']!r}"
+            )
+            assert entry["depth"] == 1, (
+                f"expected depth=1; got {entry['depth']}"
+            )
+
+            # [Assert] No truncation
+            assert body["truncated"] is False
+            assert body["dropped"] == 0
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_refers_to_depth2_transitive_callers_exact(self, built_index) -> None:
+        """[artifact] refers_to(alpha, kind='callers', depth=2) → beta(depth=1) + gamma(depth=2)."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-artifact-depth2")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.alpha", "kind": "callers", "depth": 2},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            result = r["result"]
+            assert result.get("isError") is not True
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact result count — golden: 2 (beta depth=1, gamma depth=2)
+            assert len(body["results"]) == 2, (
+                f"expected 2 callers (beta depth=1, gamma depth=2); got {body['results']}"
+            )
+
+            # Build lookup by fqn
+            by_fqn = {e["fqn"]: e for e in body["results"]}
+
+            # [Assert] beta at depth=1
+            assert "mypkg.core.beta" in by_fqn, (
+                f"mypkg.core.beta must be in depth=2 results; got {list(by_fqn.keys())}"
+            )
+            assert by_fqn["mypkg.core.beta"]["depth"] == 1, (
+                f"beta must be at depth=1; got depth={by_fqn['mypkg.core.beta']['depth']}"
+            )
+
+            # [Assert] gamma at depth=2
+            assert "mypkg.core.gamma" in by_fqn, (
+                f"mypkg.core.gamma must be in depth=2 results; got {list(by_fqn.keys())}"
+            )
+            assert by_fqn["mypkg.core.gamma"]["depth"] == 2, (
+                f"gamma must be at depth=2; got depth={by_fqn['mypkg.core.gamma']['depth']}"
+            )
+
+            # [Assert] Ranking: depth-1 before depth-2
+            fqns = [e["fqn"] for e in body["results"]]
+            assert fqns.index("mypkg.core.beta") < fqns.index("mypkg.core.gamma"), (
+                "depth-1 caller (beta) must appear before depth-2 caller (gamma) in results"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_refers_to_zero_callers_exact_empty_results(self, built_index) -> None:
+        """[artifact] refers_to(gamma, kind='callers') → exactly results=[], truncated=False, dropped=0."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-artifact-zero")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.gamma", "kind": "callers"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            result = r["result"]
+            assert result.get("isError") is not True
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact golden values
+            assert body["results"] == [], (
+                f"expected empty results for gamma (no callers); got {body['results']}"
+            )
+            assert body["truncated"] is False, (
+                f"truncated must be False for empty results; got {body['truncated']!r}"
+            )
+            assert body["dropped"] == 0, (
+                f"dropped must be 0 for empty results; got {body['dropped']}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_refers_to_module_granularity_exact(self, built_index) -> None:
+        """[artifact] refers_to(alpha, kind='callers', granularity='module') → exactly ['mypkg.core']."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-artifact-module-gran")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {
+                        "fqn": "mypkg.core.alpha",
+                        "kind": "callers",
+                        "granularity": "module",
+                    },
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            result = r["result"]
+            assert result.get("isError") is not True
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact module list — golden: ['mypkg.core'] (both beta and gamma are in core)
+            assert body["results"] == ["mypkg.core"], (
+                f"expected module results=['mypkg.core'] (deduped); got {body['results']}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_refers_to_depth_exceeds_max_exact_error_shape(self, built_index) -> None:
+        """[artifact] refers_to(depth=3) → exact error shape: isError:true, error_reason='depth_exceeds_max'."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-artifact-depth-max")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.core.alpha", "kind": "all", "depth": 3},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            result = r["result"]
+
+            # [Assert] isError at both MCP result level and body level
+            assert result.get("isError") is True, (
+                "depth=3 must return isError:true at MCP result level"
+            )
+
+            body = json.loads(result["content"][0]["text"])
+            assert body.get("isError") is True, (
+                "depth=3 body must also have isError:true"
+            )
+            assert body.get("error_reason") == "depth_exceeds_max", (
+                f"expected error_reason='depth_exceeds_max'; got {body.get('error_reason')!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_artifact
+    def test_refers_to_fqn_not_in_graph_exact_error_shape(self, built_index) -> None:
+        """[artifact] refers_to(bad_fqn) → exact error shape: isError:true, error_reason='fqn_not_in_graph', stale=False, stale_files=[]."""
+        index_file, pkg_root, _, _ = built_index
+        proc = _spawn_server(index_file, root=pkg_root)
+        try:
+            _handshake(proc, "it71-artifact-not-found")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "refers_to",
+                    "arguments": {"fqn": "mypkg.does_not_exist.whatever", "kind": "all"},
+                },
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            result = r["result"]
+
+            assert result.get("isError") is True
+
+            body = json.loads(result["content"][0]["text"])
+
+            # [Assert] Exact error fields
+            assert body.get("error_reason") == "fqn_not_in_graph", (
+                f"expected 'fqn_not_in_graph'; got {body.get('error_reason')!r}"
+            )
+            assert body.get("stale") is False, (
+                f"stale must be exactly False (not None, not 0); got {body.get('stale')!r}"
+            )
+            assert body.get("stale_files") == [], (
+                f"stale_files must be exactly [] on not-found; got {body.get('stale_files')!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)

--- a/tests/test_misses_classifier_m7.py
+++ b/tests/test_misses_classifier_m7.py
@@ -8,7 +8,6 @@ attr chains are NOT stolen by the new whitelists.
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 from pyscope_mcp.analyzer import _classify_miss
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -29,7 +29,6 @@ import sys
 import time
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE = "pyscope_mcp"

--- a/tests/test_query_logger.py
+++ b/tests/test_query_logger.py
@@ -153,19 +153,19 @@ def _read_log(log_path: Path) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# S1 — happy-path tool call (callers_of)
+# S1 — happy-path tool call (refers_to)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_s1_happy_path_callers_of(server: RpcServer, tmp_index: Path, log_path: Path):
-    """S1: callers_of call appends one valid JSONL entry."""
+    """S1: refers_to call appends one valid JSONL entry."""
     import pyscope_mcp.server as srv
     srv._INDEX = CallGraphIndex.load(tmp_index)
 
     _init_logger(log_path)
 
     lines = [
-        _req("tools/call", {"name": "callers_of", "arguments": {"fqn": "pkg.mod.bar"}}, req_id=7),
+        _req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "kind": "callers"}}, req_id=7),
     ]
     responses = await _run(server, lines)
 
@@ -181,7 +181,7 @@ async def test_s1_happy_path_callers_of(server: RpcServer, tmp_index: Path, log_
     assert e["ts"]  # non-empty ISO string
     assert e["server_id"]  # non-empty UUID string
     assert e["rpc_id"] == 7
-    assert e["tool"] == "callers_of"
+    assert e["tool"] == "refers_to"
     assert "fqn" in e["args"]
     assert isinstance(e["duration_ms"], int) and e["duration_ms"] >= 0
     assert e["is_error"] is False

--- a/tests/test_query_logger.py
+++ b/tests/test_query_logger.py
@@ -16,7 +16,6 @@ Test scenarios per the refined spec:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 from pathlib import Path
@@ -149,7 +148,7 @@ def _read_log(log_path: Path) -> list[dict]:
     if not log_path.exists():
         return []
     lines = log_path.read_text(encoding="utf-8").splitlines()
-    return [json.loads(l) for l in lines if l.strip()]
+    return [json.loads(line) for line in lines if line.strip()]
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +317,7 @@ async def test_s4_opt_out_no_file_created(server: RpcServer, tmp_index: Path, lo
 
 def test_s5_log_rotation(tmp_path: Path):
     """S5: rotation at LOG_MAX_BYTES, max LOG_BACKUP_COUNT historical files."""
-    from pyscope_mcp._log import LOG_BACKUP_COUNT, LOG_MAX_BYTES, QueryLogger
+    from pyscope_mcp._log import LOG_MAX_BYTES, QueryLogger
 
     log_path = tmp_path / "query.jsonl"
     ql = QueryLogger(log_path)

--- a/tests/test_refers_to.py
+++ b/tests/test_refers_to.py
@@ -1,0 +1,347 @@
+"""Tests for the refers_to() method (issue #71).
+
+Covers all reference kinds (call, import, except, annotation, isinstance),
+both granularities (function/module), both kind filters (all/callers),
+depth enforcement, depth_exceeds_max guard, fqn_not_in_graph error,
+context priority (call beats others), deduplication, and BFS ordering.
+
+These tests use synthetic node dicts so no source files or real analyzer
+runs are needed.  The conftest.make_nodes helper builds call edges; for
+non-call edge kinds we build the nodes dict directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _nodes_with_kind(fqn_from: str, fqn_to: str, kind: str) -> dict[str, dict]:
+    """Build a minimal nodes dict with one edge of the given kind."""
+    return {
+        fqn_from: {
+            "calls": {kind: [fqn_to]},
+            "called_by": {},
+        },
+        fqn_to: {
+            "calls": {},
+            "called_by": {kind: [fqn_from]},
+        },
+    }
+
+
+def _merge_nodes(*node_dicts: dict[str, dict]) -> dict[str, dict]:
+    """Merge multiple node dicts, union-ing their calls/called_by buckets."""
+    merged: dict[str, dict] = {}
+    for nd in node_dicts:
+        for fqn, node in nd.items():
+            if fqn not in merged:
+                merged[fqn] = {"calls": {}, "called_by": {}}
+            for kind, targets in node.get("calls", {}).items():
+                merged[fqn]["calls"].setdefault(kind, [])
+                merged[fqn]["calls"][kind] = sorted(
+                    set(merged[fqn]["calls"][kind]) | set(targets)
+                )
+            for kind, sources in node.get("called_by", {}).items():
+                merged[fqn]["called_by"].setdefault(kind, [])
+                merged[fqn]["called_by"][kind] = sorted(
+                    set(merged[fqn]["called_by"][kind]) | set(sources)
+                )
+    return merged
+
+
+def _idx(tmp_path: Path, nodes: dict[str, dict]) -> CallGraphIndex:
+    return CallGraphIndex.from_nodes(str(tmp_path), nodes)
+
+
+# ---------------------------------------------------------------------------
+# 1. All five reference kinds are found by kind="all"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kind_name", ["call", "import", "except", "annotation", "isinstance"])
+def test_refers_to_all_finds_each_kind(tmp_path: Path, kind_name: str) -> None:
+    """kind='all' must find referencing functions for every supported edge kind."""
+    target = "pkg.target.Symbol"
+    referrer = "pkg.user.consumer"
+    nodes = _nodes_with_kind(referrer, target, kind_name)
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", depth=1)
+
+    assert result.get("isError") is not True, f"unexpected error: {result}"
+    fqns = [e["fqn"] for e in result["results"]]
+    assert referrer in fqns, (
+        f"kind='{kind_name}' referrer not found; results={fqns}"
+    )
+    # context field must match the edge kind
+    entry = next(e for e in result["results"] if e["fqn"] == referrer)
+    assert entry["context"] == kind_name, (
+        f"expected context='{kind_name}', got '{entry['context']}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. kind="callers" finds only call edges
+# ---------------------------------------------------------------------------
+
+def test_refers_to_callers_excludes_non_call_edges(tmp_path: Path) -> None:
+    """kind='callers' must only traverse call edges, not import/except/etc."""
+    target = "pkg.target.Symbol"
+    call_referrer = "pkg.a.caller"
+    import_referrer = "pkg.b.importer"
+
+    nodes = _merge_nodes(
+        _nodes_with_kind(call_referrer, target, "call"),
+        _nodes_with_kind(import_referrer, target, "import"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="callers", depth=1)
+    fqns = [e["fqn"] for e in result["results"]]
+
+    assert call_referrer in fqns, "call referrer must appear in kind='callers' results"
+    assert import_referrer not in fqns, "import referrer must NOT appear in kind='callers' results"
+
+
+# ---------------------------------------------------------------------------
+# 3. context priority: "call" beats other kinds when a function does both
+# ---------------------------------------------------------------------------
+
+def test_refers_to_call_context_priority(tmp_path: Path) -> None:
+    """When a function has both call and import edges to target, context must be 'call'."""
+    target = "pkg.target.Symbol"
+    referrer = "pkg.a.multi"
+
+    # referrer both imports and calls target
+    nodes = _merge_nodes(
+        _nodes_with_kind(referrer, target, "call"),
+        _nodes_with_kind(referrer, target, "import"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", depth=1)
+    assert result.get("isError") is not True
+    entries = [e for e in result["results"] if e["fqn"] == referrer]
+    assert len(entries) == 1, f"referrer must appear exactly once, got {entries}"
+    assert entries[0]["context"] == "call", (
+        f"'call' must win context priority, got '{entries[0]['context']}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. depth=1 vs depth=2 BFS
+# ---------------------------------------------------------------------------
+
+def test_refers_to_depth1_does_not_include_depth2(tmp_path: Path) -> None:
+    """depth=1 must not include depth-2 referrers."""
+    target = "pkg.target.fn"
+    depth1 = "pkg.a.direct"
+    depth2 = "pkg.b.indirect"
+
+    nodes = _merge_nodes(
+        _nodes_with_kind(depth1, target, "call"),
+        _nodes_with_kind(depth2, depth1, "call"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", depth=1)
+    fqns = [e["fqn"] for e in result["results"]]
+    assert depth1 in fqns
+    assert depth2 not in fqns, "depth-2 referrer must not appear with depth=1"
+
+
+def test_refers_to_depth2_includes_both_depths(tmp_path: Path) -> None:
+    """depth=2 must include both direct (depth-1) and transitive (depth-2) referrers."""
+    target = "pkg.target.fn"
+    depth1 = "pkg.a.direct"
+    depth2 = "pkg.b.indirect"
+
+    nodes = _merge_nodes(
+        _nodes_with_kind(depth1, target, "call"),
+        _nodes_with_kind(depth2, depth1, "call"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", depth=2)
+    fqns = [e["fqn"] for e in result["results"]]
+    assert depth1 in fqns
+    assert depth2 in fqns
+
+
+def test_refers_to_depth_exceeds_max(tmp_path: Path) -> None:
+    """depth > 2 must return isError:True with error_reason='depth_exceeds_max'."""
+    nodes = make_nodes({"pkg.a.fn": []})
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to("pkg.a.fn", kind="all", depth=3)
+    assert result.get("isError") is True
+    assert result.get("error_reason") == "depth_exceeds_max"
+
+
+# ---------------------------------------------------------------------------
+# 5. fqn_not_in_graph error
+# ---------------------------------------------------------------------------
+
+def test_refers_to_fqn_not_in_graph(tmp_path: Path) -> None:
+    """Absent FQN must return isError:True with error_reason='fqn_not_in_graph'."""
+    nodes = make_nodes({"pkg.a.fn": []})
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to("does.not.exist", kind="all", depth=1)
+    assert result.get("isError") is True
+    assert result.get("error_reason") == "fqn_not_in_graph"
+
+
+# ---------------------------------------------------------------------------
+# 6. Function granularity result shape
+# ---------------------------------------------------------------------------
+
+def test_refers_to_function_granularity_result_shape(tmp_path: Path) -> None:
+    """Function granularity results must be dicts with fqn, context, depth fields."""
+    target = "pkg.target.fn"
+    referrer = "pkg.a.caller"
+    nodes = _nodes_with_kind(referrer, target, "call")
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", granularity="function", depth=1)
+    assert result.get("isError") is not True
+    assert len(result["results"]) == 1
+
+    entry = result["results"][0]
+    assert "fqn" in entry
+    assert "context" in entry
+    assert "depth" in entry
+    assert entry["fqn"] == referrer
+    assert entry["context"] == "call"
+    assert entry["depth"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Module granularity result shape
+# ---------------------------------------------------------------------------
+
+def test_refers_to_module_granularity_result_shape(tmp_path: Path) -> None:
+    """Module granularity results must be a flat list of module FQN strings."""
+    target = "pkg.target.fn"
+    referrer = "pkg.caller_mod.some_func"
+    nodes = _nodes_with_kind(referrer, target, "call")
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="callers", granularity="module", depth=1)
+    assert result.get("isError") is not True
+    # results should be strings (module FQNs)
+    assert "pkg.caller_mod" in result["results"]
+    for item in result["results"]:
+        assert isinstance(item, str), f"module result item must be str, got {type(item)}: {item!r}"
+
+
+# ---------------------------------------------------------------------------
+# 8. Deduplication: same FQN via multiple edge kinds appears once
+# ---------------------------------------------------------------------------
+
+def test_refers_to_deduplication_across_kinds(tmp_path: Path) -> None:
+    """A function that appears via multiple edge kinds must appear only once in results."""
+    target = "pkg.target.Symbol"
+    referrer = "pkg.a.multi"
+
+    # referrer has import, call, and annotation edges to target
+    nodes = _merge_nodes(
+        _nodes_with_kind(referrer, target, "call"),
+        _nodes_with_kind(referrer, target, "import"),
+        _nodes_with_kind(referrer, target, "annotation"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", depth=1)
+    assert result.get("isError") is not True
+    fqns = [e["fqn"] for e in result["results"]]
+    assert fqns.count(referrer) == 1, (
+        f"referrer must appear exactly once despite multiple edge kinds; got count={fqns.count(referrer)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. BFS depth ordering: depth-1 before depth-2
+# ---------------------------------------------------------------------------
+
+def test_refers_to_depth1_sorted_before_depth2(tmp_path: Path) -> None:
+    """In depth=2 results, depth-1 entries must appear before depth-2 entries."""
+    target = "pkg.target.fn"
+    depth1 = "pkg.z.direct"   # z > a alphabetically — would sort last without BFS ranking
+    depth2 = "pkg.a.indirect"  # a < z alphabetically — would sort first without BFS ranking
+
+    nodes = _merge_nodes(
+        _nodes_with_kind(depth1, target, "call"),
+        _nodes_with_kind(depth2, depth1, "call"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="all", depth=2)
+    fqns = [e["fqn"] for e in result["results"]]
+
+    assert depth1 in fqns
+    assert depth2 in fqns
+    assert fqns.index(depth1) < fqns.index(depth2), (
+        "depth-1 referrer must appear before depth-2 referrer regardless of alphabetical order"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Zero referrers — empty results is not an error
+# ---------------------------------------------------------------------------
+
+def test_refers_to_zero_referrers_is_not_error(tmp_path: Path) -> None:
+    """A present FQN with zero referrers must return results=[] not isError."""
+    nodes = make_nodes({"pkg.mod.isolated": []})
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to("pkg.mod.isolated", kind="all", depth=1)
+    assert result.get("isError") is not True
+    assert result["results"] == []
+    assert result["truncated"] is False
+    assert result["dropped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 11. Standard response fields present
+# ---------------------------------------------------------------------------
+
+def test_refers_to_standard_fields_present(tmp_path: Path) -> None:
+    """Result dict must always include truncated, dropped, completeness, stale, stale_files."""
+    nodes = make_nodes({"pkg.mod.fn": []})
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to("pkg.mod.fn", kind="all", depth=1)
+    for field in ("results", "truncated", "dropped", "completeness", "stale", "stale_files"):
+        assert field in result, f"field '{field}' must be present in refers_to result"
+
+
+# ---------------------------------------------------------------------------
+# 12. Module granularity deduplication across multiple symbols
+# ---------------------------------------------------------------------------
+
+def test_refers_to_module_granularity_deduplicates_modules(tmp_path: Path) -> None:
+    """Two callers from the same module must result in that module appearing once."""
+    target = "pkg.target.fn"
+    caller1 = "pkg.caller_mod.func_a"
+    caller2 = "pkg.caller_mod.func_b"
+
+    nodes = _merge_nodes(
+        _nodes_with_kind(caller1, target, "call"),
+        _nodes_with_kind(caller2, target, "call"),
+    )
+    idx = _idx(tmp_path, nodes)
+
+    result = idx.refers_to(target, kind="callers", granularity="module", depth=1)
+    assert result.get("isError") is not True
+    assert result["results"].count("pkg.caller_mod") == 1, (
+        "same caller module must appear only once in module granularity results"
+    )

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -179,8 +179,8 @@ async def test_golden_handshake(server: RpcServer, tmp_index: Path):
     assert list_resp["id"] == 2
     tools = list_resp["result"]["tools"]
     tool_names = {t["name"] for t in tools}
-    assert tool_names == {"stats", "reload", "build", "callers_of", "callees_of", "module_callers", "module_callees", "search", "file_skeleton", "neighborhood"}
-    assert len(tools) == 10
+    assert tool_names == {"stats", "reload", "build", "refers_to", "callees_of", "module_callees", "search", "file_skeleton", "neighborhood"}
+    assert len(tools) == 9
 
 
 @pytest.mark.asyncio
@@ -190,7 +190,7 @@ async def test_tool_annotations(server: RpcServer):
     responses = await _run(server, lines)
     tools = {t["name"]: t for t in responses[0]["result"]["tools"]}
 
-    for name in ("stats", "callers_of", "callees_of", "module_callers", "module_callees", "search"):
+    for name in ("stats", "refers_to", "callees_of", "module_callees", "search"):
         ann = tools[name]["annotations"]
         assert ann["readOnlyHint"] is True, f"{name} should be readOnly"
         assert ann["idempotentHint"] is True
@@ -220,18 +220,59 @@ async def test_tool_stats(server: RpcServer):
 
 
 @pytest.mark.asyncio
-async def test_tool_callers_of(server: RpcServer):
-    lines = [_req("tools/call", {"name": "callers_of", "arguments": {"fqn": "pkg.mod.bar"}}, req_id=1)]
+async def test_tool_refers_to(server: RpcServer):
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar"}}, req_id=1)]
     responses = await _run(server, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
     payload = json.loads(r["content"][0]["text"])
-    # Must return dict shape, not bare list
-    assert isinstance(payload, dict), "callers_of must return a dict, not a bare list"
+    # Must return dict shape with results list
+    assert isinstance(payload, dict), "refers_to must return a dict"
     assert "results" in payload
     assert "truncated" in payload
     assert isinstance(payload["results"], list)
     assert isinstance(payload["truncated"], bool)
+
+
+@pytest.mark.asyncio
+async def test_tool_refers_to_kind_callers(server: RpcServer):
+    """refers_to with kind='callers' returns call-only entries with context='call'."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "kind": "callers"}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "results" in payload
+    # Each entry has fqn, context, depth
+    for entry in payload["results"]:
+        assert "fqn" in entry
+        assert entry["context"] == "call"
+        assert "depth" in entry
+
+
+@pytest.mark.asyncio
+async def test_tool_refers_to_granularity_module(server: RpcServer):
+    """refers_to with granularity='module' returns flat list of module FQN strings."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "granularity": "module"}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is False
+    payload = json.loads(r["content"][0]["text"])
+    assert "results" in payload
+    # Results should be strings (module FQNs), not dicts
+    for item in payload["results"]:
+        assert isinstance(item, str)
+
+
+@pytest.mark.asyncio
+async def test_tool_refers_to_depth_exceeds_max(server: RpcServer):
+    """refers_to with depth > 2 returns isError:true with depth_exceeds_max."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "depth": 3}}, req_id=1)]
+    responses = await _run(server, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is True
+    text = r["content"][0]["text"]
+    assert "depth_exceeds_max" in text
 
 
 @pytest.mark.asyncio
@@ -250,8 +291,9 @@ async def test_tool_callees_of(server: RpcServer):
 
 
 @pytest.mark.asyncio
-async def test_tool_module_callers(server: RpcServer):
-    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "pkg.mod"}}, req_id=1)]
+async def test_tool_module_callers_via_refers_to(server: RpcServer):
+    """refers_to(kind='callers', granularity='module') replaces module_callers."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.bar", "kind": "callers", "granularity": "module"}}, req_id=1)]
     responses = await _run(server, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
@@ -276,11 +318,11 @@ async def test_tool_module_callees(server: RpcServer):
 
 
 @pytest.mark.asyncio
-async def test_tool_module_callers_prefix(server: RpcServer):
-    """module_callers with a package prefix returns aggregated callers as {results, truncated}."""
+async def test_tool_refers_to_module_finds_callers(server: RpcServer):
+    """refers_to(kind='callers', granularity='module') on pkg.mod.bar finds pkg.other as caller module."""
     # The fixture has: pkg.mod.foo, pkg.mod.bar, pkg.other.baz
     # pkg.other calls into pkg.mod (pkg.other.baz → pkg.mod.foo)
-    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "pkg.mod"}}, req_id=1)]
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "pkg.mod.foo", "kind": "callers", "granularity": "module"}}, req_id=1)]
     responses = await _run(server, lines)
     r = responses[0]["result"]
     assert r["isError"] is False
@@ -300,41 +342,30 @@ async def test_tool_module_callees_prefix(server: RpcServer):
 
 
 @pytest.mark.asyncio
-async def test_tool_module_callers_empty_prefix(server: RpcServer):
-    """Empty-string prefix is valid — matches all modules; payload has truncated key."""
-    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": ""}}, req_id=1)]
+async def test_tool_refers_to_fqn_not_found(server: RpcServer):
+    """refers_to with nonexistent FQN returns fqn_not_in_graph error."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"fqn": "does.not.exist.fn"}}, req_id=1)]
     responses = await _run(server, lines)
     r = responses[0]["result"]
-    assert r["isError"] is False
+    assert r["isError"] is True
     payload = json.loads(r["content"][0]["text"])
-    assert "results" in payload
-    assert "truncated" in payload
-
-
-@pytest.mark.asyncio
-async def test_tool_module_callers_no_match(server: RpcServer):
-    """A prefix matching no module returns {results: [], truncated: false} — no error."""
-    lines = [_req("tools/call", {"name": "module_callers", "arguments": {"module": "does.not.exist"}}, req_id=1)]
-    responses = await _run(server, lines)
-    r = responses[0]["result"]
-    assert r["isError"] is False
-    payload = json.loads(r["content"][0]["text"])
-    assert payload["results"] == []
-    assert payload["truncated"] is False
+    assert payload["error_reason"] == "fqn_not_in_graph"
 
 
 @pytest.mark.asyncio
 async def test_tool_descriptions_mention_prefix(server: RpcServer):
-    """module_callers and module_callees tool descriptions document prefix semantics."""
+    """refers_to and module_callees tool descriptions document semantics."""
     lines = [_req("tools/list", req_id=1)]
     responses = await _run(server, lines)
     tools = {t["name"]: t for t in responses[0]["result"]["tools"]}
 
-    mc_desc = tools["module_callers"]["description"]
+    rt_desc = tools["refers_to"]["description"]
     mce_desc = tools["module_callees"]["description"]
 
-    assert "prefix" in mc_desc.lower(), "module_callers description must mention 'prefix'"
-    assert "truncated" in mc_desc.lower(), "module_callers description must mention truncation"
+    assert "refers_to" in rt_desc.lower() or "reference" in rt_desc.lower(), (
+        "refers_to description must describe its purpose"
+    )
+    assert "truncated" in rt_desc.lower(), "refers_to description must mention truncation"
     assert "prefix" in mce_desc.lower(), "module_callees description must mention 'prefix'"
     assert "truncated" in mce_desc.lower(), "module_callees description must mention truncation"
 
@@ -398,9 +429,9 @@ async def test_tool_reload(server: RpcServer):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_callers_of_missing_fqn(server: RpcServer):
+async def test_refers_to_missing_fqn(server: RpcServer):
     """Missing required 'fqn' returns isError:true, not a JSON-RPC error."""
-    lines = [_req("tools/call", {"name": "callers_of", "arguments": {}}, req_id=1)]
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {}}, req_id=1)]
     responses = await _run(server, lines)
     r = responses[0]
     # Should be a successful RPC response with isError=true
@@ -423,9 +454,9 @@ async def test_search_missing_query(server: RpcServer):
 
 
 @pytest.mark.asyncio
-async def test_module_callers_missing_module(server: RpcServer):
-    """Missing required 'module' returns isError:true, not a JSON-RPC error."""
-    lines = [_req("tools/call", {"name": "module_callers", "arguments": {}}, req_id=1)]
+async def test_refers_to_missing_module(server: RpcServer):
+    """refers_to with missing fqn returns isError:true, not a JSON-RPC error."""
+    lines = [_req("tools/call", {"name": "refers_to", "arguments": {"kind": "callers"}}, req_id=1)]
     responses = await _run(server, lines)
     assert "result" in responses[0]
     assert responses[0]["result"]["isError"] is True
@@ -863,7 +894,7 @@ async def test_tools_list_ignores_cursor_and_omits_next_cursor(server: RpcServer
     result = responses[0]["result"]
     assert "tools" in result
     assert "nextCursor" not in result
-    assert len(result["tools"]) == 10
+    assert len(result["tools"]) == 9
 
 
 @pytest.mark.asyncio
@@ -1022,17 +1053,15 @@ async def test_notification_handler_raises_silent(server: RpcServer):
     "name,arguments,expect_error",
     [
         # Wrong-type fqn: truthy values that aren't in the graph.
-        # The not-in-graph check fires before _bfs → isError:true.
-        ("callers_of",     {"fqn": 123},                             True),
+        # The not-in-graph check fires before BFS → isError:true.
+        ("refers_to",      {"fqn": 123},                             True),
         ("callees_of",     {"fqn": 123},                             True),
-        # Non-string module: str.startswith raises TypeError → isError:true.
-        ("module_callers", {"module": True},                         True),
         # List-typed module: unhashable → TypeError on dict lookup → isError:true.
         ("module_callees", {"module": ["pkg", "mod"]},               True),
         # Non-string query: `.lower()` on dict raises AttributeError → isError:true.
         ("search",         {"query": {"nested": 1}},                 True),
         # Non-int depth: int("deep") raises ValueError → isError:true.
-        ("callers_of",     {"fqn": "pkg.mod.foo", "depth": "deep"},  True),
+        ("refers_to",      {"fqn": "pkg.mod.foo", "depth": "deep"},  True),
         ("callees_of",     {"fqn": "pkg.mod.foo", "depth": "deep"},  True),
     ],
 )

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -98,7 +98,7 @@ def test_stdio_multiple_requests(index_path: Path) -> None:
         r2 = _recv(proc)
         assert r2["id"] == 2
         tools = r2["result"]["tools"]
-        assert len(tools) == 10
+        assert len(tools) == 9
         assert all("name" in t and "inputSchema" in t for t in tools)
 
         # Third request — ping.
@@ -481,7 +481,7 @@ def test_file_skeleton_stale_e2e_wire(tmp_path: Path) -> None:
 
 
 def test_callers_of_stale_e2e_wire(tmp_path: Path) -> None:
-    """E2E: build real index, modify source file, call callers_of → stale: true over the wire."""
+    """E2E: build real index, modify source file, call refers_to → stale: true over the wire."""
     pkg = tmp_path / "mypkg"
     pkg.mkdir()
     (pkg / "__init__.py").write_text("")
@@ -529,7 +529,7 @@ def test_callers_of_stale_e2e_wire(tmp_path: Path) -> None:
 
         _send(proc, {
             "jsonrpc": "2.0", "id": 2, "method": "tools/call",
-            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.foo"}},
+            "params": {"name": "refers_to", "arguments": {"fqn": "mypkg.core.foo", "kind": "callers"}},
         })
         r = _recv(proc)
         assert r["id"] == 2
@@ -552,7 +552,7 @@ def test_callers_of_stale_e2e_wire(tmp_path: Path) -> None:
 
 
 def test_callers_of_fqn_not_in_graph_e2e(index_path: Path) -> None:
-    """E2E: callers_of with a nonexistent FQN returns isError:true + error_reason over real stdio pipes."""
+    """E2E: refers_to with a nonexistent FQN returns isError:true + error_reason over real stdio pipes."""
     repo_root = Path(__file__).resolve().parents[1]
     env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
     proc = subprocess.Popen(
@@ -577,10 +577,10 @@ def test_callers_of_fqn_not_in_graph_e2e(index_path: Path) -> None:
         assert r["id"] == 1
         _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
 
-        # Call callers_of with a FQN that cannot be in the index
+        # Call refers_to with a FQN that cannot be in the index
         _send(proc, {
             "jsonrpc": "2.0", "id": 2, "method": "tools/call",
-            "params": {"name": "callers_of", "arguments": {"fqn": "no.such.fqn.at.all"}},
+            "params": {"name": "refers_to", "arguments": {"fqn": "no.such.fqn.at.all", "kind": "callers"}},
         })
         r = _recv(proc)
         assert r["id"] == 2
@@ -694,7 +694,7 @@ def test_completeness_field_e2e(tmp_path: Path) -> None:
         # foo's callers include bar, which has missed dynamic calls → partial
         _send(proc, {
             "jsonrpc": "2.0", "id": 2, "method": "tools/call",
-            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.foo"}},
+            "params": {"name": "refers_to", "arguments": {"fqn": "mypkg.core.foo", "kind": "callers"}},
         })
         r2 = _recv(proc)
         assert r2["id"] == 2
@@ -706,10 +706,10 @@ def test_completeness_field_e2e(tmp_path: Path) -> None:
         )
 
         # bar has no callers and no missed_callers entry for bar-as-callee → complete
-        # (bar IS in the graph as a caller of foo, so callers_of(bar) returns results:[])
+        # (bar IS in the graph as a caller of foo, so refers_to(bar) returns results:[])
         _send(proc, {
             "jsonrpc": "2.0", "id": 3, "method": "tools/call",
-            "params": {"name": "callers_of", "arguments": {"fqn": "mypkg.core.bar"}},
+            "params": {"name": "refers_to", "arguments": {"fqn": "mypkg.core.bar", "kind": "callers"}},
         })
         r3 = _recv(proc)
         assert r3["id"] == 3

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -152,7 +152,7 @@ def test_callers_of_clean(tmp_path: Path) -> None:
     shas = {"mod.py": _sha256(content)}
     idx = _make_idx(tmp_path, _raw_ab(), skeletons, shas)
 
-    result = idx.callers_of("pkg.mod.fn_b", depth=1)
+    result = idx.refers_to("pkg.mod.fn_b", kind="callers", depth=1)
     assert result["stale"] is False
     assert result["stale_files"] == []
 
@@ -164,7 +164,7 @@ def test_callers_of_stale(tmp_path: Path) -> None:
     shas = {"mod.py": _sha256(b"def fn_a(): pass\n")}  # stored differs from disk
     idx = _make_idx(tmp_path, _raw_ab(), skeletons, shas)
 
-    result = idx.callers_of("pkg.mod.fn_b", depth=1)
+    result = idx.refers_to("pkg.mod.fn_b", kind="callers", depth=1)
     assert result["stale"] is True
     assert "mod.py" in result["stale_files"]
 
@@ -198,7 +198,7 @@ def test_callers_of_pre_v3(tmp_path: Path) -> None:
     """callers_of pre-v3 index returns index_format_incompatible."""
     skeletons = {"mod.py": [_sym("pkg.mod.fn_a"), _sym("pkg.mod.fn_b")]}
     idx = _make_idx(tmp_path, _raw_ab(), skeletons, file_shas=None)
-    result = idx.callers_of("pkg.mod.fn_b")
+    result = idx.refers_to("pkg.mod.fn_b", kind="callers")
     assert result["stale"] is True
     assert result["index_stale_reason"] == "index_format_incompatible"
 
@@ -324,7 +324,7 @@ def test_module_callers_clean(tmp_path: Path) -> None:
     idx = _make_idx(tmp_path, _raw_module(), skeletons, shas)
 
     # pkg.core calls pkg.util; module_callers("pkg.util") → ["pkg.core"]
-    result = idx.module_callers("pkg.util")
+    result = idx.refers_to("pkg.util.helper", kind="callers", granularity="module")
     assert result["stale"] is False
     assert result["stale_files"] == []
 
@@ -336,7 +336,7 @@ def test_module_callers_stale(tmp_path: Path) -> None:
     shas = {"core.py": _sha256(b"def run(): pass\n")}
     idx = _make_idx(tmp_path, _raw_module(), skeletons, shas)
 
-    result = idx.module_callers("pkg.util")
+    result = idx.refers_to("pkg.util.helper", kind="callers", granularity="module")
     assert result["stale"] is True
     assert "core.py" in result["stale_files"]
 
@@ -371,6 +371,6 @@ def test_module_callers_pre_v3(tmp_path: Path) -> None:
     """module_callers with pre-v3 index returns index_format_incompatible."""
     skeletons = {"core.py": [_sym("pkg.core.run")]}
     idx = _make_idx(tmp_path, _raw_module(), skeletons, file_shas=None)
-    result = idx.module_callers("pkg.util")
+    result = idx.refers_to("pkg.util.helper", kind="callers", granularity="module")
     assert result["stale"] is True
     assert result["index_stale_reason"] == "index_format_incompatible"

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-import pytest
 
 from pyscope_mcp.graph import CallGraphIndex, SymbolSummary
 from conftest import make_nodes


### PR DESCRIPTION
Closes #71

## Summary

- Adds `refers_to(fqn, kind, granularity, depth)` MCP tool that finds all typed AST references to a symbol: call, import, except, annotation, and isinstance edges from the epic #76 site-keyed graph
- Hard-deletes `callers_of` and `module_callers` (no migration wrappers): `refers_to(kind="callers")` replaces `callers_of`, `refers_to(kind="callers", granularity="module")` replaces `module_callers`
- Adds `_bfs_nodes_called_by` helper that walks `nodes["called_by"]` directly for multi-kind BFS traversal, and `ReferencedByEntry`/`ReferencedByResult` TypedDicts in types.py
- Implements depth-ranked ordering (depth-1 before depth-2), call-wins context priority, module deduplication, cap=50, and `depth_exceeds_max` guard for depth>2
- 18 new tests in `test_refers_to.py`; 728+ tests pass (3 pre-existing environment failures unrelated to this PR)

## Test plan

- [x] `tests/test_refers_to.py` — 18 tests covering all 5 edge kinds, both granularities, both kind filters, depth enforcement, error cases, context priority, deduplication, BFS ordering
- [x] `tests/test_graph.py` — updated to use `refers_to(kind="callers")` throughout
- [x] `tests/test_rpc_server.py` — tool list updated to 9 tools (removed callers_of/module_callers, added refers_to)
- [x] All integration and e2e tests updated: `test_rpc_stdio_e2e.py`, `test_integration_issue66.py`, `test_integration_issue69.py`, `test_component_issue62.py`, `test_component_issue66.py`, `test_component_issue69.py`
- [x] `test_bfs_ranking_integration.py` — updated to use refers_to for depth-ranked BFS regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)