### PR TITLE
fix(#96): deferred index init — graceful degradation on stale/missing index

### DIFF
--- a/src/pyscope_mcp/cli.py
+++ b/src/pyscope_mcp/cli.py
@@ -122,13 +122,11 @@ def cmd_serve(args: argparse.Namespace) -> int:
     index = _index_path(args.index)
     if not index.is_absolute():
         index = (root / index).resolve()
-    if not index.exists():
-        print(
-            f"[pyscope-mcp] no index at {index}. Run 'pyscope-mcp build' first.",
-            file=sys.stderr,
-        )
-        return 2
 
+    # Do NOT exit early for missing/stale index. Pass the path to run_stdio
+    # unconditionally; it will enter deferred-error mode and keep all tools
+    # registered. This prevents the silent tool-disappearance on stale schema
+    # or first-run before 'pyscope-mcp build' has been executed.
     server.run_stdio(index_path=index)
     return 0
 

--- a/src/pyscope_mcp/server.py
+++ b/src/pyscope_mcp/server.py
@@ -39,6 +39,17 @@ logger = logging.getLogger(__name__)
 _INDEX: CallGraphIndex | None = None
 _INDEX_PATH: Path | None = None
 
+# Deferred-error state: set at startup if the index cannot be loaded.
+# All index-dependent tools check this before calling _get_index().
+# Cleared by reload/build on success. Never blocks the tools/list response.
+_DEFERRED_ERROR: str | None = None
+
+# Actionable remedy string appended to all deferred-error messages.
+_DEFERRED_ERROR_ACTION = (
+    "Run 'pyscope-mcp build' to regenerate the index, "
+    "then call the 'reload' MCP tool."
+)
+
 # UUID generated once at module import (= server startup).
 # Since the MCP server is spawned per-session as a stdio subprocess,
 # this naturally partitions log entries by session.
@@ -489,12 +500,22 @@ async def _tools_call(id, params):  # noqa: A002
 
 
 async def _dispatch_tool(name: str, arguments: dict) -> dict:
-    global _INDEX
+    global _INDEX, _DEFERRED_ERROR
 
     if name == "reload":
         if _INDEX_PATH is None:
             raise RuntimeError("server started without an index path")
-        _INDEX = CallGraphIndex.load(_INDEX_PATH)
+        # Harden: if the index is still broken, update deferred-error and keep running.
+        try:
+            _INDEX = CallGraphIndex.load(_INDEX_PATH)
+            _DEFERRED_ERROR = None  # clear on success
+        except (FileNotFoundError, ValueError) as exc:
+            _INDEX = None
+            if isinstance(exc, FileNotFoundError):
+                _DEFERRED_ERROR = f"Index not found at {_INDEX_PATH}. {_DEFERRED_ERROR_ACTION}"
+            else:
+                _DEFERRED_ERROR = f"{exc}. {_DEFERRED_ERROR_ACTION}"
+            return _error_result(_DEFERRED_ERROR)
         return _text(_INDEX.stats())
 
     if name == "build":
@@ -519,9 +540,14 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
                 return _error_result(
                     f"build failed (exit {proc_result.returncode}): {stderr}"
                 )
-            # Reload the freshly-written index
+            # Reload the freshly-written index; clear deferred-error on success.
             _INDEX = CallGraphIndex.load(_INDEX_PATH)
+            _DEFERRED_ERROR = None
             return _text(_INDEX.stats())
+
+    # Gate all index-dependent tools: return actionable error if startup load failed.
+    if _DEFERRED_ERROR:
+        return _error_result(_DEFERRED_ERROR)
 
     idx = _get_index()
 
@@ -594,10 +620,32 @@ async def _dispatch_tool(name: str, arguments: dict) -> dict:
 # Public entry point
 # ---------------------------------------------------------------------------
 def run_stdio(index_path: Path) -> None:
-    """Load the index and start the JSON-RPC stdio loop (blocks until EOF/shutdown)."""
-    global _INDEX_PATH, _INDEX
+    """Load the index and start the JSON-RPC stdio loop (blocks until EOF/shutdown).
+
+    If the index file is missing or has a stale schema, the load error is captured
+    in _DEFERRED_ERROR instead of crashing. All tools are still registered and visible
+    via tools/list. Index-dependent tool calls return isError:true with an actionable
+    message until a valid index is available.
+    """
+    global _INDEX_PATH, _INDEX, _DEFERRED_ERROR
     _INDEX_PATH = Path(index_path)
-    _INDEX = CallGraphIndex.load(_INDEX_PATH)
+    try:
+        _INDEX = CallGraphIndex.load(_INDEX_PATH)
+        _DEFERRED_ERROR = None
+    except FileNotFoundError:
+        logger.warning(
+            "Index not found at %s — starting in deferred-error mode. %s",
+            _INDEX_PATH, _DEFERRED_ERROR_ACTION,
+        )
+        _INDEX = None
+        _DEFERRED_ERROR = f"Index not found at {_INDEX_PATH}. {_DEFERRED_ERROR_ACTION}"
+    except ValueError as exc:
+        logger.warning(
+            "Index load failed (%s) — starting in deferred-error mode. %s",
+            exc, _DEFERRED_ERROR_ACTION,
+        )
+        _INDEX = None
+        _DEFERRED_ERROR = f"{exc}. {_DEFERRED_ERROR_ACTION}"
 
     # Initialise query logger (no-op when PYSCOPE_MCP_LOG=0).
     from pyscope_mcp import _log

--- a/tests/test_component_issue96.py
+++ b/tests/test_component_issue96.py
@@ -1,0 +1,482 @@
+"""Component tests for issue #96 — deferred index initialisation.
+
+Three cross-module boundaries tested:
+
+  B1 (server.py → graph.py): server.run_stdio() calls CallGraphIndex.load().
+     When load raises FileNotFoundError (missing index), run_stdio must set
+     _DEFERRED_ERROR to a non-None string containing "pyscope-mcp build" and
+     leave _INDEX as None — without raising or crashing.
+     When load raises ValueError (stale schema), the same deferred-error state
+     applies.
+
+  B2 (server.py → graph.py): server._dispatch_tool('reload') calls
+     CallGraphIndex.load(). When the index is still broken, load raises again;
+     _dispatch_tool must update _DEFERRED_ERROR, leave _INDEX as None, and
+     return isError:true. When a valid index is placed on disk, _dispatch_tool
+     must load it, clear _DEFERRED_ERROR, set _INDEX, and return isError:false.
+
+  B3 (cli.py → server.py): cli.cmd_serve() passes the index path to
+     server.run_stdio() unconditionally — no early-exit guard. If the index
+     is missing, run_stdio enters deferred-error mode (B1 contract); cmd_serve
+     must not raise or sys.exit before run_stdio is entered. The wiring is
+     tested by patching asyncio.run to prevent the event loop from starting
+     (component scope, no subprocess).
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pyscope_mcp.server as _srv
+from pyscope_mcp.graph import CallGraphIndex
+from conftest import make_nodes
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_valid_index(tmp_path: Path) -> Path:
+    """Write a minimal valid index to disk and return its path."""
+    raw: dict[str, list[str]] = {
+        "pkg.mod.alpha": ["pkg.mod.beta"],
+        "pkg.mod.beta": [],
+    }
+    idx = CallGraphIndex.from_nodes(tmp_path, make_nodes(raw))
+    idx_path = tmp_path / "index.json"
+    idx.save(idx_path)
+    return idx_path
+
+
+def _write_stale_schema_index(path: Path) -> None:
+    """Write a v0 index (schema mismatch) to path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 0, "root": "/", "raw": {}}))
+
+
+def _reset_server_state() -> None:
+    """Reset module-level server state between tests."""
+    _srv._INDEX = None
+    _srv._INDEX_PATH = None
+    _srv._DEFERRED_ERROR = None
+    _srv._SERVER._shutdown_requested = False
+
+
+# ---------------------------------------------------------------------------
+# B1 — server.run_stdio() → CallGraphIndex.load(): deferred-error state
+# ---------------------------------------------------------------------------
+
+class TestB1RunStdioDefersErrorOnMissingIndex:
+    """B1: run_stdio sets _DEFERRED_ERROR when load raises FileNotFoundError."""
+
+    def setup_method(self):
+        _reset_server_state()
+
+    def teardown_method(self):
+        _reset_server_state()
+
+    def test_run_stdio_missing_index_sets_deferred_error(self, tmp_path: Path) -> None:
+        """[B1] run_stdio with missing index must set _DEFERRED_ERROR (not raise).
+
+        Verifies: FileNotFoundError from load() is caught; _DEFERRED_ERROR is
+        non-None and contains 'pyscope-mcp build' so the agent knows the remedy.
+        """
+        # Arrange — index file does not exist
+        missing_index = tmp_path / ".pyscope-mcp" / "index.json"
+
+        # Act — patch asyncio.run so the event loop never starts (component scope)
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            _srv.run_stdio(missing_index)
+
+        # Assert
+        assert _srv._DEFERRED_ERROR is not None, (
+            "run_stdio must set _DEFERRED_ERROR when the index is missing, "
+            "not crash or leave it None"
+        )
+        assert "pyscope-mcp build" in _srv._DEFERRED_ERROR, (
+            f"_DEFERRED_ERROR must contain 'pyscope-mcp build' so the agent "
+            f"knows the remedy; got: {_srv._DEFERRED_ERROR!r}"
+        )
+
+    def test_run_stdio_missing_index_leaves_index_none(self, tmp_path: Path) -> None:
+        """[B1] run_stdio with missing index must leave _INDEX as None.
+
+        Verifies the server does not enter a partial-load state where _INDEX
+        points to a stale or empty object.
+        """
+        # Arrange
+        missing_index = tmp_path / "no" / "such" / "index.json"
+
+        # Act
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            _srv.run_stdio(missing_index)
+
+        # Assert
+        assert _srv._INDEX is None, (
+            "run_stdio must leave _INDEX=None when the index file is missing; "
+            f"got _INDEX={_srv._INDEX!r}"
+        )
+
+    def test_run_stdio_stale_schema_sets_deferred_error(self, tmp_path: Path) -> None:
+        """[B1] run_stdio with stale-schema index (v0) must set _DEFERRED_ERROR.
+
+        Verifies the ValueError path from CallGraphIndex.load() is caught and
+        results in the same deferred-error state as the FileNotFoundError path.
+        """
+        # Arrange — v0 schema index on disk
+        stale_index = tmp_path / "index.json"
+        _write_stale_schema_index(stale_index)
+
+        # Act
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            _srv.run_stdio(stale_index)
+
+        # Assert
+        assert _srv._DEFERRED_ERROR is not None, (
+            "run_stdio must set _DEFERRED_ERROR when the index has a stale schema, "
+            "not crash; the ValueError from load() must be caught"
+        )
+        assert "pyscope-mcp build" in _srv._DEFERRED_ERROR, (
+            f"_DEFERRED_ERROR must contain 'pyscope-mcp build'; "
+            f"got: {_srv._DEFERRED_ERROR!r}"
+        )
+
+    def test_run_stdio_stale_schema_leaves_index_none(self, tmp_path: Path) -> None:
+        """[B1] run_stdio with stale-schema index must leave _INDEX=None."""
+        # Arrange
+        stale_index = tmp_path / "index.json"
+        _write_stale_schema_index(stale_index)
+
+        # Act
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            _srv.run_stdio(stale_index)
+
+        # Assert
+        assert _srv._INDEX is None, (
+            "run_stdio must leave _INDEX=None for a stale-schema index"
+        )
+
+    def test_run_stdio_valid_index_clears_deferred_error(self, tmp_path: Path) -> None:
+        """[B1] run_stdio with a valid index must set _INDEX and leave _DEFERRED_ERROR=None.
+
+        Negative-case: the deferred-error path must NOT fire for a good index.
+        """
+        # Arrange — pre-arm a stale error to confirm run_stdio clears it
+        _srv._DEFERRED_ERROR = "stale sentinel from previous run"
+        idx_path = _make_valid_index(tmp_path)
+
+        # Act
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            _srv.run_stdio(idx_path)
+
+        # Assert
+        assert _srv._DEFERRED_ERROR is None, (
+            "run_stdio with a valid index must clear any pre-existing "
+            f"_DEFERRED_ERROR; got: {_srv._DEFERRED_ERROR!r}"
+        )
+        assert _srv._INDEX is not None, (
+            "run_stdio with a valid index must load and set _INDEX"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B2 — _dispatch_tool('reload') → CallGraphIndex.load(): state machine
+# ---------------------------------------------------------------------------
+
+class TestB2ReloadDispatchStateTransitions:
+    """B2: _dispatch_tool('reload') correctly transitions _DEFERRED_ERROR state."""
+
+    def setup_method(self):
+        _reset_server_state()
+
+    def teardown_method(self):
+        _reset_server_state()
+
+    @pytest.mark.asyncio
+    async def test_reload_with_missing_index_returns_is_error(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2] reload on a still-missing index returns isError:true.
+
+        The reload branch must call load(), receive FileNotFoundError,
+        update _DEFERRED_ERROR, and return _error_result — not crash the server.
+        """
+        # Arrange — index path points to non-existent file
+        missing_index = tmp_path / ".pyscope-mcp" / "index.json"
+        _srv._INDEX_PATH = missing_index
+        _srv._INDEX = None
+        _srv._DEFERRED_ERROR = f"Index not found at {missing_index}. {_srv._DEFERRED_ERROR_ACTION}"
+
+        # Act
+        result = await _srv._dispatch_tool("reload", {})
+
+        # Assert
+        assert result.get("isError") is True, (
+            "reload on a missing index must return isError:true; "
+            f"got: {result}"
+        )
+        assert "content" in result, "isError result must have 'content' key"
+        content_text = result["content"][0]["text"]
+        assert "pyscope-mcp build" in content_text, (
+            f"reload error message must contain 'pyscope-mcp build'; "
+            f"got: {content_text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reload_with_missing_index_leaves_deferred_error_set(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2] reload on a still-missing index must NOT clear _DEFERRED_ERROR.
+
+        After a failed reload, subsequent tool calls must still return
+        isError:true — _DEFERRED_ERROR must be updated (not cleared).
+        """
+        # Arrange
+        missing_index = tmp_path / ".pyscope-mcp" / "index.json"
+        _srv._INDEX_PATH = missing_index
+        _srv._INDEX = None
+        _srv._DEFERRED_ERROR = None  # start clean; reload is the trigger
+
+        # Act
+        await _srv._dispatch_tool("reload", {})
+
+        # Assert
+        assert _srv._DEFERRED_ERROR is not None, (
+            "_DEFERRED_ERROR must be set after reload fails on a missing index"
+        )
+        assert _srv._INDEX is None, (
+            "_INDEX must remain None after a failed reload"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reload_with_valid_index_clears_deferred_error(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2] reload with a valid index on disk clears _DEFERRED_ERROR.
+
+        After a successful reload, _DEFERRED_ERROR must be None and _INDEX
+        must point to the loaded graph.
+        """
+        # Arrange — write a valid index; pre-arm the deferred-error state
+        idx_path = _make_valid_index(tmp_path)
+        _srv._INDEX_PATH = idx_path
+        _srv._INDEX = None
+        _srv._DEFERRED_ERROR = (
+            f"Index not found at {idx_path}. {_srv._DEFERRED_ERROR_ACTION}"
+        )
+
+        # Act
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=128, stdout="")
+            result = await _srv._dispatch_tool("reload", {})
+
+        # Assert
+        assert result.get("isError") is False, (
+            "reload on a valid index must return isError:false; "
+            f"got: {result}"
+        )
+        assert _srv._DEFERRED_ERROR is None, (
+            "reload success must clear _DEFERRED_ERROR; "
+            f"got: {_srv._DEFERRED_ERROR!r}"
+        )
+        assert _srv._INDEX is not None, (
+            "reload success must set _INDEX to the loaded graph"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reload_success_enables_subsequent_tool_calls(
+        self, tmp_path: Path
+    ) -> None:
+        """[B2] After a successful reload, index-dependent tools return isError:false.
+
+        Verifies the full state-machine transition: deferred-error → reload →
+        cleared → stats returns live data. This is the contract that agents
+        depend on to recover from a missing-index startup.
+        """
+        # Arrange — write a valid index; simulate deferred-error startup state
+        idx_path = _make_valid_index(tmp_path)
+        _srv._INDEX_PATH = idx_path
+        _srv._INDEX = None
+        _srv._DEFERRED_ERROR = (
+            f"Index not found at {idx_path}. {_srv._DEFERRED_ERROR_ACTION}"
+        )
+
+        # Confirm pre-condition: stats returns isError:true in deferred-error state
+        pre_result = await _srv._dispatch_tool("stats", {})
+        assert pre_result.get("isError") is True, (
+            "pre-condition: stats must return isError:true in deferred-error state"
+        )
+
+        # Act — reload the now-valid index
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=128, stdout="")
+            reload_result = await _srv._dispatch_tool("reload", {})
+        assert reload_result.get("isError") is False, (
+            f"reload must succeed now index is on disk; got: {reload_result}"
+        )
+
+        # Assert — subsequent stats call must return live data
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=128, stdout="")
+            post_result = await _srv._dispatch_tool("stats", {})
+
+        assert post_result.get("isError") is False, (
+            "stats after successful reload must return isError:false; "
+            f"got: {post_result}"
+        )
+        payload = json.loads(post_result["content"][0]["text"])
+        assert "functions" in payload, (
+            f"stats payload must include 'functions' after reload; "
+            f"got keys: {list(payload.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B3 — cli.cmd_serve() → server.run_stdio(): unconditional wiring contract
+# ---------------------------------------------------------------------------
+
+class TestB3CmdServeWiresRunStdioUnconditionally:
+    """B3: cli.cmd_serve() passes index path to server.run_stdio() without early exit.
+
+    The previous code had an early-exit guard:
+        if not index.exists():
+            print(...)
+            return 2
+    Issue #96 removes this guard so run_stdio() is always called — entering
+    deferred-error mode if the index is missing.
+
+    These tests verify the wiring at component scope (no subprocess). They
+    patch asyncio.run to prevent the event loop from starting and inspect
+    what state was established before the loop would start.
+    """
+
+    def setup_method(self):
+        _reset_server_state()
+
+    def teardown_method(self):
+        _reset_server_state()
+
+    def test_cmd_serve_calls_run_stdio_for_missing_index(self, tmp_path: Path) -> None:
+        """[B3] cmd_serve with a missing index path calls run_stdio (not sys.exit/return 2).
+
+        Verifies the early-exit guard has been removed. If run_stdio is called,
+        _DEFERRED_ERROR will be set (B1 contract). If the guard is still present,
+        run_stdio is never entered and _DEFERRED_ERROR stays None.
+        """
+        # Arrange
+        missing_index = tmp_path / ".pyscope-mcp" / "index.json"
+
+        import pyscope_mcp.cli as cli_mod
+
+        # Build an argparse.Namespace that cmd_serve expects
+        args = types.SimpleNamespace(
+            root=str(tmp_path),
+            index=str(missing_index),
+        )
+
+        # Act — patch asyncio.run so no event loop starts; patch _log.init
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            cli_mod.cmd_serve(args)
+
+        # Assert — B1 contract: run_stdio entered deferred-error mode
+        assert _srv._DEFERRED_ERROR is not None, (
+            "cmd_serve with a missing index must call run_stdio, which sets "
+            "_DEFERRED_ERROR. If _DEFERRED_ERROR is None, the early-exit guard "
+            "was not removed and run_stdio was never entered."
+        )
+        assert "pyscope-mcp build" in _srv._DEFERRED_ERROR, (
+            f"Deferred error message must contain 'pyscope-mcp build'; "
+            f"got: {_srv._DEFERRED_ERROR!r}"
+        )
+
+    def test_cmd_serve_missing_index_does_not_raise(self, tmp_path: Path) -> None:
+        """[B3] cmd_serve with missing index must not raise any exception.
+
+        Before issue #96, the early-exit guard only returned 2 (no exception).
+        After the fix, run_stdio catches the error. Neither path must raise.
+        """
+        # Arrange
+        missing_index = tmp_path / "no" / "index.json"
+
+        import pyscope_mcp.cli as cli_mod
+
+        args = types.SimpleNamespace(
+            root=str(tmp_path),
+            index=str(missing_index),
+        )
+
+        # Act + Assert — no exception raised
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            try:
+                cli_mod.cmd_serve(args)
+            except Exception as exc:
+                pytest.fail(
+                    f"cmd_serve raised {type(exc).__name__}: {exc} — "
+                    "it must not raise when the index is missing"
+                )
+
+    def test_cmd_serve_valid_index_reaches_run_stdio_with_live_index(
+        self, tmp_path: Path
+    ) -> None:
+        """[B3] cmd_serve with a valid index passes it to run_stdio, which loads it.
+
+        Negative-case: confirms the unconditional wiring works for the happy path
+        too — run_stdio loads the index and _DEFERRED_ERROR stays None.
+        """
+        # Arrange — write a valid index
+        idx_path = _make_valid_index(tmp_path)
+
+        import pyscope_mcp.cli as cli_mod
+
+        args = types.SimpleNamespace(
+            root=str(tmp_path),
+            index=str(idx_path),
+        )
+
+        # Act
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            cli_mod.cmd_serve(args)
+
+        # Assert
+        assert _srv._DEFERRED_ERROR is None, (
+            "cmd_serve with a valid index must NOT set _DEFERRED_ERROR; "
+            f"got: {_srv._DEFERRED_ERROR!r}"
+        )
+        assert _srv._INDEX is not None, (
+            "cmd_serve with a valid index must load _INDEX via run_stdio"
+        )
+
+    def test_cmd_serve_index_path_is_passed_to_run_stdio(self, tmp_path: Path) -> None:
+        """[B3] cmd_serve passes the resolved index path to run_stdio.
+
+        Verifies that _INDEX_PATH set by run_stdio matches the path cmd_serve
+        computed — the absolute resolved path must be recorded in server state
+        so reload/build tools can locate the index later.
+        """
+        # Arrange — valid index at a known path
+        idx_path = _make_valid_index(tmp_path)
+
+        import pyscope_mcp.cli as cli_mod
+
+        args = types.SimpleNamespace(
+            root=str(tmp_path),
+            index=str(idx_path),
+        )
+
+        # Act
+        with patch("asyncio.run"), patch("pyscope_mcp._log.init"):
+            cli_mod.cmd_serve(args)
+
+        # Assert — _INDEX_PATH must be set and resolve to the same absolute path
+        assert _srv._INDEX_PATH is not None, (
+            "cmd_serve must set _INDEX_PATH via run_stdio"
+        )
+        assert Path(_srv._INDEX_PATH).resolve() == idx_path.resolve(), (
+            f"_INDEX_PATH must match the path cmd_serve passed to run_stdio; "
+            f"got {_srv._INDEX_PATH!r}, expected {idx_path!r}"
+        )

--- a/tests/test_integration_issue96.py
+++ b/tests/test_integration_issue96.py
@@ -1,0 +1,431 @@
+"""Integration tests for issue #96 — deferred index initialisation.
+
+Two scenarios at integration tier (real subprocess, real OS pipes):
+
+  slice-deferred-init-stale-schema-e2e (wiring):
+    Verifies that `pyscope-mcp serve` with a stale-schema (v0) index does NOT
+    crash before registering tools. The server starts, responds to the MCP
+    initialize handshake, returns all 9 tools in tools/list, and returns
+    isError:true with a "pyscope-mcp build" message for any index-dependent
+    tool call. The server remains alive for subsequent requests.
+
+  slice-deferred-init-missing-index-e2e (wiring):
+    Verifies that `pyscope-mcp serve` with a missing index path does NOT exit
+    with code 2 (the pre-#96 behaviour). The server starts, registers all 9
+    tools, and returns isError:true with "pyscope-mcp build" for index-dependent
+    tools. Clean shutdown is possible.
+
+Pattern: real subprocess, real OS pipes, stdio JSON-RPC 2.0.
+Mirrors test_integration_issue71.py conventions (same _send/_recv helpers,
+same _handshake/_shutdown/_spawn_server pattern, same marker discipline).
+
+No artifact tier: the deferred-error output is structural (isError flag, text
+message substring), not an exact-value golden fixture — classifying this scenario
+as volatile_output=true.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_integration_issue71.py)
+# ---------------------------------------------------------------------------
+
+
+def _send(proc: subprocess.Popen, msg: dict) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write((json.dumps(msg) + "\n").encode())
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen, timeout: float = 10.0) -> dict:
+    assert proc.stdout is not None
+    line = proc.stdout.readline()
+    if not line:
+        err = proc.stderr.read().decode() if proc.stderr else ""
+        raise AssertionError(f"server produced no stdout; stderr={err!r}")
+    return json.loads(line.decode())
+
+
+def _handshake(proc: subprocess.Popen, client_name: str = "it96-test") -> None:
+    """Send MCP initialize + initialized notification; assert initialize OK."""
+    _send(proc, {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": client_name, "version": "0"},
+        },
+    })
+    r = _recv(proc)
+    assert r["id"] == 1
+    assert r["result"]["protocolVersion"] == "2024-11-05"
+    _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+
+def _shutdown(proc: subprocess.Popen, req_id: int = 99) -> None:
+    """Send shutdown + close stdin; assert server exits 0."""
+    _send(proc, {"jsonrpc": "2.0", "id": req_id, "method": "shutdown"})
+    r = _recv(proc)
+    assert r == {"jsonrpc": "2.0", "id": req_id, "result": {}}
+    assert proc.stdin is not None
+    proc.stdin.close()
+    assert proc.wait(timeout=5) == 0
+
+
+def _spawn_server(index_path: Path, root: Path | None = None) -> subprocess.Popen:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+    args = [
+        sys.executable, "-m", "pyscope_mcp.cli", "serve",
+        "--root", str(root or repo_root),
+        "--index", str(index_path),
+    ]
+    return subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario: slice-deferred-init-stale-schema-e2e
+# SCENARIO: slice-deferred-init-stale-schema-e2e
+# layers_involved: src/pyscope_mcp/server.py, src/pyscope_mcp/cli.py
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredInitStaleSchemaWiring:
+    """Wiring tier — slice-deferred-init-stale-schema-e2e.
+
+    Verifies:
+    - server starts (does not crash) when given a v0 (stale-schema) index
+    - MCP initialize handshake succeeds; serverInfo.name == 'pyscope-mcp'
+    - tools/list returns all 9 tools in deferred-error state
+    - stats returns isError:true with 'pyscope-mcp build' in the message
+    - server remains alive after a deferred-error tool call (ping works)
+    - clean shutdown returns {} and server exits 0
+    """
+
+    @pytest.fixture(autouse=True)
+    def stale_index(self, tmp_path: Path) -> Path:
+        """Write a v0 (stale-schema) index to a temp directory."""
+        stale_dir = tmp_path / ".pyscope-mcp"
+        stale_dir.mkdir(parents=True)
+        idx_path = stale_dir / "index.json"
+        idx_path.write_text('{"version": 0, "root": "/", "raw": {}}')
+        self._stale_index_path = idx_path
+        self._tmp_path = tmp_path
+        return idx_path
+
+    @pytest.mark.integration_wiring
+    def test_server_starts_with_stale_schema_index(self) -> None:
+        """Server must not crash before the MCP handshake when index schema is stale."""
+        proc = _spawn_server(self._stale_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-stale-startup")
+            # Success: handshake completed — server started and is responsive
+            assert proc.poll() is None, "Server process must still be running after handshake"
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_tools_list_returns_all_9_tools_in_deferred_error_state(self) -> None:
+        """tools/list must return all 9 tools even when the index is stale."""
+        proc = _spawn_server(self._stale_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-stale-tools-list")
+
+            _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+            r = _recv(proc)
+            assert r["id"] == 2
+            tools = r["result"]["tools"]
+            tool_names = {t["name"] for t in tools}
+
+            # Schema assertions (wiring tier)
+            assert len(tools) == 9, (
+                f"Expected 9 tools in deferred-error state; got {len(tools)}: "
+                f"{sorted(tool_names)}"
+            )
+            assert all("name" in t and "inputSchema" in t for t in tools), (
+                "Each tool entry must have 'name' and 'inputSchema'"
+            )
+            assert "stats" in tool_names, "stats must be registered"
+            assert "reload" in tool_names, "reload must be registered"
+            assert "build" in tool_names, "build must be registered"
+            assert "refers_to" in tool_names, "refers_to must be registered"
+            assert "callees_of" in tool_names, "callees_of must be registered"
+            assert "module_callees" in tool_names, "module_callees must be registered"
+            assert "search" in tool_names, "search must be registered"
+            assert "file_skeleton" in tool_names, "file_skeleton must be registered"
+            assert "neighborhood" in tool_names, "neighborhood must be registered"
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_stats_returns_is_error_with_build_message(self) -> None:
+        """stats in deferred-error state returns isError:true with 'pyscope-mcp build'."""
+        proc = _spawn_server(self._stale_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-stale-stats")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": "stats", "arguments": {}},
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"Unexpected JSON-RPC error: {r}"
+
+            # Wiring tier: status code / isError flag assertion
+            assert r["result"]["isError"] is True, (
+                "stats must return isError:true when the index is in deferred-error state"
+            )
+
+            # Schema assertion: content array present and non-empty
+            content = r["result"]["content"]
+            assert isinstance(content, list) and len(content) > 0, (
+                "isError result must have a non-empty 'content' list"
+            )
+            assert content[0].get("type") == "text", (
+                "content[0].type must be 'text'"
+            )
+
+            # Message substring assertion (wiring: actionable message present)
+            text = content[0]["text"]
+            assert "pyscope-mcp build" in text, (
+                f"Error message must contain 'pyscope-mcp build' so the agent "
+                f"knows the remedy; got: {text!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_server_stays_alive_after_deferred_error_tool_call(self) -> None:
+        """Server must remain responsive after a deferred-error tool call (ping test)."""
+        proc = _spawn_server(self._stale_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-stale-alive")
+
+            # Trigger deferred-error path
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": "stats", "arguments": {}},
+            })
+            r = _recv(proc)
+            assert r["result"]["isError"] is True
+
+            # Server must still respond to ping
+            _send(proc, {"jsonrpc": "2.0", "id": 3, "method": "ping"})
+            r_ping = _recv(proc)
+            assert r_ping == {"jsonrpc": "2.0", "id": 3, "result": {}}, (
+                "Server must remain alive and respond to ping after a deferred-error tool call"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    @pytest.mark.parametrize("tool_name,arguments", [
+        ("refers_to",      {"fqn": "pkg.mod.foo"}),
+        ("callees_of",     {"fqn": "pkg.mod.foo"}),
+        ("module_callees", {"module": "pkg.mod"}),
+        ("search",         {"query": "foo"}),
+        ("file_skeleton",  {"path": "pkg/mod.py"}),
+        ("neighborhood",   {"symbol": "pkg.mod.foo"}),
+    ])
+    def test_all_index_dependent_tools_return_is_error(
+        self, tool_name: str, arguments: dict
+    ) -> None:
+        """Each index-dependent tool must return isError:true in deferred-error state."""
+        proc = _spawn_server(self._stale_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name=f"it96-stale-{tool_name}")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"Unexpected JSON-RPC error for {tool_name}: {r}"
+            assert r["result"]["isError"] is True, (
+                f"{tool_name} must return isError:true in deferred-error state; "
+                f"got isError={r['result'].get('isError')}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Scenario: slice-deferred-init-missing-index-e2e
+# SCENARIO: slice-deferred-init-missing-index-e2e
+# layers_involved: src/pyscope_mcp/server.py, src/pyscope_mcp/cli.py
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredInitMissingIndexWiring:
+    """Wiring tier — slice-deferred-init-missing-index-e2e.
+
+    Verifies:
+    - server starts (does not exit with code 2) when index path does not exist
+    - MCP initialize handshake succeeds
+    - tools/list returns all 9 tools
+    - stats returns isError:true with 'pyscope-mcp build' in the message
+    - clean shutdown returns {} and server exits 0
+    """
+
+    @pytest.fixture(autouse=True)
+    def missing_index(self, tmp_path: Path) -> Path:
+        """Provide a path to an index that deliberately does not exist."""
+        idx_path = tmp_path / ".pyscope-mcp" / "index.json"
+        # Intentionally do NOT create the file or directory
+        self._missing_index_path = idx_path
+        self._tmp_path = tmp_path
+        return idx_path
+
+    @pytest.mark.integration_wiring
+    def test_server_starts_with_missing_index(self) -> None:
+        """Server must not exit with code 2 when the index file does not exist.
+
+        Before issue #96, cli.cmd_serve had an early-exit guard that returned 2
+        when index.exists() was False. This test verifies the guard is removed:
+        the server must start and respond to the MCP initialize handshake.
+        """
+        proc = _spawn_server(self._missing_index_path, root=self._tmp_path)
+        try:
+            # If the server exited early (old behavior), _recv would raise AssertionError
+            # because stdout would be empty. The handshake completing proves the server started.
+            _handshake(proc, client_name="it96-missing-startup")
+            assert proc.poll() is None, "Server must still be running after handshake"
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_tools_list_returns_all_9_tools_for_missing_index(self) -> None:
+        """tools/list must return all 9 tools even when the index file is missing."""
+        proc = _spawn_server(self._missing_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-missing-tools-list")
+
+            _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+            r = _recv(proc)
+            assert r["id"] == 2
+            tools = r["result"]["tools"]
+
+            # Schema assertions (wiring tier)
+            assert len(tools) == 9, (
+                f"Expected 9 tools when index is missing; got {len(tools)}: "
+                f"{[t['name'] for t in tools]}"
+            )
+            assert all("name" in t and "inputSchema" in t for t in tools), (
+                "Each tool entry must have 'name' and 'inputSchema'"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_stats_returns_is_error_with_build_message_for_missing_index(self) -> None:
+        """stats must return isError:true with 'pyscope-mcp build' when index is missing."""
+        proc = _spawn_server(self._missing_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-missing-stats")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": "stats", "arguments": {}},
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"Unexpected JSON-RPC error: {r}"
+
+            # Wiring tier: isError flag
+            assert r["result"]["isError"] is True, (
+                "stats must return isError:true when the index file is missing"
+            )
+
+            # Schema assertions
+            content = r["result"]["content"]
+            assert isinstance(content, list) and len(content) > 0
+            assert content[0].get("type") == "text"
+
+            # Actionable message check
+            text = content[0]["text"]
+            assert "pyscope-mcp build" in text, (
+                f"Error message must reference 'pyscope-mcp build'; got: {text!r}"
+            )
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)
+
+    @pytest.mark.integration_wiring
+    def test_reload_with_missing_index_returns_is_error(self) -> None:
+        """reload while index is still missing must return isError:true; server stays up."""
+        proc = _spawn_server(self._missing_index_path, root=self._tmp_path)
+        try:
+            _handshake(proc, client_name="it96-missing-reload")
+
+            _send(proc, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": "reload", "arguments": {}},
+            })
+            r = _recv(proc)
+            assert r["id"] == 2
+            assert "error" not in r, f"Unexpected JSON-RPC error: {r}"
+
+            # reload on a missing index must return isError:true
+            assert r["result"]["isError"] is True, (
+                "reload with a missing index must return isError:true"
+            )
+            content = r["result"]["content"]
+            assert isinstance(content, list) and len(content) > 0
+            text = content[0]["text"]
+            assert "pyscope-mcp build" in text, (
+                f"reload error message must reference 'pyscope-mcp build'; got: {text!r}"
+            )
+
+            # Server must still be alive
+            _send(proc, {"jsonrpc": "2.0", "id": 3, "method": "ping"})
+            r_ping = _recv(proc)
+            assert r_ping == {"jsonrpc": "2.0", "id": 3, "result": {}}
+
+            _shutdown(proc)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=2)

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -148,9 +148,11 @@ def reset_server_state(tmp_index: Path):
     import pyscope_mcp.server as srv
     srv._INDEX_PATH = tmp_index
     srv._INDEX = None
+    srv._DEFERRED_ERROR = None
     srv._SERVER._shutdown_requested = False
     yield
     srv._INDEX = None
+    srv._DEFERRED_ERROR = None
 
 
 # ---------------------------------------------------------------------------
@@ -1311,3 +1313,163 @@ def test_no_heavy_deps_on_serve_path():
         f"Heavy deps loaded on serve path: {sorted(intersection)}. "
         "Issue #40 removed these from the serve path — do not reintroduce."
     )
+
+
+# ---------------------------------------------------------------------------
+# Deferred-error state — issue #96
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def server_deferred_missing(tmp_path: Path) -> RpcServer:
+    """Server with _DEFERRED_ERROR set for a missing index."""
+    import pyscope_mcp.server as srv
+
+    missing = tmp_path / "nonexistent" / "index.json"
+    srv._INDEX_PATH = missing
+    srv._INDEX = None
+    srv._DEFERRED_ERROR = (
+        f"Index not found at {missing}. "
+        f"{srv._DEFERRED_ERROR_ACTION}"
+    )
+    return srv._SERVER
+
+
+@pytest.fixture()
+def server_deferred_stale(tmp_path: Path) -> RpcServer:
+    """Server with _DEFERRED_ERROR set simulating a stale-schema error."""
+    import pyscope_mcp.server as srv
+
+    stale = tmp_path / "stale_index.json"
+    stale.write_text("{}")  # file exists but schema is wrong
+    srv._INDEX_PATH = stale
+    srv._INDEX = None
+    srv._DEFERRED_ERROR = (
+        f"Index version mismatch: expected 5, got 0. "
+        f"{srv._DEFERRED_ERROR_ACTION}"
+    )
+    return srv._SERVER
+
+
+@pytest.mark.asyncio
+async def test_deferred_error_tools_list_still_returns_all_tools(
+    server_deferred_missing: RpcServer,
+):
+    """tools/list in deferred-error state must return all 9 tools."""
+    lines = [_req("tools/list", req_id=1)]
+    responses = await _run(server_deferred_missing, lines)
+    tools = responses[0]["result"]["tools"]
+    tool_names = {t["name"] for t in tools}
+    assert len(tools) == 9
+    assert tool_names == {
+        "stats", "reload", "build", "refers_to", "callees_of",
+        "module_callees", "search", "file_skeleton", "neighborhood",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name,arguments", [
+    ("stats",         {}),
+    ("refers_to",     {"fqn": "pkg.mod.foo"}),
+    ("callees_of",    {"fqn": "pkg.mod.foo"}),
+    ("module_callees",{"module": "pkg.mod"}),
+    ("search",        {"query": "foo"}),
+    ("file_skeleton", {"path": "pkg/mod.py"}),
+    ("neighborhood",  {"symbol": "pkg.mod.foo"}),
+])
+async def test_deferred_error_index_tools_return_is_error(
+    server_deferred_missing: RpcServer,
+    tool_name: str,
+    arguments: dict,
+):
+    """Each index-dependent tool in deferred-error state returns isError:true
+    with a message containing 'pyscope-mcp build'."""
+    lines = [_req("tools/call", {"name": tool_name, "arguments": arguments}, req_id=1)]
+    responses = await _run(server_deferred_missing, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is True, f"{tool_name} should return isError:true in deferred-error state"
+    text = r["content"][0]["text"]
+    assert "pyscope-mcp build" in text, (
+        f"{tool_name} error message must contain 'pyscope-mcp build'; got: {text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deferred_error_stale_schema_message_contains_pyscope_build(
+    server_deferred_stale: RpcServer,
+):
+    """Stale-schema deferred error also produces 'pyscope-mcp build' in the message."""
+    lines = [_req("tools/call", {"name": "stats", "arguments": {}}, req_id=1)]
+    responses = await _run(server_deferred_stale, lines)
+    r = responses[0]["result"]
+    assert r["isError"] is True
+    text = r["content"][0]["text"]
+    assert "pyscope-mcp build" in text
+
+
+@pytest.mark.asyncio
+async def test_deferred_error_reload_with_broken_index_returns_is_error(
+    tmp_index: Path,
+):
+    """reload when the index file has a bad schema returns isError:true; server stays up."""
+    import pyscope_mcp.server as srv
+
+    # Write a broken index (wrong version) to the path
+    bad_index = tmp_index.parent / "bad_index.json"
+    bad_index.write_text('{"version": 0, "root": "/", "raw": {}}')
+
+    srv._INDEX_PATH = bad_index
+    srv._INDEX = None
+    srv._DEFERRED_ERROR = None  # start clean — reload is the trigger here
+
+    lines = [
+        _req("tools/call", {"name": "reload", "arguments": {}}, req_id=1),
+        _req("tools/call", {"name": "stats", "arguments": {}}, req_id=2),
+    ]
+    responses = await _run(srv._SERVER, lines)
+
+    # reload must return isError:true (index still broken)
+    r_reload = responses[0]["result"]
+    assert r_reload["isError"] is True, "reload with broken index must return isError:true"
+    text = r_reload["content"][0]["text"]
+    assert "pyscope-mcp build" in text, (
+        f"reload error message must contain 'pyscope-mcp build'; got: {text!r}"
+    )
+
+    # The subsequent stats call must ALSO return isError:true (deferred-error preserved)
+    r_stats = responses[1]["result"]
+    assert r_stats["isError"] is True, "stats after failed reload must still return isError:true"
+
+
+@pytest.mark.asyncio
+async def test_deferred_error_reload_with_valid_index_clears_error(
+    tmp_index: Path,
+):
+    """reload after a valid index is placed on disk clears _DEFERRED_ERROR."""
+    import pyscope_mcp.server as srv
+
+    # Pre-arm deferred-error state
+    srv._INDEX_PATH = tmp_index
+    srv._INDEX = None
+    srv._DEFERRED_ERROR = f"Index not found at {tmp_index}. {srv._DEFERRED_ERROR_ACTION}"
+
+    lines = [
+        _req("tools/call", {"name": "reload", "arguments": {}}, req_id=1),
+        _req("tools/call", {"name": "stats", "arguments": {}}, req_id=2),
+    ]
+    responses = await _run(srv._SERVER, lines)
+
+    # reload must succeed (tmp_index is valid)
+    r_reload = responses[0]["result"]
+    assert r_reload["isError"] is False, (
+        f"reload with valid index must succeed; got: {r_reload['content'][0]['text']!r}"
+    )
+    payload = json.loads(r_reload["content"][0]["text"])
+    assert "functions" in payload, "reload must return stats payload on success"
+
+    # _DEFERRED_ERROR must now be cleared
+    assert srv._DEFERRED_ERROR is None, "reload success must clear _DEFERRED_ERROR"
+
+    # Subsequent stats call must also succeed
+    r_stats = responses[1]["result"]
+    assert r_stats["isError"] is False, "stats after successful reload must succeed"

--- a/tests/test_rpc_stdio_e2e.py
+++ b/tests/test_rpc_stdio_e2e.py
@@ -631,6 +631,154 @@ def test_shutdown_then_eof_exits_zero(index_path: Path) -> None:
             proc.wait(timeout=2)
 
 
+def test_deferred_error_stale_schema_e2e(tmp_path: Path) -> None:
+    """E2E (issue #96): serve with a stale-schema index does not crash.
+
+    All 9 tools must appear in tools/list. Index-dependent tool calls must
+    return isError:true with a message containing 'pyscope-mcp build'.
+    The server keeps running for subsequent requests.
+    """
+    # Write a deliberately broken index (wrong version number)
+    stale_dir = tmp_path / ".pyscope-mcp"
+    stale_dir.mkdir(parents=True)
+    stale_index = stale_dir / "index.json"
+    stale_index.write_text('{"version": 0, "root": "/", "raw": {}}')
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "serve",
+            "--root", str(tmp_path),
+            "--index", str(stale_index),
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        # Handshake — server must start (not crash)
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-deferred", "version": "0"},
+            },
+        })
+        r1 = _recv(proc)
+        assert r1["id"] == 1
+        assert r1["result"]["serverInfo"]["name"] == "pyscope-mcp"
+
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        # tools/list must return all 9 tools (deferred-error does not hide them)
+        _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        r2 = _recv(proc)
+        assert r2["id"] == 2
+        tools = r2["result"]["tools"]
+        assert len(tools) == 9, (
+            f"Expected 9 tools in deferred-error state; got {len(tools)}: "
+            f"{[t['name'] for t in tools]}"
+        )
+
+        # stats must return isError:true with actionable message
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "stats", "arguments": {}},
+        })
+        r3 = _recv(proc)
+        assert r3["id"] == 3
+        assert "error" not in r3, f"Unexpected JSON-RPC error: {r3}"
+        assert r3["result"]["isError"] is True
+        text = r3["result"]["content"][0]["text"]
+        assert "pyscope-mcp build" in text, (
+            f"Error message must contain 'pyscope-mcp build'; got: {text!r}"
+        )
+
+        # Server stays alive — ping works
+        _send(proc, {"jsonrpc": "2.0", "id": 4, "method": "ping"})
+        r4 = _recv(proc)
+        assert r4 == {"jsonrpc": "2.0", "id": 4, "result": {}}
+
+        # Clean shutdown
+        _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
+        r_shutdown = _recv(proc)
+        assert r_shutdown == {"jsonrpc": "2.0", "id": 99, "result": {}}
+        proc.stdin.close()
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def test_deferred_error_missing_index_e2e(tmp_path: Path) -> None:
+    """E2E (issue #96): serve with a missing index does not exit with code 2.
+
+    All 9 tools must appear in tools/list. stats returns isError:true.
+    """
+    missing_index = tmp_path / ".pyscope-mcp" / "index.json"
+    # Intentionally do NOT create the file
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=str(repo_root / "src"))
+
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "pyscope_mcp.cli", "serve",
+            "--root", str(tmp_path),
+            "--index", str(missing_index),
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        # Server must start (not exit with code 2 as it previously did)
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-missing", "version": "0"},
+            },
+        })
+        r1 = _recv(proc)
+        assert r1["id"] == 1
+        assert r1["result"]["serverInfo"]["name"] == "pyscope-mcp"
+
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        # tools/list must return all 9 tools
+        _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        r2 = _recv(proc)
+        assert r2["id"] == 2
+        tools = r2["result"]["tools"]
+        assert len(tools) == 9
+
+        # stats must return isError:true with 'pyscope-mcp build' in the message
+        _send(proc, {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "stats", "arguments": {}},
+        })
+        r3 = _recv(proc)
+        assert r3["id"] == 3
+        assert r3["result"]["isError"] is True
+        text = r3["result"]["content"][0]["text"]
+        assert "pyscope-mcp build" in text
+
+        # Clean shutdown
+        _send(proc, {"jsonrpc": "2.0", "id": 99, "method": "shutdown"})
+        r_shutdown = _recv(proc)
+        assert r_shutdown == {"jsonrpc": "2.0", "id": 99, "result": {}}
+        proc.stdin.close()
+        assert proc.wait(timeout=5) == 0
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
 def test_completeness_field_e2e(tmp_path: Path) -> None:
     """E2E: build → serve → callers_of returns completeness='partial' when missed_callers present.
 


### PR DESCRIPTION
Closes #96

## What changed

`pyscope-mcp serve` previously crashed before registering any MCP tools whenever the on-disk index was missing or had a stale schema version. The tools would silently disappear from the Claude Code tool list with no actionable error. This PR implements _deferred initialisation_: the server always starts and registers all 9 tools regardless of index state; any index-dependent tool call returns \`isError: true\` with a message containing the exact remedy (\`pyscope-mcp build\` + \`reload\`). The early-exit guard in \`cli.py\` (which exited with code 2 on missing index before tools were registered) is removed.

## Implementation walkthrough

### New module-level state in `server.py`

Two new module-level constants/variables are added:

- **`_DEFERRED_ERROR: str | None`** — holds the error message string when startup load fails. \`None\` when the index is healthy. Checked in \`_dispatch_tool\` before \`_get_index()\` is called. Reset to \`None\` by \`reload\` or \`build\` on success.
- **`_DEFERRED_ERROR_ACTION: str`** — constant suffix appended to all deferred-error messages: \`"Run 'pyscope-mcp build' to regenerate the index, then call the 'reload' MCP tool."\`

### `run_stdio` — deferred-init on startup failure

`run_stdio` now wraps `CallGraphIndex.load()` in `try/except (FileNotFoundError, ValueError)`. On error it sets `_DEFERRED_ERROR` with the original exception message + `_DEFERRED_ERROR_ACTION`, leaves `_INDEX = None`, logs a warning to stderr, and continues to start the RPC loop normally. On success it clears `_DEFERRED_ERROR = None` (in case a module reload during testing left stale state).

### `_dispatch_tool` — deferred-error gate

The \`reload\` branch is hardened: it now wraps \`CallGraphIndex.load()\` in try/except, updates \`_DEFERRED_ERROR\` and returns \`_error_result(_DEFERRED_ERROR)\` on failure, and clears \`_DEFERRED_ERROR = None\` on success before returning stats.

The \`build\` branch is intentionally **not** gated — it is the recovery path and must remain callable regardless of deferred-error state. After a successful subprocess build it also clears \`_DEFERRED_ERROR\`.

Immediately before \`idx = _get_index()\` (shared by all query tools: stats, refers_to, callees_of, module_callees, search, file_skeleton, neighborhood), a single guard is inserted:
\`\`\`python
if _DEFERRED_ERROR:
    return _error_result(_DEFERRED_ERROR)
\`\`\`
This means all 7 query tools return a uniform actionable \`isError: true\` response in deferred-error state without duplicating the check.

### `cli.py` — remove early-exit guard

Lines 125–130 (the \`if not index.exists(): return 2\` block) are replaced with a comment explaining the new contract and an unconditional \`server.run_stdio(index_path=index)\` call.

### Default execution path

**Before**: `cmd_serve → index.exists() check → exit(2) if missing` — tools never registered, silent disappearance.

**After**: `cmd_serve → run_stdio(index_path)` → `try: load()` (success: clear error / failure: set _DEFERRED_ERROR) → `asyncio.run(_SERVER.run())` — all tools registered, index-dependent calls return actionable error.

### Edge cases and error handling

- **Stale schema (`ValueError`)**: the ValueError from `CallGraphIndex.load()` already contains the version mismatch message; `_DEFERRED_ERROR` is set to `f"{exc}. {_DEFERRED_ERROR_ACTION}"`.
- **Missing file (`FileNotFoundError`)**: `_DEFERRED_ERROR` is set to `f"Index not found at {_INDEX_PATH}. {_DEFERRED_ERROR_ACTION}"`.
- **`reload` while index still broken**: returns `isError: true` with updated `_DEFERRED_ERROR`; server continues running.
- **`reload` after valid index**: clears `_DEFERRED_ERROR`, all subsequent query tools work normally.
- **`build` tool**: always callable in deferred-error state; clears `_DEFERRED_ERROR` after successful subprocess + load.

### What was intentionally not changed

`_get_index()`, `_STALE_ACTION`, all tool schemas, `tools/list` handler, and the `CallGraphIndex` API are unchanged. The deferred-error message uses a new constant rather than altering `_STALE_ACTION` (which has a different contract for result-scoped staleness in query responses).

## Tier / approach

Tier 2 — Planner (read-only research + plan) → Coder A (server.py + cli.py) + Tester (unit + e2e tests) in parallel → ADR-approved decisions applied

## Acceptance criteria

- [x] `pyscope-mcp serve` with stale schema does not crash; all 9 tools appear in `tools/list`
- [x] `pyscope-mcp serve` with missing index does not exit with code 2; all 9 tools appear in `tools/list`
- [x] Index-dependent tool call (stats, etc.) returns `isError: true` with text containing "pyscope-mcp build" when in deferred-error state
- [x] `reload` while index still broken returns `isError: true`; server continues running
- [x] `reload` after valid index exists returns `isError: false` with stats; clears deferred-error state
- [x] `build` tool remains callable regardless of deferred-error state
- [x] All 9 tools visible in `tools/list` in deferred-error state
- [x] All existing tests pass (780 passed)
- [x] New unit tests cover all deferred-error paths (7 parametrized tool tests + 4 state-transition tests)
- [x] New e2e tests cover startup-with-stale-schema and startup-with-missing-index scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)